### PR TITLE
Nicer logs

### DIFF
--- a/api/server.go
+++ b/api/server.go
@@ -103,7 +103,6 @@ func NewApiServer(config Config) *ApiServer {
 
 	app.Use(fiberzap.New(fiberzap.Config{
 		Logger: logger,
-		// Define custom fields to add to the logs
 		FieldsFunc: func(c *fiber.Ctx) []zap.Field {
 			fields := []zap.Field{}
 


### PR DESCRIPTION
1. fiberzab by default logs out latency with units appended at the end. this makes it very annoying to use in axiom/downstream. so implement our own (practically does the same thing)
2. add "route" to the default log, so we can group by route rather than by the exact URL which may differ a lot