### PR TITLE
Fix: Included unlisted tracks in /v1/tracks endpoint

### DIFF
--- a/api/dbv1/queries/get_tracks.sql
+++ b/api/dbv1/queries/get_tracks.sql
@@ -206,7 +206,7 @@ FROM tracks t
 JOIN aggregate_track using (track_id)
 LEFT JOIN aggregate_plays on play_item_id = t.track_id
 LEFT JOIN track_routes on t.track_id = track_routes.track_id and track_routes.is_current = true
-WHERE (is_unlisted = false OR t.owner_id = @my_id)
+WHERE (is_unlisted = false OR t.owner_id = @my_id OR @include_unlisted::bool = TRUE)
   AND t.track_id = ANY(@ids::int[])
 ORDER BY t.track_id
 ;

--- a/api/v1_tracks.go
+++ b/api/v1_tracks.go
@@ -37,8 +37,9 @@ func (app *ApiServer) v1Tracks(c *fiber.Ctx) error {
 
 	tracks, err := app.queries.FullTracks(c.Context(), dbv1.FullTracksParams{
 		GetTracksParams: dbv1.GetTracksParams{
-			MyID: int32(myId),
-			Ids:  ids,
+			MyID:            int32(myId),
+			Ids:             ids,
+			IncludeUnlisted: true,
 		},
 	})
 	if err != nil {


### PR DESCRIPTION
Note: this changes some behavior compared to current Discovery API, which requires the caller to know the track's permalink (ie, the URL), not just the ID. Here, we open it up so if you know the ID, that's enough.

Some places call FullTracks that _do_ require the filter (mainly, the `Parallel` calls from FullPlaylists etc), so made this an opt in.