### PR TITLE
[API-117] Add trending playlists endpoint

### DIFF
--- a/api/dbv1/models.go
+++ b/api/dbv1/models.go
@@ -1404,6 +1404,15 @@ type PlaylistTrack struct {
 	UpdatedAt  pgtype.Timestamptz `json:"updated_at"`
 }
 
+type PlaylistTrendingScore struct {
+	PlaylistID int32     `json:"playlist_id"`
+	Type       string    `json:"type"`
+	Version    string    `json:"version"`
+	TimeRange  string    `json:"time_range"`
+	Score      float64   `json:"score"`
+	CreatedAt  time.Time `json:"created_at"`
+}
+
 type Reaction struct {
 	ID            int32       `json:"id"`
 	ReactionValue int32       `json:"reaction_value"`

--- a/api/fixture_test.go
+++ b/api/fixture_test.go
@@ -120,6 +120,15 @@ var (
 		"created_at": time.Now(),
 	}
 
+	playlistTrendingScoreBaseRow = map[string]any{
+		"playlist_id": nil,
+		"type":        "PLAYLISTS",
+		"version":     "pnagD",
+		"time_range":  nil,
+		"score":       nil,
+		"created_at":  time.Now(),
+	}
+
 	connectedWalletsBaseRow = map[string]any{
 		"id":          nil,
 		"user_id":     nil,

--- a/api/server.go
+++ b/api/server.go
@@ -194,7 +194,6 @@ func NewApiServer(config config.Config) *ApiServer {
 		app.Use("/v1/full/users/subscribers", BalancerForward(config.PythonUpstreams))
 
 		app.Use("/v1/full/playlists/top", BalancerForward(config.PythonUpstreams))
-		app.Use("/v1/full/playlists/trending", BalancerForward(config.PythonUpstreams))
 
 		app.Use("/v1/full/tracks/best_new_releases", BalancerForward(config.PythonUpstreams))
 		app.Use("/v1/full/tracks/feeling_lucky", BalancerForward(config.PythonUpstreams))
@@ -258,6 +257,7 @@ func NewApiServer(config config.Config) *ApiServer {
 		// Playlists
 		g.Get("/playlists", app.v1playlists)
 		g.Get("/playlists/unclaimed_id", app.v1PlaylistsUnclaimedId)
+		g.Get("/playlists/trending", app.v1PlaylistsTrending)
 
 		g.Use("/playlists/:playlistId", app.requirePlaylistIdMiddleware)
 		g.Get("/playlists/:playlistId", app.v1Playlist)

--- a/api/server_test.go
+++ b/api/server_test.go
@@ -77,6 +77,7 @@ func TestMain(m *testing.M) {
 	insertFixtures("reposts", repostBaseRow, "testdata/repost_fixtures.csv")
 	insertFixtures("developer_apps", developerAppBaseRow, "testdata/developer_app_fixtures.csv")
 	insertFixtures("track_trending_scores", trackTrendingScoreBaseRow, "testdata/track_trending_scores_fixtures.csv")
+	insertFixtures("playlist_trending_scores", playlistTrendingScoreBaseRow, "testdata/playlist_trending_scores_fixtures.csv")
 	insertFixtures("associated_wallets", connectedWalletsBaseRow, "testdata/connected_wallets_fixtures.csv")
 	insertFixtures("aggregate_user_tips", aggregateUserTipsBaseRow, "testdata/aggregate_user_tips_fixtures.csv")
 	insertFixtures("usdc_purchases", usdcPurchaseBaseRow, "testdata/usdc_purchases_fixtures.csv")
@@ -144,7 +145,7 @@ func Test200UnAuthed(t *testing.T) {
 		"/v1/full/playlists?id=7eP5n",
 		"/v1/full/playlists/7eP5n/reposts",
 		"/v1/full/playlists/7eP5n/favorites",
-
+		"/v1/full/playlists/trending",
 		// unclaimed ids
 		"/v1/users/unclaimed_id",
 		"/v1/tracks/unclaimed_id",

--- a/api/testdata/playlist_trending_scores_fixtures.csv
+++ b/api/testdata/playlist_trending_scores_fixtures.csv
@@ -1,0 +1,4 @@
+playlist_id,time_range,score
+1,week,100
+2,week,90
+500,week,80

--- a/api/v1_playlists_trending_test.go
+++ b/api/v1_playlists_trending_test.go
@@ -1,0 +1,28 @@
+package api
+
+import (
+	"testing"
+
+	"bridgerton.audius.co/api/dbv1"
+	"bridgerton.audius.co/trashid"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetTrendingPlaylists(t *testing.T) {
+	var resp struct {
+		Data []dbv1.FullPlaylist
+	}
+	status, body := testGet(t, "/v1/playlists/trending", &resp)
+
+	assert.Equal(t, 200, status)
+
+	jsonAssert(t, body, map[string]any{
+		"data.0.id": trashid.MustEncodeHashID(1),
+		"data.1.id": trashid.MustEncodeHashID(500),
+	})
+
+	// These playlists fall outside of params
+	for _, playlist := range resp.Data {
+		assert.NotEqual(t, trashid.MustEncodeHashID(2), playlist.PlaylistID, "Playlist 2 should not be in result set")
+	}
+}

--- a/sql/schema1.sql
+++ b/sql/schema1.sql
@@ -967,8 +967,8 @@ BEGIN
       -- Logging the action
       RAISE NOTICE 'Adding foreign key constraint to table %', _table_name;
 
-      EXECUTE format('ALTER TABLE %s ADD CONSTRAINT %s FOREIGN KEY (blocknumber) REFERENCES blocks (number) ON DELETE CASCADE', 
-                     quote_ident(_table_name), 
+      EXECUTE format('ALTER TABLE %s ADD CONSTRAINT %s FOREIGN KEY (blocknumber) REFERENCES blocks (number) ON DELETE CASCADE',
+                     quote_ident(_table_name),
                      quote_ident(_table_name || '_blocknumber_fkey'));
 
    END LOOP;
@@ -1589,9 +1589,9 @@ BEGIN
       -- Logging the deletion
       RAISE NOTICE 'Deleting rows from table % where is_current is false', _table_name;
 
-      EXECUTE format('DELETE FROM %s WHERE is_current = false', 
+      EXECUTE format('DELETE FROM %s WHERE is_current = false',
                      quote_ident(_table_name));
-                     
+
    END LOOP;
 END
 $$;
@@ -1611,7 +1611,7 @@ BEGIN
    LOOP
       RAISE NOTICE 'Deleting rows from table % where is_current is false', _table_name;
 
-      EXECUTE format('DELETE FROM %s WHERE is_current = false', 
+      EXECUTE format('DELETE FROM %s WHERE is_current = false',
                      quote_ident(_table_name));
 
    END LOOP;
@@ -1632,11 +1632,11 @@ BEGIN
    FOREACH _table_name IN ARRAY _table_names
    LOOP
       RAISE NOTICE 'Dropping foreign key constraint to table %', _table_name;
-      EXECUTE format('LOCK TABLE %s IN ACCESS EXCLUSIVE MODE', 
+      EXECUTE format('LOCK TABLE %s IN ACCESS EXCLUSIVE MODE',
                      quote_ident(_table_name));
 
-      EXECUTE format('ALTER TABLE %s DROP CONSTRAINT IF EXISTS %s', 
-                     quote_ident(_table_name), 
+      EXECUTE format('ALTER TABLE %s DROP CONSTRAINT IF EXISTS %s',
+                     quote_ident(_table_name),
                      quote_ident(_table_name || '_blocknumber_fkey'));
 
    END LOOP;
@@ -1942,14 +1942,14 @@ begin
   select * into reward_manager_tx from reward_manager_txs where reward_manager_txs.signature = new.signature limit 1;
 
   if reward_manager_tx is not null then
-		select id into existing_notification 
+		select id into existing_notification
 		from notification
 		where
 		type = 'challenge_reward' and
 		new.user_id = any(user_ids) and
 		timestamp >= (new.created_at - interval '1 hour')
 		limit 1;
-		
+
 		if existing_notification is null then
 			-- create a notification for the challenge disbursement
 			insert into notification
@@ -1987,14 +1987,14 @@ CREATE FUNCTION public.handle_comment() RETURNS trigger
     AS $$
 begin
   if new.entity_type = 'Track' then
-    insert into aggregate_track (track_id) 
-    values (new.entity_id) 
+    insert into aggregate_track (track_id)
+    values (new.entity_id)
     on conflict do nothing;
   end if;
 
   -- update agg track
   if new.entity_type = 'Track' then
-    update aggregate_track 
+    update aggregate_track
     set comment_count = (
       select count(*)
       from comments c
@@ -2032,12 +2032,12 @@ declare
 begin
   select comments.user_id, comments.entity_id, comments.entity_type
   into comment_user_id , entity_id, entity_type
-  from comments 
+  from comments
   where comment_id = new.comment_id;
 
-  select tracks.owner_id 
-  into entity_user_id 
-  from tracks 
+  select tracks.owner_id
+  into entity_user_id
+  from tracks
   where track_id = entity_id;
 
   begin
@@ -2045,10 +2045,10 @@ begin
       insert into notification
         (blocknumber, user_ids, timestamp, type, specifier, group_id, data)
         values
-        ( 
+        (
           new.blocknumber,
-          ARRAY [new.user_id], 
-          new.created_at, 
+          ARRAY [new.user_id],
+          new.created_at,
           'comment_mention',
           comment_user_id,
           'comment_mention:' || entity_id || ':type:' || entity_type,
@@ -2091,25 +2091,25 @@ declare
   created_at timestamp without time zone;
   notification_muted boolean;
 begin
-  select comments.user_id, comments.entity_id, comments.entity_type 
-  into parent_comment_user_id, entity_id, entity_type 
-  from comments 
+  select comments.user_id, comments.entity_id, comments.entity_type
+  into parent_comment_user_id, entity_id, entity_type
+  from comments
   where comment_id = new.parent_comment_id;
 
   select comments.user_id, comments.blocknumber, comments.created_at
   into comment_user_id, blocknumber, created_at
-  from comments 
+  from comments
   where comment_id = new.comment_id;
 
-  select tracks.owner_id 
-  into entity_user_id 
-  from tracks 
+  select tracks.owner_id
+  into entity_user_id
+  from tracks
   where track_id = entity_id;
 
   select comment_notification_settings.is_muted
   into notification_muted
   from comment_notification_settings
-  where user_id = parent_comment_user_id 
+  where user_id = parent_comment_user_id
   and comment_notification_settings.entity_id = new.parent_comment_id
   and comment_notification_settings.entity_type = 'Comment';
 
@@ -2118,10 +2118,10 @@ begin
       insert into notification
         (blocknumber, user_ids, timestamp, type, specifier, group_id, data)
         values
-        ( 
+        (
           blocknumber,
           ARRAY [parent_comment_user_id],
-          created_at, 
+          created_at,
           'comment_thread',
           comment_user_id,
           'comment_thread:' || new.parent_comment_id,
@@ -2170,11 +2170,11 @@ begin
     delta := 1;
   end if;
 
-  update aggregate_user 
-  set following_count = following_count + delta 
+  update aggregate_user
+  set following_count = following_count + delta
   where user_id = new.follower_user_id;
 
-  update aggregate_user 
+  update aggregate_user
   set follower_count = follower_count + delta
   where user_id = new.followee_user_id
   returning follower_count into new_follower_count;
@@ -2183,7 +2183,7 @@ begin
   select new_follower_count into milestone where new_follower_count in (10, 25, 50, 100, 250, 500, 1000, 5000, 10000, 20000, 50000, 100000, 1000000);
   select score < 0 into is_shadowbanned from aggregate_user where user_id = new.follower_user_id;
   if milestone is not null and new.is_delete is false and is_shadowbanned = false then
-      insert into milestones 
+      insert into milestones
         (id, name, threshold, blocknumber, slot, timestamp)
       values
         (new.followee_user_id, 'FOLLOWER_COUNT', milestone, new.blocknumber, new.slot, new.created_at)
@@ -2232,7 +2232,7 @@ exception
     raise warning 'An error occurred in %: %', tg_name, sqlerrm;
     raise;
 
-end; 
+end;
 $$;
 
 
@@ -2288,7 +2288,7 @@ begin
                 'challenge_reward',
                 'challenge_reward:' || new.user_id || ':challenge:' || new.challenge_id || ':specifier:' || new.specifier,
                 new.user_id,
-                case 
+                case
                     when new.challenge_id = 'e' then
                         json_build_object(
                             'specifier', new.specifier,
@@ -2306,9 +2306,9 @@ begin
             )
             on conflict do nothing;
         else
-            -- transactional notifications cover this 
+            -- transactional notifications cover this
             if (new.challenge_id != 'b' and new.challenge_id != 's') then
-                select id into existing_notification 
+                select id into existing_notification
                 from notification
                 where
                 type = 'reward_in_cooldown' and
@@ -2358,7 +2358,7 @@ begin
     insert into aggregate_plays (play_item_id, count) values (new.play_item_id, 0) on conflict do nothing;
 
     update aggregate_plays
-        set count = count + 1 
+        set count = count + 1
         where play_item_id = new.play_item_id
         returning count into new_listen_count;
 
@@ -2373,8 +2373,8 @@ begin
         and timestamp = date_trunc('month', new.created_at)
         and country = coalesce(new.country, '');
 
-    select new_listen_count 
-        into milestone 
+    select new_listen_count
+        into milestone
         where new_listen_count in (10,25,50,100,250,500,1000,2500,5000,10000,25000,50000,100000,250000,500000,1000000);
 
     if milestone is not null then
@@ -2574,7 +2574,7 @@ begin
           json_build_object('track_id', new.track_id, 'playlist_id', new.playlist_id, 'playlist_owner_id', playlist_record.playlist_owner_id)
         from album_purchasers as album_purchaser;
   end if;
-  
+
   return null;
 
 exception
@@ -2601,16 +2601,16 @@ declare
 begin
 
   raise NOTICE 'start';
-  
+
   if new.reaction_type = 'tip' then
 
     raise NOTICE 'is tip';
 
-    SELECT amount, sender_user_id, receiver_user_id 
-    INTO tip_amount, tip_sender_user_id, tip_receiver_user_id 
-    FROM user_tips ut 
+    SELECT amount, sender_user_id, receiver_user_id
+    INTO tip_amount, tip_sender_user_id, tip_receiver_user_id
+    FROM user_tips ut
     WHERE ut.signature = new.reacted_to;
-    
+
     raise NOTICE 'did select % %', tip_sender_user_id, tip_receiver_user_id;
     raise NOTICE 'did select %', new.reacted_to;
 
@@ -2705,7 +2705,7 @@ begin
   end if;
 
   -- update agg user
-  update aggregate_user 
+  update aggregate_user
   set repost_count = (
     select count(*)
     from reposts r
@@ -2718,7 +2718,7 @@ begin
   -- update agg track or playlist
   if new.repost_type = 'track' then
     milestone_name := 'TRACK_REPOST_COUNT';
-    update aggregate_track 
+    update aggregate_track
     set repost_count = (
       select count(*)
       from reposts r
@@ -2744,7 +2744,7 @@ begin
           and r.is_delete is false
           and r.repost_type = new.repost_type
           and r.repost_item_id = new.repost_item_id
-    )    
+    )
     where playlist_id = new.repost_item_id
     returning repost_count into new_val;
 
@@ -2758,7 +2758,7 @@ begin
   select score < 0 into is_shadowbanned from aggregate_user where user_id = new.user_id;
 
   if new.is_delete = false and milestone is not null and owner_user_id is not null and is_shadowbanned = false then
-    insert into milestones 
+    insert into milestones
       (id, name, threshold, blocknumber, slot, timestamp)
     values
       (new.repost_item_id, milestone_name, milestone, new.blocknumber, new.slot, new.created_at)
@@ -2859,7 +2859,7 @@ begin
 				'user_id',
 				new.user_id,
 				'type',
-        case 
+        case
           when is_album then 'album'
           else new.repost_type
         end
@@ -2963,7 +2963,7 @@ begin
     where p.playlist_id = new.save_item_id
     and p.is_current
     on conflict do nothing;
-    
+
     select ap.is_album into is_album
     from aggregate_playlist ap
     where ap.playlist_id = new.save_item_id;
@@ -2988,7 +2988,7 @@ begin
   if new.save_type = 'track' then
     milestone_name := 'TRACK_SAVE_COUNT';
 
-    update aggregate_track 
+    update aggregate_track
     set save_count = (
       select count(*)
       from saves r
@@ -3002,7 +3002,7 @@ begin
     returning save_count into new_val;
 
     -- update agg user
-    update aggregate_user 
+    update aggregate_user
     set track_save_count = (
       select count(*)
       from saves r
@@ -3012,7 +3012,7 @@ begin
         and r.save_type = new.save_type
     )
     where user_id = new.user_id;
-    
+
   	if new.is_delete IS FALSE then
 		  select tracks.owner_id, tracks.remix_of into owner_user_id, track_remix_of from tracks where is_current and track_id = new.save_item_id;
 	  end if;
@@ -3043,7 +3043,7 @@ begin
   select score < 0 into is_shadowbanned from aggregate_user where user_id = new.user_id;
 
   if new.is_delete = false and milestone is not null and is_shadowbanned = false then
-    insert into milestones 
+    insert into milestones
       (id, name, threshold, blocknumber, slot, timestamp)
     values
       (new.save_item_id, milestone_name, milestone, new.blocknumber, new.slot, new.created_at)
@@ -3087,10 +3087,10 @@ begin
       insert into notification
         (blocknumber, user_ids, timestamp, type, specifier, group_id, data)
         values
-        ( 
+        (
           new.blocknumber,
-          ARRAY [owner_user_id], 
-          new.created_at, 
+          ARRAY [owner_user_id],
+          new.created_at,
           'save',
           new.user_id,
           'save:' || new.save_item_id || ':type:'|| new.save_type,
@@ -3149,7 +3149,7 @@ begin
           'user_id',
           new.user_id,
           'type',
-          case 
+          case
             when is_album then 'album'
             else new.save_type
           end
@@ -3163,16 +3163,16 @@ begin
     if new.is_delete is false and new.save_type = 'track' and track_remix_of is not null and is_shadowbanned = false then
       select
         case when tracks.owner_id = new.user_id then TRUE else FALSE end as boolean into is_remix_cosign
-        from tracks 
+        from tracks
         where is_current and track_id = (track_remix_of->'tracks'->0->>'parent_track_id')::int;
       if is_remix_cosign then
         insert into notification
           (blocknumber, user_ids, timestamp, type, specifier, group_id, data)
           values
-          ( 
+          (
             new.blocknumber,
-            ARRAY [owner_user_id], 
-            new.created_at, 
+            ARRAY [owner_user_id],
+            new.created_at,
             'cosign',
             new.user_id,
             'cosign:parent_track' || (track_remix_of->'tracks'->0->>'parent_track_id')::int || ':original_track:'|| new.save_item_id,
@@ -3194,7 +3194,7 @@ exception
       raise warning 'An error occurred in %: %', tg_name, sqlerrm;
       raise;
 
-end; 
+end;
 $$;
 
 
@@ -3422,7 +3422,7 @@ begin
     when others then
         raise warning 'An error occurred in %: %', tg_name, sqlerrm;
         return null;
-end; 
+end;
 $$;
 
 
@@ -3521,7 +3521,7 @@ begin
   ) as tier (label, val)
   WHERE
     substr(new.current_balance, 1, GREATEST(1, length(new.current_balance) - 18))::bigint >= tier.val
-  ORDER BY 
+  ORDER BY
     tier.val DESC
   limit 1;
 
@@ -3531,7 +3531,7 @@ begin
   ) as tier (label, val)
   WHERE
     substr(new.previous_balance, 1, GREATEST(1, length(new.previous_balance) - 18))::bigint >= tier.val
-  ORDER BY 
+  ORDER BY
     tier.val DESC
   limit 1;
 
@@ -3540,10 +3540,10 @@ begin
     insert into notification
       (blocknumber, user_ids, timestamp, type, specifier, group_id, data)
     values
-      ( 
+      (
         new.blocknumber,
-        ARRAY [new.user_id], 
-        new.updated_at, 
+        ARRAY [new.user_id],
+        new.updated_at,
         'tier_change',
         new.user_id,
         'tier_change:user_id:' || new.user_id ||  ':tier:' || new_tier || ':blocknumber:' || new.blocknumber,
@@ -3579,10 +3579,10 @@ begin
   insert into notification
     (slot, user_ids, timestamp, type, specifier, group_id, data)
   values
-    ( 
+    (
       new.slot,
-      ARRAY [new.receiver_user_id], 
-      new.created_at, 
+      ARRAY [new.receiver_user_id],
+      new.created_at,
       'tip_receive',
       new.receiver_user_id,
       'tip_receive:user_id:' || new.receiver_user_id || ':signature:' || new.signature,
@@ -3593,10 +3593,10 @@ begin
         'tx_signature', new.signature
       )
     ),
-    ( 
+    (
       new.slot,
-      ARRAY [new.sender_user_id], 
-      new.created_at, 
+      ARRAY [new.sender_user_id],
+      new.created_at,
       'tip_send',
       new.sender_user_id,
       'tip_send:user_id:' || new.sender_user_id || ':signature:' || new.signature,
@@ -4022,7 +4022,7 @@ CREATE FUNCTION public.on_new_notification_row() RETURNS trigger
 begin
   PERFORM pg_notify(TG_TABLE_NAME, json_build_object('notification_id', new.id)::text);
   return null;
-end; 
+end;
 $$;
 
 
@@ -4036,7 +4036,7 @@ CREATE FUNCTION public.on_new_notification_seen_row() RETURNS trigger
 begin
   PERFORM pg_notify(TG_TABLE_NAME, json_build_object('user_id', new.user_id)::text);
   return null;
-end; 
+end;
 $$;
 
 
@@ -4075,7 +4075,7 @@ declare
 begin
     -- fetch the user_id where wallet matches grantee_address
     select user_id into matched_user_id from users where lower(wallet) = lower(NEW.grantee_address);
-    
+
     if matched_user_id is not null then
         -- if the grant is newly created (i.e. the grant is not deleted, is not approved yet, and was just created indicated by created timestamp = last updated timestamp) OR grant went from deleted (revoked) to not deleted and is not approved yet...
         if (TG_OP = 'INSERT' and NEW.is_revoked = FALSE and NEW.is_approved is null and NEW.created_at = NEW.updated_at or
@@ -4129,7 +4129,7 @@ exception
   when others then
       raise warning 'An error occurred in %: %', tg_name, sqlerrm;
       return null;
-end; 
+end;
 $$;
 
 
@@ -4474,19 +4474,19 @@ begin
     if codes is null then
         return true;
     end if;
-    
+
     -- array must have at least one element
     if array_length(codes, 1) is null then
         return false;
     end if;
-    
+
     -- check each element to make sure it's a 2 letter ISO code
     for i in 1..array_length(codes, 1) loop
         if codes[i] !~ '^[A-Z]{2}$' then
             return false;
         end if;
     end loop;
-    
+
     return true;
 end;
 $_$;
@@ -7156,6 +7156,19 @@ CREATE TABLE public.track_trending_scores (
     created_at timestamp without time zone NOT NULL
 );
 
+--
+-- Name: track_trending_scores; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.playlist_trending_scores (
+    playlist_id integer NOT NULL,
+    type character varying NOT NULL,
+    version character varying NOT NULL,
+    time_range character varying NOT NULL,
+    score double precision NOT NULL,
+    created_at timestamp NOT NULL
+);
+
 
 --
 -- Name: users; Type: TABLE; Schema: public; Owner: -
@@ -8847,6 +8860,13 @@ ALTER TABLE ONLY public.track_routes
 
 ALTER TABLE ONLY public.track_trending_scores
     ADD CONSTRAINT track_trending_scores_pkey PRIMARY KEY (track_id, type, version, time_range);
+
+--
+-- Name: playlist_trending_scores playlist_trending_scores_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.playlist_trending_scores
+    ADD CONSTRAINT playlist_trending_scores_pkey PRIMARY KEY (playlist_id, type, version, time_range);
 
 
 --


### PR DESCRIPTION
CANNOT BE MERGED until https://github.com/AudiusProject/audius-protocol/pull/12111 is deployed to production.

Adds the trending playlists endpoint, which is a pretty simple join of the trending playlists scores against playlists that are public/not albums/not deleted/etc.

I manually modified the schema file to include the new table, but we could / should probably do a new pg_dump for it at some point.