### PR TITLE
Add write db URL and rename discoveryDbUrl

### DIFF
--- a/api/server.go
+++ b/api/server.go
@@ -84,7 +84,7 @@ func NewApiServer(config config.Config) *ApiServer {
 	logger := InitLogger(config)
 	requestValidator := initRequestValidator()
 
-	connConfig, err := pgxpool.ParseConfig(config.DbUrl)
+	connConfig, err := pgxpool.ParseConfig(config.ReadDbUrl)
 	if err != nil {
 		logger.Error("db connect failed", zap.Error(err))
 	}

--- a/api/server_test.go
+++ b/api/server_test.go
@@ -59,7 +59,7 @@ func emptyTestApp(t *testing.T) *ApiServer {
 
 	app := NewApiServer(config.Config{
 		Env:                "test",
-		DbUrl:              "postgres://postgres:example@localhost:21300/" + dbName,
+		ReadDbUrl:          "postgres://postgres:example@localhost:21300/" + dbName,
 		DelegatePrivateKey: "0633fddb74e32b3cbc64382e405146319c11a1a52dc96598e557c5dbe2f31468",
 		SolanaConfig:       config.SolanaConfig{RpcProviders: []string{""}},
 	})

--- a/config/config.go
+++ b/config/config.go
@@ -11,7 +11,8 @@ import (
 
 type Config struct {
 	Env                string
-	DbUrl              string
+	ReadDbUrl          string
+	WriteDbUrl         string
 	Nodes              []Node
 	DeadNodes          []string
 	DelegatePrivateKey string
@@ -27,7 +28,8 @@ type Config struct {
 
 var Cfg = Config{
 	Env:                os.Getenv("ENV"),
-	DbUrl:              os.Getenv("discoveryDbUrl"),
+	ReadDbUrl:          os.Getenv("readDbUrl"),
+	WriteDbUrl:         os.Getenv("writeDbUrl"),
 	DelegatePrivateKey: os.Getenv("delegatePrivateKey"),
 	AxiomToken:         os.Getenv("axiomToken"),
 	AxiomDataset:       os.Getenv("axiomDataset"),


### PR DESCRIPTION
Splits the DB URL into a read and write db URL so that reads can use a read replica while writes go to the write leader.

https://github.com/AudiusProject/audius-k8s/pull/430 added the `readDbUrl` to the env so that should be good to go now (still will need the `writeDbUrl` in the future)