### PR TITLE
v1UsersTop and v1UsersGenreTop

### DIFF
--- a/api/server.go
+++ b/api/server.go
@@ -264,8 +264,6 @@ func NewApiServer(config config.Config) *ApiServer {
 	// so add some exclusions here to make `bridge.audius.co` less broken
 	// todo: implement these endpoints in bridgerton.
 	{
-		app.Use("/v1/full/users/top", BalancerForward(config.PythonUpstreams))
-		app.Use("/v1/full/users/genre/top", BalancerForward(config.PythonUpstreams))
 		app.Use("/v1/full/users/subscribers", BalancerForward(config.PythonUpstreams))
 
 		app.Use("/v1/full/playlists/top", BalancerForward(config.PythonUpstreams))
@@ -283,6 +281,8 @@ func NewApiServer(config config.Config) *ApiServer {
 		// Users
 		g.Get("/users", app.v1Users)
 		g.Get("/users/unclaimed_id", app.v1UsersUnclaimedId)
+		g.Get("/users/top", app.v1UsersTop)
+		g.Get("/users/genre/top", app.v1UsersGenreTop)
 		g.Get("/users/account/:wallet", app.requireAuthMiddleware, app.v1UsersAccount)
 
 		g.Use("/users/handle/:handle", app.requireHandleMiddleware)

--- a/api/v1_users_genre_top.go
+++ b/api/v1_users_genre_top.go
@@ -1,0 +1,34 @@
+package api
+
+import (
+	"github.com/gofiber/fiber/v2"
+	"github.com/jackc/pgx/v5"
+)
+
+type GetUsersGenreTopQueryParams struct {
+	Genres []string `query:"genre" validation:"required"`
+}
+
+func (app *ApiServer) v1UsersGenreTop(c *fiber.Ctx) error {
+	query := GetUsersGenreTopQueryParams{}
+	if err := app.ParseAndValidateQueryParams(c, &query); err != nil {
+		return err
+	}
+
+	sql := `
+		SELECT users.user_id
+		FROM users
+		JOIN aggregate_user using (user_id)
+		WHERE
+			is_current = TRUE
+			AND track_count > 0
+			AND dominant_genre = ANY(@genres)
+		ORDER BY follower_count DESC, user_id ASC
+		LIMIT @limit
+		OFFSET @offset
+	;`
+
+	return app.queryFullUsers(c, sql, pgx.NamedArgs{
+		"genres": query.Genres,
+	})
+}

--- a/api/v1_users_top.go
+++ b/api/v1_users_top.go
@@ -1,0 +1,22 @@
+package api
+
+import (
+	"github.com/gofiber/fiber/v2"
+	"github.com/jackc/pgx/v5"
+)
+
+func (app *ApiServer) v1UsersTop(c *fiber.Ctx) error {
+	sql := `
+		SELECT users.user_id
+		FROM users
+		JOIN aggregate_user using (user_id)
+		WHERE
+			is_current = TRUE
+			AND track_count > 0
+		ORDER BY follower_count DESC, user_id ASC
+		LIMIT @limit
+		OFFSET @offset
+	;`
+
+	return app.queryFullUsers(c, sql, pgx.NamedArgs{})
+}


### PR DESCRIPTION
Note: Unlike Python, the genres here are case sensitive. This keeps the index working and makes the query fast. We could probably make a list of all allowed genres somewhere and marshal the parameter to that before querying though.

Also, the genre is now required in the top/genres endpoint.

Opted against adding tests here, at least for now.