### PR TITLE
Add 10s now playing buffer

### DIFF
--- a/api/v1_users_now_playing.go
+++ b/api/v1_users_now_playing.go
@@ -50,7 +50,7 @@ func (app *ApiServer) v1UsersNowPlaying(c *fiber.Ctx) error {
 	// Add a 10 second buffer to account for the track stopping and the next
 	// track getting indexed.
 	endTime := np.CreatedAt.Add(time.Duration(np.Duration) * time.Second)
-	if endTime.Before(time.Now().Add(10 * time.Second)) {
+	if endTime.Before(time.Now().Add(-10 * time.Second)) {
 		return c.JSON(fiber.Map{
 			"data": nil,
 		})


### PR DESCRIPTION
After playing around a tiny bit with this, i felt that a buffer for the next track to get indexed would be useful, so that if you're streaming a lineup and refreshing the endpoint, there are no `gaps`