### PR TITLE
Enable unescaping for params to fix fetching playlists with emojis in slug

### DIFF
--- a/api/server.go
+++ b/api/server.go
@@ -177,6 +177,7 @@ func NewApiServer(config config.Config) *ApiServer {
 			JSONDecoder:    json.Unmarshal,
 			ErrorHandler:   errorHandler(logger),
 			ReadBufferSize: 32_768,
+			UnescapePath:   true,
 		}),
 		pool:                  pool,
 		queries:               dbv1.New(pool),


### PR DESCRIPTION
We fail to look up playlists by permalink if the slug has an emoji in it. That's because the default behavior for fiber is _not_ to unescape string param values. Since we store the slugs as UTF-8 encoded, we need this on or we have to manually decode things everywhere where it might matter.