### PR TITLE
Add missing fields to track: playlists containing, album backlink...

### DIFF
--- a/api/dbv1/queries/get_tracks.sql
+++ b/api/dbv1/queries/get_tracks.sql
@@ -1,21 +1,4 @@
 -- name: GetTracks :many
-WITH album_backlinks AS (
-  SELECT DISTINCT ON (pt.track_id)
-    pt.track_id,
-    p.playlist_id,
-    p.playlist_name,
-    u.handle,
-    pr.slug
-  FROM playlist_tracks pt
-  JOIN playlists p ON p.playlist_id = pt.playlist_id
-  JOIN users u ON u.user_id = p.playlist_owner_id AND u.is_current = true
-  JOIN playlist_routes pr ON pr.playlist_id = p.playlist_id AND pr.is_current = true
-  WHERE pt.is_removed = false
-    AND p.is_album = true
-    AND p.is_delete = false
-    AND p.is_current = true
-  ORDER BY pt.track_id, p.created_at DESC
-)
 SELECT
   t.track_id,
   description,
@@ -38,17 +21,37 @@ SELECT
   is_downloadable,
   aggregate_plays.count as play_count,
   ddex_app,
-  playlists_containing_track,
   pinned_comment_id,
+  playlists_containing_track,
+
   (
     SELECT json_build_object(
       'playlist_id', ab.playlist_id,
       'playlist_name', ab.playlist_name,
       'permalink', '/' || ab.handle || '/album/' || ab.slug
     )
-    FROM album_backlinks ab
-    WHERE ab.track_id = t.track_id
-  )::jsonb as album_backlink,
+    FROM (
+      SELECT
+        pt.track_id,
+        p.playlist_id,
+        p.playlist_name,
+        u.handle,
+        pr.slug
+      FROM playlist_tracks pt
+      JOIN playlists p ON p.playlist_id = pt.playlist_id
+      JOIN users u ON u.user_id = p.playlist_owner_id AND u.is_current = true
+      JOIN playlist_routes pr ON pr.playlist_id = p.playlist_id AND pr.is_current = true
+      WHERE
+        pt.track_id = t.track_id
+        AND pt.is_removed = false
+        AND p.is_album = true
+        AND p.is_delete = false
+        AND p.is_current = true
+      ORDER BY pt.track_id, p.created_at DESC
+      LIMIT 1
+    ) ab
+  )::jsonb AS album_backlink,
+
   t.blocknumber,
   create_date,
   t.created_at,


### PR DESCRIPTION
I hate it

<img width="777" alt="image" src="https://github.com/user-attachments/assets/d0ffbe98-f067-4037-baf6-f5d6113de8a5" />

But it still remains fast even with the heavy join. Same query as python currently does.

I think we can make future work to precompute this in indexing. But I would rather just unblock for now. Thoughts?