### PR TITLE
Pin versions of tooling in setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,8 +24,8 @@ psql::
 	docker compose exec db psql -U postgres
 
 setup::
-	go install github.com/bokwoon95/wgo@latest
-	go install -v github.com/sqlc-dev/sqlc/cmd/sqlc@latest
+	go install github.com/bokwoon95/wgo@v0.5.11
+	go install -v github.com/sqlc-dev/sqlc/cmd/sqlc@v1.29.0
 
 apidiff::
 	open http://localhost:1323/apidiff.html


### PR DESCRIPTION
Generally a good idea, but also prevents the state I'm in where my version is different than everyone else and our generation step causes all sql files to get an update due to the version line changing in the output. 😁 