### PR TITLE
[API-190] Add track remix parents endpoint

### DIFF
--- a/api/server.go
+++ b/api/server.go
@@ -344,6 +344,7 @@ func NewApiServer(config config.Config) *ApiServer {
 		g.Get("/tracks/:trackId/stems", app.v1TrackStems)
 		g.Get("/tracks/:trackId/favorites", app.v1TrackFavorites)
 		g.Get("/tracks/:trackId/comments", app.v1TrackComments)
+		g.Get("/tracks/:trackId/remixing", app.v1TrackRemixing)
 
 		// Playlists
 		g.Get("/playlists", app.v1Playlists)

--- a/api/v1_track_remixing.go
+++ b/api/v1_track_remixing.go
@@ -1,0 +1,63 @@
+package api
+
+import (
+	"bridgerton.audius.co/api/dbv1"
+	"github.com/gofiber/fiber/v2"
+	"github.com/jackc/pgx/v5"
+)
+
+type GetTrackRemixingParams struct {
+	Limit  int `query:"limit" default:"20" validate:"min=1,max=100"`
+	Offset int `query:"offset" default:"0" validate:"min=0"`
+}
+
+func (app *ApiServer) v1TrackRemixing(c *fiber.Ctx) error {
+	params := GetTrackRemixingParams{}
+	if err := app.ParseAndValidateQueryParams(c, &params); err != nil {
+		return err
+	}
+
+	myId := app.getMyId(c)
+	trackId := c.Locals("trackId").(int)
+	sql := `
+		SELECT pt.track_id
+		FROM tracks pt
+		JOIN remixes r ON r.parent_track_id = pt.track_id AND r.child_track_id = @trackId
+		JOIN tracks ct ON ct.track_id = @trackId
+		WHERE pt.is_current = true
+		AND pt.is_unlisted = false
+		AND ct.is_current = true
+		AND ct.is_stream_gated = false
+		ORDER BY pt.created_at DESC, pt.track_id DESC
+		LIMIT @limit OFFSET @offset
+	`
+
+	// Get all remix tracks in a single query
+	rows, err := app.pool.Query(c.Context(), sql, pgx.NamedArgs{
+		"trackId": trackId,
+		"limit":   params.Limit,
+		"offset":  params.Offset,
+	})
+
+	if err != nil {
+		return err
+	}
+
+	trackIds, err := pgx.CollectRows(rows, pgx.RowTo[int32])
+	if err != nil {
+		return err
+	}
+
+	tracks, err := app.queries.FullTracks(c.Context(), dbv1.FullTracksParams{
+		GetTracksParams: dbv1.GetTracksParams{
+			Ids:  trackIds,
+			MyID: myId,
+		},
+	})
+
+	if err != nil {
+		return err
+	}
+
+	return v1TracksResponse(c, tracks)
+}

--- a/api/v1_track_remixing_test.go
+++ b/api/v1_track_remixing_test.go
@@ -1,0 +1,136 @@
+package api
+
+import (
+	"testing"
+
+	"bridgerton.audius.co/trashid"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestV1TrackRemixing(t *testing.T) {
+	app := emptyTestApp(t)
+
+	fixtures := FixtureMap{
+		"users": []map[string]any{
+			{
+				"user_id": 1,
+				"handle":  "user1",
+			},
+			{
+				"user_id": 2,
+				"handle":  "user2",
+			},
+		},
+		"tracks": []map[string]any{
+			{
+				"track_id":        1,
+				"title":           "Parent Track 1",
+				"owner_id":        1,
+				"is_stream_gated": false,
+				"is_unlisted":     false,
+				"created_at":      parseTime(t, "2024-01-01"),
+			},
+			{
+				"track_id":        2,
+				"title":           "Parent Track 2",
+				"owner_id":        1,
+				"is_stream_gated": false,
+				"is_unlisted":     true,
+				"created_at":      parseTime(t, "2024-01-01"),
+			},
+			{
+				"track_id":        3,
+				"title":           "Parent Track 3",
+				"owner_id":        1,
+				"is_stream_gated": false,
+				"is_unlisted":     false,
+				"created_at":      parseTime(t, "2024-01-01"),
+			},
+			{
+				"track_id":        10,
+				"title":           "Child Track 1",
+				"owner_id":        2,
+				"is_stream_gated": false,
+				"is_unlisted":     false,
+				"created_at":      parseTime(t, "2024-01-02"),
+			},
+			{
+				"track_id":        11,
+				"title":           "Child Track 2",
+				"owner_id":        2,
+				"is_stream_gated": false,
+				"created_at":      parseTime(t, "2024-01-02"),
+			},
+			{
+				"track_id":        12,
+				"title":           "Child Track 3",
+				"owner_id":        2,
+				"is_stream_gated": true,
+				"is_unlisted":     false,
+				"created_at":      parseTime(t, "2024-01-02"),
+			},
+		},
+		"remixes": []map[string]any{
+			{
+				"parent_track_id": 1,
+				"child_track_id":  10,
+			},
+			{
+				"parent_track_id": 3,
+				"child_track_id":  10,
+			},
+			{
+				"parent_track_id": 2,
+				"child_track_id":  11,
+			},
+			{
+				"parent_track_id": 1,
+				"child_track_id":  12,
+			},
+		},
+	}
+
+	createFixtures(app, fixtures)
+
+	status, body := testGet(t, app, "/v1/full/tracks/"+trashid.MustEncodeHashID(10)+"/remixing")
+	assert.Equal(t, 200, status)
+
+	jsonAssert(t, body, map[string]any{
+		"data.#":    2,
+		"data.0.id": trashid.MustEncodeHashID(3),
+		"data.1.id": trashid.MustEncodeHashID(1),
+	})
+
+	status, body = testGet(t, app, "/v1/full/tracks/"+trashid.MustEncodeHashID(11)+"/remixing")
+
+	jsonAssert(t, body, map[string]any{
+		"data.#": 0,
+	})
+
+	status, body = testGet(t, app, "/v1/full/tracks/"+trashid.MustEncodeHashID(12)+"/remixing")
+
+	jsonAssert(t, body, map[string]any{
+		"data.#": 0,
+	})
+}
+
+func TestV1TrackRemixingInvalidParams(t *testing.T) {
+	app := emptyTestApp(t)
+
+	baseUrl := "/v1/full/tracks/" + trashid.MustEncodeHashID(10) + "/remixing"
+
+	status, _ := testGet(t, app, baseUrl+"?limit=invalid")
+	assert.Equal(t, 400, status)
+
+	status, _ = testGet(t, app, baseUrl+"?limit=-1")
+	assert.Equal(t, 400, status)
+
+	status, _ = testGet(t, app, baseUrl+"?limit=101")
+	assert.Equal(t, 400, status)
+
+	status, _ = testGet(t, app, baseUrl+"?offset=-1")
+	assert.Equal(t, 400, status)
+
+	status, _ = testGet(t, app, baseUrl+"?offset=invalid")
+	assert.Equal(t, 400, status)
+}


### PR DESCRIPTION
I'm matching the logic from the python endpoint, which is a little strange.
* It is capable of returning multiple remix parents (though no prod data actually does this)
* It does not support returning remix parents for premium tracks (you can't monetize a remix)
* It does not support returning hidden remix parents (regardless if you own said parents)

The tests reflect these cases.