### PR TITLE
Require userId for pubkeys

### DIFF
--- a/api/comms_pubkey.go
+++ b/api/comms_pubkey.go
@@ -7,11 +7,11 @@ import (
 
 func (api *ApiServer) getPubkey(c *fiber.Ctx) error {
 	userId := api.getUserId(c)
-	sql := `SELECT pubkey_base64 FROM user_pubkeys WHERE user_id = @user_id`
+	sql := `SELECT pubkey_base64 FROM user_pubkeys WHERE user_id = @userId`
 
 	var pubkey string
 	err := api.pool.QueryRow(c.Context(), sql, pgx.NamedArgs{
-		"user_id": userId,
+		"userId": userId,
 	}).Scan(&pubkey)
 	if err != nil {
 		return err

--- a/api/server.go
+++ b/api/server.go
@@ -337,8 +337,8 @@ func NewApiServer(config config.Config) *ApiServer {
 	// Comms
 	comms := app.Group("/comms")
 	// Cached/non-cached are the same as there are no other nodes to query anymore
-	comms.Get("/pubkey/:userId", app.getPubkey)
-	comms.Get("/pubky/:userId/cached", app.getPubkey)
+	comms.Get("/pubkey/:userId", app.requireUserIdMiddleware, app.getPubkey)
+	comms.Get("/pubky/:userId/cached", app.requireUserIdMiddleware, app.getPubkey)
 
 	unfurlBlocklist := unfurlist.WithBlocklistPrefixes(
 		[]string{


### PR DESCRIPTION
I guess we stopped using the userId middleware by default at some point? But anyway,, this one should be required.