### PR TITLE
Use float64 for playlist_contents.time

### DIFF
--- a/api/dbv1/full_playlists.go
+++ b/api/dbv1/full_playlists.go
@@ -31,9 +31,9 @@ type FullPlaylist struct {
 }
 
 type FullPlaylistContentsItem struct {
-	Time         int64  `json:"timestamp"`
-	TrackId      string `json:"track_id"`
-	MetadataTime int64  `json:"metadata_timestamp"`
+	Time         float64 `json:"timestamp"`
+	TrackId      string  `json:"track_id"`
+	MetadataTime float64 `json:"metadata_timestamp"`
 }
 
 func (q *Queries) FullPlaylistsKeyed(ctx context.Context, arg FullPlaylistsParams) (map[int32]FullPlaylist, error) {

--- a/api/dbv1/jsonb_types.go
+++ b/api/dbv1/jsonb_types.go
@@ -15,9 +15,9 @@ type SquareImage struct {
 
 type PlaylistContents struct {
 	TrackIDs []struct {
-		Time         int64 `json:"time"`
-		Track        int64 `json:"track"`
-		MetadataTime int64 `json:"metadata_time"`
+		Time         float64 `json:"time"`
+		Track        int64   `json:"track"`
+		MetadataTime float64 `json:"metadata_time"`
 	} `json:"track_ids"`
 }
 


### PR DESCRIPTION
For this request:

http://localhost:1323/v1/full/playlists?id=Nk3GWZ0&id=aAXkA&id=k9lPGb1&id=OMAbb1&id=PW1GddN&id=OJ8Y3xV&id=wPKyvYK&id=2dywBlG&id=9OojERa&id=3AOMo5k&id=9mK7wG2&id=Nz2Nw&id=EJ4jq7&id=drgZ9y&id=bpObRwX&id=3Ad8yv0&id=0Mgm242&id=pZ55boo&id=GErb81v&id=zKpaE27&id=3J7442Z&id=VQvbVaQ&id=y2y4qpw&id=jZ2k2Va&id=zVAqGzj&id=5z1kRlX&id=R0mAkR1&id=K7jV0Ol&id=0v5aJq6&id=0g1XaMK&id=km14Ymw&id=o6wq5ym&id=dGb5gRy&id=qy9qx3E&id=jE6MaGG&id=p5mKAYB&id=ExOp1Bw&id=54jZlaV&id=54WpzN7&id=ePpK7&id=DOPRl&id=KEMNAbl&api_key=8acf5eb7436ea403ee536a7334faa5e9ada4b50f&app_name=audius-client

Was getting:

```
can't scan into dest[14] (col: playlist_contents): json: cannot unmarshal number 1725996919.209 into Go struct field .track_ids.time of type int64
```

Update field to float64 type.