### PR TITLE
Make item_type and class fields consistent with DN for library endpoints

### DIFF
--- a/api/v1_users_library_playlists.go
+++ b/api/v1_users_library_playlists.go
@@ -99,7 +99,10 @@ func (app *ApiServer) v1UsersLibraryPlaylists(c *fiber.Ctx) error {
 		FROM playlist_actions
 		GROUP BY item_id
 	)
-	SELECT deduped.*
+	SELECT
+		'collection_activity_full_without_tracks' as class,
+		'playlist' as item_type,
+		deduped.*
 	FROM deduped
 	JOIN playlists ON playlist_id = item_id
 	LEFT JOIN aggregate_playlist USING (playlist_id)
@@ -121,12 +124,12 @@ func (app *ApiServer) v1UsersLibraryPlaylists(c *fiber.Ctx) error {
 	}
 
 	type Activity struct {
-		// Class         string    `json:"class"`
+		Class         string    `json:"class"`
 		ItemID        int32     `json:"item_id"`
 		ItemCreatedAt time.Time `json:"timestamp"`
 		IsPurchase    bool      `json:"-"`
-
-		Item any `db:"-" json:"item"`
+		ItemType      string    `json:"item_type"`
+		Item          any       `db:"-" json:"item"`
 	}
 
 	items, err := pgx.CollectRows(rows, pgx.RowToStructByName[Activity])

--- a/api/v1_users_library_tracks.go
+++ b/api/v1_users_library_tracks.go
@@ -101,7 +101,8 @@ func (app *ApiServer) v1UsersLibraryTracks(c *fiber.Ctx) error {
 		'track_activity_full' as class,
 		item_id,
 		item_created_at,
-		is_purchase
+		is_purchase,
+		'track' as item_type
 	FROM deduped
 	JOIN tracks ON track_id = item_id
 	JOIN users ON owner_id = user_id
@@ -129,6 +130,7 @@ func (app *ApiServer) v1UsersLibraryTracks(c *fiber.Ctx) error {
 		ItemID        int32     `json:"item_id"`
 		ItemCreatedAt time.Time `json:"timestamp"`
 		IsPurchase    bool      `json:"-"`
+		ItemType      string    `json:"item_type"`
 
 		Item any `db:"-" json:"item"`
 	}


### PR DESCRIPTION
Api diff shows these fields missing and it might still be used on the client, so adding these in.