### PR TITLE
Move my_follows to CTE.

### DIFF
--- a/api/dbv1/queries/get_tracks.sql
+++ b/api/dbv1/queries/get_tracks.sql
@@ -1,4 +1,16 @@
 -- name: GetTracks :many
+WITH my_follows AS (
+  SELECT
+    followee_user_id as user_id,
+    follower_count
+  FROM follows
+  JOIN aggregate_user ON followee_user_id = user_id
+  WHERE @my_id > 0
+    AND follower_user_id = @my_id
+    AND follows.is_delete = false
+  ORDER BY follower_count DESC
+  LIMIT 5000
+)
 SELECT
   t.track_id,
   description,
@@ -98,8 +110,7 @@ SELECT
     FROM (
       SELECT user_id, repost_item_id, reposts.created_at
       FROM reposts
-      JOIN follows ON followee_user_id = reposts.user_id AND follower_user_id = @my_id AND follows.is_delete = false
-      JOIN aggregate_user USING (user_id)
+      JOIN my_follows USING (user_id)
       WHERE repost_item_id = t.track_id
         AND repost_type = 'track'
         AND reposts.is_delete = false
@@ -120,8 +131,7 @@ SELECT
     FROM (
       SELECT user_id, save_item_id, saves.created_at
       FROM saves
-      JOIN follows ON followee_user_id = saves.user_id AND follower_user_id = @my_id AND follows.is_delete = false
-      JOIN aggregate_user USING (user_id)
+      JOIN my_follows USING (user_id)
       WHERE save_item_id = t.track_id
         AND save_type = 'track'
         AND saves.is_delete = false


### PR DESCRIPTION
This does make the `followee_reposts` and `followee_saves` results aproximate, but it avoids paying join tax twice in subquery.  And the results are likely identical.

Takes cost estimate from:
1,451,862 -> 905,567

See explains:
https://gist.github.com/stereosteve/a606eb94e607f45f1fa8889a5cc87fcd