### PR TITLE
replace numeric ids with hash ids in json.

### DIFF
--- a/trashid/trashify.go
+++ b/trashid/trashify.go
@@ -1,0 +1,44 @@
+package trashid
+
+import (
+	"bytes"
+	"fmt"
+	"regexp"
+	"strconv"
+)
+
+var re = regexp.MustCompile(`"(?P<key>\w+_id|id)"\s*:\s*(?P<val>\d+)`)
+var skipKeys = [][]byte{
+	[]byte(`special_id`),
+}
+
+func Trashify(jsonBytes []byte) []byte {
+	return re.ReplaceAllFunc(jsonBytes, func(match []byte) []byte {
+		submatches := re.FindSubmatchIndex(match)
+		if submatches == nil || len(submatches) < 6 {
+			return match
+		}
+
+		// Extract key and value from match using named groups
+		key := match[submatches[2]:submatches[3]]
+		for _, skipKey := range skipKeys {
+			if bytes.Equal(key, skipKey) {
+				return match
+			}
+		}
+
+		val := match[submatches[4]:submatches[5]]
+		num, err := strconv.Atoi(string(val))
+		if err != nil {
+			return match
+		}
+
+		// Replace with hex string
+		hashed, err := EncodeHashId(num)
+		fmt.Println("ok", num, hashed, err)
+		if err != nil {
+			return match
+		}
+		return []byte(fmt.Sprintf(`"%s": "%s"`, key, hashed))
+	})
+}

--- a/trashid/trashify_test.go
+++ b/trashid/trashify_test.go
@@ -1,0 +1,43 @@
+package trashid
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTrashify(t *testing.T) {
+	j1 := []byte(`
+	{
+		"data": {
+			"id": 1,
+			"user_id": 2,
+			"special_id": 999,
+			"tracks": [
+				{
+					"id": 3,
+					"title": "fun",
+					"value": "id",
+					"other": "user_id",
+					"aid": 333,
+					"ida": 111
+				}
+			]
+		}
+	}
+	`)
+
+	var m map[string]any
+	err := json.Unmarshal(j1, &m)
+	assert.NoError(t, err)
+	fmt.Println(m)
+
+	j2 := Trashify(j1)
+	fmt.Println(string(j2))
+	err = json.Unmarshal(j2, &m)
+	assert.NoError(t, err)
+	fmt.Println(m)
+
+}


### PR DESCRIPTION
I believe this is the most succinct, complete and consistent approach to encoding hashids as the data goes "out the door" and truly making it a serialization concern that requires almost no app code surface area.

It is also the most performant incurring basically zero memory overhead (unlike struct embedding solutions, or multiple json round trips).

Perhaps the only downsides:
* it could be surprising if you have some `special_id` field from an external source that needs to remain a number.  I have added a list of fields to skip for this scenario.
* it is _more_ consistent than python code... so things like `stream_conditions.follow_user_id` come back from python as numbers, but with this approach it would be encoded, which might break client?

How it works:
* looks for pattern `"*_id|id":\d+` in json, parses the number, encodes and replaces the number with the encoded id.