### PR TITLE
[API-149] Add request ids to response headers and logs

### DIFF
--- a/api/server.go
+++ b/api/server.go
@@ -187,7 +187,7 @@ func NewApiServer(config config.Config) *ApiServer {
 		Next:       nil,
 		Header:     fiber.HeaderXRequestID,
 		Generator:  utils.UUIDv4,
-		ContextKey: "requestid",
+		ContextKey: "requestId",
 	}))
 	app.Use(fiberzap.New(fiberzap.Config{
 		Logger: logger,
@@ -204,8 +204,8 @@ func NewApiServer(config config.Config) *ApiServer {
 				fields = append(fields, zap.String("upstream", upstream))
 			}
 
-			if requestId, ok := c.Locals("requestid").(string); ok && requestId != "" {
-				fields = append(fields, zap.String("requestid", requestId))
+			if requestId, ok := c.Locals("requestId").(string); ok && requestId != "" {
+				fields = append(fields, zap.String("request_id", requestId))
 			}
 
 			return fields


### PR DESCRIPTION
This ended up being really easy. Fiber has a built-in middleware for this and it's already slick as hell.

If the client passes a `X-Request-Id` header, that value will be used (so can be coordinated across multiple requests if needed), otherwise one is generated. It gets added to Locals automatically, so we can pull it off there and append it to all logs.

I verified it gets sent for 200s,400s, etc.

![image](https://github.com/user-attachments/assets/a7547f67-0bb8-42ea-b0df-46e1d81dd6ff)

![image](https://github.com/user-attachments/assets/3d7e0a20-e585-4712-aa10-b7e112b4ebf7)
