### PR TITLE
Fix users supporting endpoint not using limit/offset params

### DIFF
--- a/api/v1_users_supporting.go
+++ b/api/v1_users_supporting.go
@@ -21,6 +21,8 @@ func (app *ApiServer) v1UsersSupporting(c *fiber.Ctx) error {
 
 	args := pgx.NamedArgs{
 		"userId": userId,
+		"limit":  params.Limit,
+		"offset": params.Offset,
 	}
 
 	type supportedUser struct {


### PR DESCRIPTION
we validate them but don't actually use them in the query :)