### PR TITLE
[API-182] Fix user tracks endpoint params/sorting

### DIFF
--- a/api/server_test.go
+++ b/api/server_test.go
@@ -69,6 +69,8 @@ func TestMain(m *testing.M) {
 	`)
 	checkErr(err)
 
+	insertFixturesFromArray("aggregate_plays", map[string]any{}, testdata.AggregatePlays)
+	insertFixturesFromArray("aggregate_track", map[string]any{}, testdata.AggregateTrack)
 	insertFixturesFromArray("aggregate_user", map[string]any{}, testdata.AggregateUser)
 	insertFixturesFromArray("aggregate_user_tips", aggregateUserTipsBaseRow, testdata.AggregateUserTips)
 	insertFixturesFromArray("audio_transactions_history", audioTransactionBaseRow, testdata.AudioTransactionsHistory)

--- a/api/testdata/aggregate_plays_fixtures.go
+++ b/api/testdata/aggregate_plays_fixtures.go
@@ -1,0 +1,21 @@
+package testdata
+
+var AggregatePlays = []map[string]any{
+	// data for v1_user_tracks_test.go
+	{
+		"play_item_id": 700,
+		"count":        100,
+	},
+	{
+		"play_item_id": 701,
+		"count":        50,
+	},
+	{
+		"play_item_id": 702,
+		"count":        20,
+	},
+	{
+		"play_item_id": 703,
+		"count":        10,
+	},
+}

--- a/api/testdata/aggregate_track_fixtures.go
+++ b/api/testdata/aggregate_track_fixtures.go
@@ -1,0 +1,25 @@
+package testdata
+
+var AggregateTrack = []map[string]any{
+	// data for v1_user_tracks_test.go
+	{
+		"track_id":     700,
+		"repost_count": 50,
+		"save_count":   50,
+	},
+	{
+		"track_id":     701,
+		"repost_count": 75,
+		"save_count":   100,
+	},
+	{
+		"track_id":     702,
+		"repost_count": 100,
+		"save_count":   75,
+	},
+	{
+		"track_id":     703,
+		"repost_count": 25,
+		"save_count":   25,
+	},
+}

--- a/api/testdata/track_fixtures.go
+++ b/api/testdata/track_fixtures.go
@@ -126,6 +126,13 @@ var TrackFixtures = []map[string]any{
 	{"track_id": 600, "genre": "Disco", "owner_id": 8, "title": "Underground Trending Disco Track 17", "is_unlisted": "f", "is_downloadable": "f"},
 	{"track_id": 601, "genre": "Rock", "owner_id": 11, "title": "Underground Trending Rock Track 17", "is_unlisted": "f", "is_downloadable": "f"},
 	{"track_id": 602, "genre": "Pop", "owner_id": 1, "title": "Underground Trending Pop Track 17", "is_unlisted": "f", "is_downloadable": "f"},
+
+	// data for v1_user_tracks_test.go
+	{"track_id": 700, "genre": "Electronic", "owner_id": 500, "title": "UserTracksTester Track 1", "created_at": "2021-01-01 00:00:00"},
+	{"track_id": 701, "genre": "Electronic", "owner_id": 500, "title": "UserTracksTester Track 4", "created_at": "2021-01-03 00:00:00"},
+	{"track_id": 702, "genre": "Electronic", "owner_id": 500, "title": "UserTracksTester Track 3", "created_at": "2021-01-04 00:00:00"},
+	// created before other track but later release date
+	{"track_id": 703, "genre": "Electronic", "owner_id": 500, "title": "UserTracksTester Track 2", "release_date": "2021-01-05 00:00:00", "created_at": "2021-01-02 00:00:00"},
 }
 
 /*

--- a/api/testdata/user_fixtures.go
+++ b/api/testdata/user_fixtures.go
@@ -149,4 +149,11 @@ var UserFixtures = []map[string]any{
 		"is_deactivated": false,
 		"wallet":         "0x003",
 	},
+
+	// data for v1_user_tracks_test.go
+	{
+		"user_id":   500,
+		"handle":    "UserTracksTester",
+		"handle_lc": "usertrackstester",
+	},
 }

--- a/api/v1_user_tracks_test.go
+++ b/api/v1_user_tracks_test.go
@@ -1,0 +1,227 @@
+package api
+
+import (
+	"fmt"
+	"testing"
+
+	"bridgerton.audius.co/api/dbv1"
+	"bridgerton.audius.co/trashid"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetUserTracks(t *testing.T) {
+	var userTracksResponse struct {
+		Data []dbv1.FullTrack
+	}
+
+	// Test support for handle
+	status, body := testGet(t, "/v1/full/users/handle/usertrackstester/tracks", &userTracksResponse)
+
+	assert.Equal(t, 200, status)
+	jsonAssert(t, body, map[string]any{
+		"data.0.id": trashid.MustEncodeHashID(703),
+		"data.1.id": trashid.MustEncodeHashID(702),
+		"data.2.id": trashid.MustEncodeHashID(701),
+		"data.3.id": trashid.MustEncodeHashID(700),
+	})
+
+	// Remaining assertions use the user_id version of the route
+	baseUrl := fmt.Sprintf("/v1/full/users/%s/tracks", trashid.MustEncodeHashID(500))
+
+	status, body = testGet(t, baseUrl, &userTracksResponse)
+	assert.Equal(t, 200, status)
+
+	// Note: Date sorts prefer release_date but fall back to created_at
+	// Default sort by legacy date desc
+	jsonAssert(t, body, map[string]any{
+		"data.0.id": trashid.MustEncodeHashID(703),
+		"data.1.id": trashid.MustEncodeHashID(702),
+		"data.2.id": trashid.MustEncodeHashID(701),
+		"data.3.id": trashid.MustEncodeHashID(700),
+	})
+
+	// Sort by date asc
+	url := fmt.Sprintf("%s?sort=date&sort_direction=asc", baseUrl)
+	status, body = testGet(t, url, &userTracksResponse)
+	assert.Equal(t, 200, status)
+
+	jsonAssert(t, body, map[string]any{
+		"data.0.id": trashid.MustEncodeHashID(700),
+		"data.1.id": trashid.MustEncodeHashID(701),
+		"data.2.id": trashid.MustEncodeHashID(702),
+		"data.3.id": trashid.MustEncodeHashID(703),
+	})
+
+	// Release date desc
+	url = fmt.Sprintf("%s?sort_method=release_date&sort_direction=desc", baseUrl)
+	status, body = testGet(t, url, &userTracksResponse)
+	assert.Equal(t, 200, status)
+
+	jsonAssert(t, body, map[string]any{
+		"data.0.id": trashid.MustEncodeHashID(703),
+		"data.1.id": trashid.MustEncodeHashID(702),
+		"data.2.id": trashid.MustEncodeHashID(701),
+		"data.3.id": trashid.MustEncodeHashID(700),
+	})
+
+	// Release date asc
+	url = fmt.Sprintf("%s?sort_method=release_date&sort_direction=asc", baseUrl)
+	status, body = testGet(t, url, &userTracksResponse)
+	assert.Equal(t, 200, status)
+
+	jsonAssert(t, body, map[string]any{
+		"data.0.id": trashid.MustEncodeHashID(700),
+		"data.1.id": trashid.MustEncodeHashID(701),
+		"data.2.id": trashid.MustEncodeHashID(702),
+		"data.3.id": trashid.MustEncodeHashID(703),
+	})
+
+	// Sort by legacy plays desc
+	url = fmt.Sprintf("%s?sort=plays&sort_direction=desc", baseUrl)
+	status, body = testGet(t, url, &userTracksResponse)
+	assert.Equal(t, 200, status)
+
+	jsonAssert(t, body, map[string]any{
+		"data.0.id": trashid.MustEncodeHashID(700),
+		"data.1.id": trashid.MustEncodeHashID(701),
+		"data.2.id": trashid.MustEncodeHashID(702),
+		"data.3.id": trashid.MustEncodeHashID(703),
+	})
+
+	// Sort by legacy plays asc
+	url = fmt.Sprintf("%s?sort=plays&sort_direction=asc", baseUrl)
+	status, body = testGet(t, url, &userTracksResponse)
+	assert.Equal(t, 200, status)
+
+	jsonAssert(t, body, map[string]any{
+		"data.0.id": trashid.MustEncodeHashID(703),
+		"data.1.id": trashid.MustEncodeHashID(702),
+		"data.2.id": trashid.MustEncodeHashID(701),
+		"data.3.id": trashid.MustEncodeHashID(700),
+	})
+
+	// Sort by sort_method plays desc
+	url = fmt.Sprintf("%s?sort_method=plays&sort_direction=desc", baseUrl)
+	status, body = testGet(t, url, &userTracksResponse)
+	assert.Equal(t, 200, status)
+
+	jsonAssert(t, body, map[string]any{
+		"data.0.id": trashid.MustEncodeHashID(700),
+		"data.1.id": trashid.MustEncodeHashID(701),
+		"data.2.id": trashid.MustEncodeHashID(702),
+		"data.3.id": trashid.MustEncodeHashID(703),
+	})
+
+	// Sort by sort_method plays asc
+	url = fmt.Sprintf("%s?sort_method=plays&sort_direction=asc", baseUrl)
+	status, body = testGet(t, url, &userTracksResponse)
+	assert.Equal(t, 200, status)
+
+	jsonAssert(t, body, map[string]any{
+		"data.0.id": trashid.MustEncodeHashID(703),
+		"data.1.id": trashid.MustEncodeHashID(702),
+		"data.2.id": trashid.MustEncodeHashID(701),
+		"data.3.id": trashid.MustEncodeHashID(700),
+	})
+
+	// Sort by title desc
+	url = fmt.Sprintf("%s?sort_method=title&sort_direction=desc", baseUrl)
+	status, body = testGet(t, url, &userTracksResponse)
+	assert.Equal(t, 200, status)
+
+	jsonAssert(t, body, map[string]any{
+		"data.0.id": trashid.MustEncodeHashID(701),
+		"data.1.id": trashid.MustEncodeHashID(702),
+		"data.2.id": trashid.MustEncodeHashID(703),
+		"data.3.id": trashid.MustEncodeHashID(700),
+	})
+
+	// Sort by title asc
+	url = fmt.Sprintf("%s?sort_method=title&sort_direction=asc", baseUrl)
+	status, body = testGet(t, url, &userTracksResponse)
+	assert.Equal(t, 200, status)
+
+	jsonAssert(t, body, map[string]any{
+		"data.0.id": trashid.MustEncodeHashID(700),
+		"data.1.id": trashid.MustEncodeHashID(703),
+		"data.2.id": trashid.MustEncodeHashID(702),
+		"data.3.id": trashid.MustEncodeHashID(701),
+	})
+
+	// Sort by reposts desc
+	url = fmt.Sprintf("%s?sort_method=reposts&sort_direction=desc", baseUrl)
+	status, body = testGet(t, url, &userTracksResponse)
+	assert.Equal(t, 200, status)
+
+	jsonAssert(t, body, map[string]any{
+		"data.0.id": trashid.MustEncodeHashID(702),
+		"data.1.id": trashid.MustEncodeHashID(701),
+		"data.2.id": trashid.MustEncodeHashID(700),
+		"data.3.id": trashid.MustEncodeHashID(703),
+	})
+
+	// Sort by reposts asc
+	url = fmt.Sprintf("%s?sort_method=reposts&sort_direction=asc", baseUrl)
+	status, body = testGet(t, url, &userTracksResponse)
+	assert.Equal(t, 200, status)
+
+	jsonAssert(t, body, map[string]any{
+		"data.0.id": trashid.MustEncodeHashID(703),
+		"data.1.id": trashid.MustEncodeHashID(700),
+		"data.2.id": trashid.MustEncodeHashID(701),
+		"data.3.id": trashid.MustEncodeHashID(702),
+	})
+
+	// Sort by saves desc
+	url = fmt.Sprintf("%s?sort_method=saves&sort_direction=desc", baseUrl)
+	status, body = testGet(t, url, &userTracksResponse)
+	assert.Equal(t, 200, status)
+
+	jsonAssert(t, body, map[string]any{
+		"data.0.id": trashid.MustEncodeHashID(701),
+		"data.1.id": trashid.MustEncodeHashID(702),
+		"data.2.id": trashid.MustEncodeHashID(700),
+		"data.3.id": trashid.MustEncodeHashID(703),
+	})
+
+	// Sort by saves asc
+	url = fmt.Sprintf("%s?sort_method=saves&sort_direction=asc", baseUrl)
+	status, body = testGet(t, url, &userTracksResponse)
+	assert.Equal(t, 200, status)
+
+	jsonAssert(t, body, map[string]any{
+		"data.0.id": trashid.MustEncodeHashID(703),
+		"data.1.id": trashid.MustEncodeHashID(700),
+		"data.2.id": trashid.MustEncodeHashID(702),
+		"data.3.id": trashid.MustEncodeHashID(701),
+	})
+
+}
+
+func TestGetUserTracksInvalidParams(t *testing.T) {
+	baseUrl := fmt.Sprintf("/v1/full/users/%s/tracks", trashid.MustEncodeHashID(500))
+	// Test invalid sort_method
+	url := fmt.Sprintf("%s?sort_method=invalid&sort_direction=desc", baseUrl)
+	status, _ := testGet(t, url)
+	assert.Equal(t, 400, status)
+
+	// Test invalid sort_direction
+	url = fmt.Sprintf("%s?sort_method=plays&sort_direction=invalid", baseUrl)
+	status, _ = testGet(t, url)
+	assert.Equal(t, 400, status)
+
+	// Test invalid sort
+	url = fmt.Sprintf("%s?sort=invalid", baseUrl)
+	status, _ = testGet(t, url)
+	assert.Equal(t, 400, status)
+
+	// Test invalid limit
+	url = fmt.Sprintf("%s?limit=101", baseUrl)
+	status, _ = testGet(t, url)
+	assert.Equal(t, 400, status)
+
+	// Test invalid offset
+	url = fmt.Sprintf("%s?offset=invalid", baseUrl)
+	status, _ = testGet(t, url)
+	assert.Equal(t, 400, status)
+}


### PR DESCRIPTION
Two issues here:
* The user tracks handler is wired up to the `/users/:userId/tracks` route but it doesn't support querying by ID and returns nothing. Updated it to handle either case based on presence of the `handle` param in the route.
* The sorting logic isn't correct. This endpoint supports both the `sort` (deprecated) and `sort_method` params and is supposed to prefer the latter if specified. When using `sort`, the options are `plays` and `date`, defaulting to `date`. So I added back the aggregate plays join to support this case.

TODO:
* Consider conditionally joining aggregate plays only if sorting by it
* TESTS. As those would have caught this :-) 