### PR TITLE
Fix enter submission for API diff

### DIFF
--- a/static/apidiff.html
+++ b/static/apidiff.html
@@ -141,6 +141,7 @@
         </label>
         <input type="text" name="encodedDataMessage" placeholder="Encoded-Data-Message" style="width: 200px" value="${encodedDataMessage}" />
         <input type="text" name="encodedDataSignature" placeholder="Encoded-Data-Signature" style="width: 1000px" value="${encodedDataSignature}" />
+        <input type="submit" style="display: none" />
       </div>
     </form>
   `;


### PR DESCRIPTION
Weird quirk of forms: If there is more than one text input and no submit button or field marked with type='submit', then pressing enter won't submit the form. So I broke this when I added the auth header inputs.

This is a quick an easy way to make sure pressing enter from any of the text fields will resubmit the request.