### PR TITLE
[API-176] Adds validation and default value support for query params

### DIFF
--- a/api/v1_tracks_trending_ids.go
+++ b/api/v1_tracks_trending_ids.go
@@ -61,9 +61,17 @@ func encodeIds(ids []int32) ([]hashIdResponse, error) {
 	return result, nil
 }
 
+type GetTrendingTrackIdsParams struct {
+	Limit  int `query:"limit" default:"100" validate:"min=1,max=100"`
+	Offset int `query:"offset" default:"0" validate:"min=0,max=500"`
+}
+
 func (app *ApiServer) v1TracksTrendingIds(c *fiber.Ctx) error {
-	limit := c.QueryInt("limit", 100)
-	offset := c.QueryInt("offset", 0)
+	var params = GetTrendingTrackIdsParams{}
+	if err := app.ParseAndValidateQueryParams(c, &params); err != nil {
+		return err
+	}
+
 	genre := ""
 
 	weekChan := make(chan []int32)
@@ -72,7 +80,7 @@ func (app *ApiServer) v1TracksTrendingIds(c *fiber.Ctx) error {
 	errChan := make(chan error)
 
 	go func() {
-		ids, err := app.getTrendingIds(c, "week", genre, limit, offset)
+		ids, err := app.getTrendingIds(c, "week", genre, params.Limit, params.Offset)
 		if err != nil {
 			errChan <- err
 			return
@@ -81,7 +89,7 @@ func (app *ApiServer) v1TracksTrendingIds(c *fiber.Ctx) error {
 	}()
 
 	go func() {
-		ids, err := app.getTrendingIds(c, "month", genre, limit, offset)
+		ids, err := app.getTrendingIds(c, "month", genre, params.Limit, params.Offset)
 		if err != nil {
 			errChan <- err
 			return
@@ -90,7 +98,7 @@ func (app *ApiServer) v1TracksTrendingIds(c *fiber.Ctx) error {
 	}()
 
 	go func() {
-		ids, err := app.getTrendingIds(c, "allTime", genre, limit, offset)
+		ids, err := app.getTrendingIds(c, "allTime", genre, params.Limit, params.Offset)
 		if err != nil {
 			errChan <- err
 			return

--- a/api/validator.go
+++ b/api/validator.go
@@ -1,0 +1,45 @@
+package api
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+
+	"github.com/go-playground/validator/v10"
+	"github.com/gofiber/fiber/v2"
+)
+
+type RequestValidator struct {
+	validator *validator.Validate
+}
+
+func initRequestValidator() *RequestValidator {
+	requestValidator := validator.New(validator.WithRequiredStructEnabled())
+	// Prefer the query tag for parsed parameters over the struct field name
+	tagNameFunc := func(fld reflect.StructField) string {
+		name := strings.SplitN(fld.Tag.Get("query"), ",", 2)[0]
+		if name == "-" {
+			return ""
+		}
+		return name
+	}
+	requestValidator.RegisterTagNameFunc(tagNameFunc)
+	return &RequestValidator{validator: requestValidator}
+}
+
+func (v RequestValidator) Validate(data any) error {
+	err := v.validator.Struct(data)
+	if err != nil {
+		validationErrors := []string{}
+		for _, err := range err.(validator.ValidationErrors) {
+			switch err.Tag() {
+			case "required":
+				validationErrors = append(validationErrors, fmt.Sprintf("%s is required", err.Field()))
+			default:
+				validationErrors = append(validationErrors, fmt.Sprintf("%s is invalid", err.Field()))
+			}
+		}
+		return fiber.NewError(fiber.StatusBadRequest, strings.Join(validationErrors, "; "))
+	}
+	return nil
+}

--- a/go.mod
+++ b/go.mod
@@ -112,6 +112,7 @@ require (
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-runewidth v0.0.16 // indirect
+	github.com/mcuadros/go-defaults v1.2.0 // indirect
 	github.com/mitchellh/go-testing-interface v1.14.1 // indirect
 	github.com/mitchellh/mapstructure v1.5.1-0.20231216201459-8508981c8b6c // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect

--- a/go.sum
+++ b/go.sum
@@ -251,6 +251,8 @@ github.com/mattn/go-runewidth v0.0.16 h1:E5ScNMtiwvlvB5paMFdw9p4kSQzbXFikJ5SQO6T
 github.com/mattn/go-runewidth v0.0.16/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/maypok86/otter v1.2.4 h1:HhW1Pq6VdJkmWwcZZq19BlEQkHtI8xgsQzBVXJU0nfc=
 github.com/maypok86/otter v1.2.4/go.mod h1:mKLfoI7v1HOmQMwFgX4QkRk23mX6ge3RDvjdHOWG4R4=
+github.com/mcuadros/go-defaults v1.2.0 h1:FODb8WSf0uGaY8elWJAkoLL0Ri6AlZ1bFlenk56oZtc=
+github.com/mcuadros/go-defaults v1.2.0/go.mod h1:WEZtHEVIGYVDqkKSWBdWKUVdRyKlMfulPaGDWIVeCWY=
 github.com/mitchellh/go-testing-interface v1.14.1 h1:jrgshOhYAUVNMAJiKbEu7EqAwgJJ2JqpQmpLJOu07cU=
 github.com/mitchellh/go-testing-interface v1.14.1/go.mod h1:gfgS7OtZj6MA4U1UrDRp04twqAjfvlZyCfX3sDjEym8=
 github.com/mitchellh/mapstructure v1.5.1-0.20231216201459-8508981c8b6c h1:cqn374mizHuIWj+OSJCajGr/phAmuMug9qIX3l9CflE=
@@ -266,6 +268,7 @@ github.com/mr-tron/base58 v1.2.0 h1:T/HDJBh4ZCPbU39/+c3rRvE0uKBQlU27+QI8LJ4t64o=
 github.com/mr-tron/base58 v1.2.0/go.mod h1:BinMc/sQntlIE1frQmRFPUoPA1Zkr8VRgBdjWI2mNwc=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
+github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
@@ -517,6 +520,7 @@ google.golang.org/protobuf v1.36.6 h1:z1NpPI8ku2WgiWnf+t9wTPsn6eP1L7ksHUlkfLvd9x
 google.golang.org/protobuf v1.36.6/go.mod h1:jduwjTPXsFjZGTmRluh+L6NjiWu7pchiJ2/5YcXBHnY=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=


### PR DESCRIPTION
Pulled in validator and defaults packages to allow us to do struct-driven defaults and validation.
There are so many ways to expose this and I was aiming for it to be easy in the places we have to repeat it a bunch:
* Allow endpoint code to define a struct with the query params it supports, their default values, and their validation parameters
* Populating and validating said parameters is a single call on the application. It will return a pre-formatted 400 error with the field errors if things go wrong. Endpoint just returns the error up and lets the error middleware handle it

Additionally:
* For now, I'm only adding a custom message for required fields. Otherwise we just say the field is "invalid". We have to individually implement messages for each validation tag if we want custom messages. Easy to extend later if we want.
* Added a struct name lookup function that will use the 'query' tag for the field name in the error message. Since the pattern for parsing query params uses that tag to define the query param to read off the URL, this keeps the output message in sync with whatever param name we use there.
* Funny quirk of the defaults package: For number fields with a default, if you pass '0' in the query string, it will be interpreted as falsey and use the default value instead. This seems nice to me :shrug:

I will acknowledge that this kind of binds us to the pattern of using a struct to define query param parsing. I don't think we have any wild use cases where this will be super annoying. And I like the consistency of doing it this way.
If we have an endpoint that really really needs to do crazy stuff, you can always parse query params individually, dump them into a validation struct, and call the validator directly..


I only added the validation to one endpoint for this PR so I can get feedback on the pattern first. Will follow up and implement defaults/validation for at least `limit` in a separate PR.