### PR TITLE
followee_favorites and followee_reposts match v1 api.

### DIFF
--- a/api/dbv1/jsonb_types.go
+++ b/api/dbv1/jsonb_types.go
@@ -32,3 +32,17 @@ type PlaylistContents struct {
 		MetadataTime int64 `json:"metadata_time"`
 	} `json:"track_ids"`
 }
+
+type FolloweeRepost struct {
+	RepostItemId string `json:"repost_item_id"`
+	RepostType   string `json:"repost_type"`
+	UserId       string `json:"user_id"`
+	CreatedAt    string `json:"created_at"`
+}
+
+type FolloweeFavorite struct {
+	FavoriteItemId string `json:"favorite_item_id"`
+	FavoriteType   string `json:"favorite_type"`
+	UserId         string `json:"user_id"`
+	CreatedAt      string `json:"created_at"`
+}

--- a/api/dbv1/models.go
+++ b/api/dbv1/models.go
@@ -600,7 +600,7 @@ type AggregateUserTip struct {
 
 type AlbumPriceHistory struct {
 	PlaylistID      int32            `json:"playlist_id"`
-	Splits          []byte           `json:"splits"`
+	Splits          json.RawMessage  `json:"splits"`
 	TotalPriceCents int64            `json:"total_price_cents"`
 	Blocknumber     int32            `json:"blocknumber"`
 	BlockTimestamp  pgtype.Timestamp `json:"block_timestamp"`
@@ -806,7 +806,7 @@ type Collectible struct {
 	// User ID of the person who owns the collectibles
 	UserID int32 `json:"user_id"`
 	// Data about the collectibles
-	Data []byte `json:"data"`
+	Data json.RawMessage `json:"data"`
 	// Blockhash of the most recent block that changed the collectibles data
 	Blockhash string `json:"blockhash"`
 	// Block number of the most recent block that changed the collectibles data
@@ -923,7 +923,7 @@ type CoreTxDecoded struct {
 	TxIndex     int32              `json:"tx_index"`
 	TxHash      string             `json:"tx_hash"`
 	TxType      string             `json:"tx_type"`
-	TxData      []byte             `json:"tx_data"`
+	TxData      json.RawMessage    `json:"tx_data"`
 	CreatedAt   pgtype.Timestamptz `json:"created_at"`
 }
 
@@ -1243,8 +1243,8 @@ type Repost struct {
 }
 
 type RevertBlock struct {
-	Blocknumber int32  `json:"blocknumber"`
-	PrevRecords []byte `json:"prev_records"`
+	Blocknumber int32           `json:"blocknumber"`
+	PrevRecords json.RawMessage `json:"prev_records"`
 }
 
 type RewardManagerTx struct {
@@ -1299,7 +1299,7 @@ type RpcCursor struct {
 
 type RpcError struct {
 	Sig         string           `json:"sig"`
-	RpcLogJson  []byte           `json:"rpc_log_json"`
+	RpcLogJson  json.RawMessage  `json:"rpc_log_json"`
 	ErrorText   string           `json:"error_text"`
 	ErrorCount  int32            `json:"error_count"`
 	LastAttempt pgtype.Timestamp `json:"last_attempt"`
@@ -1466,7 +1466,7 @@ type Track struct {
 	AudioUploadID                      pgtype.Text      `json:"audio_upload_id"`
 	PreviewStartSeconds                pgtype.Float8    `json:"preview_start_seconds"`
 	ReleaseDate                        pgtype.Timestamp `json:"release_date"`
-	TrackSegments                      []byte           `json:"track_segments"`
+	TrackSegments                      json.RawMessage  `json:"track_segments"`
 	IsScheduledRelease                 bool             `json:"is_scheduled_release"`
 	IsDownloadable                     bool             `json:"is_downloadable"`
 	DownloadConditions                 UsageConditions  `json:"download_conditions"`
@@ -1484,7 +1484,7 @@ type Track struct {
 	CopyrightLine                      json.RawMessage  `json:"copyright_line"`
 	ProducerCopyrightLine              json.RawMessage  `json:"producer_copyright_line"`
 	ParentalWarningType                pgtype.Text      `json:"parental_warning_type"`
-	PlaylistsPreviouslyContainingTrack []byte           `json:"playlists_previously_containing_track"`
+	PlaylistsPreviouslyContainingTrack json.RawMessage  `json:"playlists_previously_containing_track"`
 	AllowedApiKeys                     []string         `json:"allowed_api_keys"`
 	Bpm                                pgtype.Float8    `json:"bpm"`
 	MusicalKey                         pgtype.Text      `json:"musical_key"`
@@ -1526,7 +1526,7 @@ type TrackDownload struct {
 
 type TrackPriceHistory struct {
 	TrackID         int32                  `json:"track_id"`
-	Splits          []byte                 `json:"splits"`
+	Splits          json.RawMessage        `json:"splits"`
 	TotalPriceCents int64                  `json:"total_price_cents"`
 	Blocknumber     int32                  `json:"blocknumber"`
 	BlockTimestamp  pgtype.Timestamp       `json:"block_timestamp"`
@@ -1599,7 +1599,7 @@ type UsdcPurchase struct {
 	Region       pgtype.Text             `json:"region"`
 	Country      pgtype.Text             `json:"country"`
 	Vendor       pgtype.Text             `json:"vendor"`
-	Splits       []byte                  `json:"splits"`
+	Splits       json.RawMessage         `json:"splits"`
 }
 
 type UsdcTransactionsHistory struct {
@@ -1731,8 +1731,8 @@ type UserEvent struct {
 }
 
 type UserListeningHistory struct {
-	UserID           int32  `json:"user_id"`
-	ListeningHistory []byte `json:"listening_history"`
+	UserID           int32           `json:"user_id"`
+	ListeningHistory json.RawMessage `json:"listening_history"`
 }
 
 type UserPayoutWalletHistory struct {

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/joho/godotenv v1.5.1
 	github.com/speps/go-hashids/v2 v2.0.1
 	github.com/stretchr/testify v1.10.0
+	github.com/valyala/fasthttp v1.59.0
 	go.uber.org/zap v1.27.0
 	golang.org/x/sync v0.12.0
 	google.golang.org/protobuf v1.36.6
@@ -50,7 +51,6 @@ require (
 	github.com/sasha-s/go-deadlock v0.3.5 // indirect
 	github.com/supranational/blst v0.3.14 // indirect
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
-	github.com/valyala/fasthttp v1.59.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.59.0 // indirect
 	go.opentelemetry.io/otel v1.34.0 // indirect

--- a/sqlc.yaml
+++ b/sqlc.yaml
@@ -17,6 +17,11 @@ sql:
               import: "encoding/json"
               type: "RawMessage"
 
+          - db_type: "jsonb"
+            go_type:
+              import: "encoding/json"
+              type: "RawMessage"
+
           - column: "tracks.copyright_line"
             go_type:
               import: "encoding/json"

--- a/trashid/hashid.go
+++ b/trashid/hashid.go
@@ -2,6 +2,7 @@ package trashid
 
 import (
 	"errors"
+	"strconv"
 
 	"github.com/speps/go-hashids/v2"
 )
@@ -28,6 +29,15 @@ func DecodeHashId(id string) (int, error) {
 
 func EncodeHashId(id int) (string, error) {
 	return hashIdUtil.Encode([]int{id})
+}
+
+func StringEncode(id string) string {
+	if num, err := strconv.Atoi(id); err == nil {
+		if result, err := hashIdUtil.Encode([]int{num}); err == nil {
+			return result
+		}
+	}
+	return id
 }
 
 func MustEncodeHashID(id int) string {


### PR DESCRIPTION
This was annoying.  The options considered:

* Make two queries for each track ID to get followee_favorites + followee_reposts.  These queries are simple and can be issued in parallel with the `GetTracks` query.  But it does mean getting 10 tracks incurs 20 additional queries for these fields.
* Make two bulk queries with a list of track IDs.  One for `followee_favorites` and one for `followee_reposts`.  Use window function to get the relevant rows grouped by each track ID.  Elemental does something similar in [this query](https://github.com/stereosteve/Elemental/blob/master/server/db/known-reposters.ts#L16-L38).

With both of these you do the familiar pattern of:
* collect base item ids
* issue queries
* key the results by the base item id.
* attach to the relevant results to proper base item.

Which is all fine I guess.

Anyway in this PR I tried the 3rd approach which is to use postgres features to build up a json result in the base query itself.  I hit a few sqlc snags initially but adding `::jsonb` to the column type mostly made things work.

And I could have called it done with just a query change were it not for the mf hashids.  So then I defined struct to match json and unmarshal and loop over and encode the hashids.

I spent too long trying to write a generic recursive hash ID encoder that would just modify the JSON on the way out.  Stupid hash IDs.  Anyway me and ChatGPT got pretty close but I gave up on that for now.  Might revisit later.