### PR TITLE
Fix cache pollution due to context parameter capturing

### DIFF
--- a/api/auth_middleware.go
+++ b/api/auth_middleware.go
@@ -8,6 +8,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/gofiber/fiber/v2"
+	"github.com/gofiber/fiber/v2/utils"
 	"github.com/jackc/pgx/v5"
 )
 
@@ -132,8 +133,8 @@ func (app *ApiServer) requireAuthMiddleware(c *fiber.Ctx) error {
 // it predates manager mode and messages are e2ee via wallet. V1 endpoints
 // should use the query or route parameters for determining the current user.
 func (app *ApiServer) getUserIDFromWallet(ctx context.Context, wallet string) (int, error) {
-
-	if hit, ok := app.resolveWalletCache.Get(wallet); ok {
+	key := utils.CopyString(wallet)
+	if hit, ok := app.resolveWalletCache.Get(key); ok {
 		return hit, nil
 	}
 
@@ -157,6 +158,6 @@ func (app *ApiServer) getUserIDFromWallet(ctx context.Context, wallet string) (i
 		return 0, fiber.NewError(fiber.ErrBadRequest.Code, "bad signature")
 	}
 
-	app.resolveWalletCache.Set(wallet, userId)
+	app.resolveWalletCache.Set(key, userId)
 	return userId, nil
 }

--- a/api/auth_middleware_test.go
+++ b/api/auth_middleware_test.go
@@ -1,6 +1,8 @@
 package api
 
 import (
+	"fmt"
+	"io"
 	"net/http/httptest"
 	"testing"
 
@@ -109,4 +111,58 @@ func TestRequireAuthMiddleware(t *testing.T) {
 	res, err := testApp.Test(req1, -1)
 	assert.NoError(t, err)
 	assert.Equal(t, fiber.StatusUnauthorized, res.StatusCode)
+}
+
+func TestWalletCache(t *testing.T) {
+	app := emptyTestApp(t)
+
+	// Create a dummy endpoint to test wallet to user ID lookup
+	// The important part here is that we are pulling a value from the context
+	// and passing it directly to getUserIDFromWallet.
+	testApp := fiber.New()
+	testApp.Get("/test/get_user_id/:wallet", func(c *fiber.Ctx) error {
+		wallet := c.Params("wallet")
+		userId, err := app.getUserIDFromWallet(c.Context(), wallet)
+		if err != nil {
+			return err
+		}
+		return c.JSON(fiber.Map{
+			"data": userId,
+		})
+	})
+
+	fixtures := FixtureMap{
+		"users": make([]map[string]any, 100),
+	}
+
+	for i := range 100 {
+		fixtures["users"][i] = map[string]any{
+			"user_id":   i + 1,
+			"handle":    fmt.Sprintf("testuser%d", i+1),
+			"handle_lc": fmt.Sprintf("testuser%d", i+1),
+			"wallet":    fmt.Sprintf("0x%064x", i+1),
+		}
+	}
+
+	createFixtures(app, fixtures)
+
+	// Test that caching doesn't reuse context params
+	for i := range 1000 {
+		user := fixtures["users"][i%100]
+		wallet := user["wallet"].(string)
+		expectedUserId := user["user_id"].(int)
+
+		req := httptest.NewRequest("GET", "/test/get_user_id/"+wallet, nil)
+		res, err := testApp.Test(req, -1)
+		assert.NoError(t, err)
+		body, err := io.ReadAll(res.Body)
+		assert.NoError(t, err)
+
+		if ok := jsonAssert(t, body, map[string]any{
+			"data": expectedUserId,
+		}); !ok {
+			fmt.Printf("failed on iteration %d\n", i)
+			return
+		}
+	}
 }

--- a/api/resolve_middleware.go
+++ b/api/resolve_middleware.go
@@ -5,6 +5,7 @@ import (
 
 	"bridgerton.audius.co/trashid"
 	"github.com/gofiber/fiber/v2"
+	"github.com/gofiber/fiber/v2/utils"
 )
 
 func (app *ApiServer) isFullMiddleware(c *fiber.Ctx) error {
@@ -49,6 +50,19 @@ func (app *ApiServer) requireUserIdMiddleware(c *fiber.Ctx) error {
 	}
 	c.Locals("userId", userId)
 	return c.Next()
+}
+
+func (app *ApiServer) resolveUserHandleToId(c *fiber.Ctx, handle string) (int32, error) {
+	key := utils.CopyString(handle)
+	if hit, ok := app.resolveHandleCache.Get(key); ok {
+		return hit, nil
+	}
+	user_id, err := app.queries.GetUserForHandle(c.Context(), handle)
+	if err != nil {
+		return 0, err
+	}
+	app.resolveHandleCache.Set(key, int32(user_id))
+	return int32(user_id), nil
 }
 
 func (app *ApiServer) requireHandleMiddleware(c *fiber.Ctx) error {

--- a/api/resolve_middleware_test.go
+++ b/api/resolve_middleware_test.go
@@ -1,0 +1,46 @@
+package api
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestResolveUserHandleToId(t *testing.T) {
+	app := emptyTestApp(t)
+
+	fixtures := FixtureMap{
+		"users": make([]map[string]any, 100),
+	}
+
+	for i := range 100 {
+		handle := fmt.Sprintf("testuser%d", i+1)
+		fixtures["users"][i] = map[string]any{
+			"user_id":   i + 1,
+			"handle":    handle,
+			"handle_lc": handle,
+		}
+	}
+
+	createFixtures(app, fixtures)
+
+	// This test verifies we aren't hitting a cache pollution bug due
+	// to fiber params not being copied before being used in the cache key. We are
+	// intentionally using a large number because the sync.Pool used by Fiber is
+	// not deterministic in _when_ it reuses a decoder and causes the bug. In empirical
+	// testing on a M1 Max, this happens around ~200 requests.
+	for i := range 1000 {
+		userId := (i % 100) + 1
+		status, body := testGet(t, app, fmt.Sprintf("/v1/full/users/handle/testuser%d", userId))
+		assert.Equal(t, 200, status)
+
+		if ok := jsonAssert(t, body, map[string]any{
+			"data.0.handle": fmt.Sprintf("testuser%d", userId),
+		}); !ok {
+			// Bail early on failure so we don't barf out a bunch of errors.
+			fmt.Printf("failed on iteration %d\n", i)
+			return
+		}
+	}
+}

--- a/api/server.go
+++ b/api/server.go
@@ -486,18 +486,6 @@ func (app *ApiServer) paramTimeRange(c *fiber.Ctx, param string, defaultValue st
 	return timeRange, nil
 }
 
-func (app *ApiServer) resolveUserHandleToId(c *fiber.Ctx, handle string) (int32, error) {
-	// if hit, ok := app.resolveHandleCache.Get(handle); ok {
-	// 	return hit, nil
-	// }
-	user_id, err := app.queries.GetUserForHandle(c.Context(), handle)
-	if err != nil {
-		return 0, err
-	}
-	// app.resolveHandleCache.Set(handle, int32(user_id))
-	return int32(user_id), nil
-}
-
 func (as *ApiServer) Serve() {
 	flushTicker := time.NewTicker(time.Second * 15)
 	go func() {

--- a/api/server_test.go
+++ b/api/server_test.go
@@ -243,7 +243,8 @@ func testGet(t *testing.T, app *ApiServer, path string, dest ...any) (int, []byt
 	return res.StatusCode, body
 }
 
-func jsonAssert(t *testing.T, body []byte, expectations map[string]any) {
+func jsonAssert(t *testing.T, body []byte, expectations map[string]any) bool {
+	success := true
 	for path, expectation := range expectations {
 		var actual any
 		switch v := expectation.(type) {
@@ -261,8 +262,11 @@ func jsonAssert(t *testing.T, body []byte, expectations map[string]any) {
 			t.Errorf("unsupported type for expectation: %T", v)
 		}
 		msg := fmt.Sprintf("Expected %s to be %v got %v", path, expectation, actual)
-		assert.Equal(t, expectation, actual, msg)
+		if !assert.Equal(t, expectation, actual, msg) {
+			success = false
+		}
 	}
+	return success
 }
 
 // testGetWithWallet makes a GET request with authentication headers for the given wallet address

--- a/api/v1_user_test.go
+++ b/api/v1_user_test.go
@@ -27,4 +27,14 @@ func TestGetUser(t *testing.T) {
 	// but we also unmarshaled into userResponse
 	// for structured testing
 	assert.Equal(t, userResponse.Data[0].ID, trashid.HashId(1))
+
+	// test that we can get a user by handle
+	status, body = testGet(t, app, "/v1/full/users/handle/rayjacobson")
+	assert.Equal(t, 200, status)
+
+	jsonAssert(t, body, map[string]any{
+		"data.0.handle":  "rayjacobson",
+		"data.0.user_id": 1,
+		"data.0.id":      "7eP5n",
+	})
 }


### PR DESCRIPTION
This was wild.

1. Fiber is [pretty clear in their docs](https://docs.gofiber.io/#zero-allocation) about why you should not hold on to any value in the Context past the life of the request.
2. We have a couple of places where we call `c.Param()` to get a string value of a wallet or handle. We pass that into a helper function to do some kind of lookup of a user.
3. To help with performance, we use Otter caches in those places, and the usage is pretty straightforward (try to get value, if we miss look it up and insert it into the cache before returning)

Imagine our surprise when the cache started returning the _wrong_ user, sometimes but not all the time, and with no discernible pattern.

The _very_ subtle issue is that since we pass the value all the way down the stack and _into_ the `Set` function on the cache without ever assigning it to a new variable or making a copy, we end up inserting a memory address belonging to a reusable Context from a pool as the key.  So at any arbitrary point in the future, we might reuse that same memory address as the key for a different value. And so the performance optimizations of two different libraries collude to remove some hair from our heads.

TL/DR you should **_always_** copy a value before using it as an Otter cache key, even if your inexperience tells you there's no way that value is passed by reference. Because it most definitely doesn't work the way you think it does.