### PR TITLE
[API-246] Always add download filename if not provided

### DIFF
--- a/api/v1_track_download.go
+++ b/api/v1_track_download.go
@@ -1,14 +1,34 @@
 package api
 
 import (
+	"path/filepath"
+	"strings"
+
 	"bridgerton.audius.co/api/dbv1"
 	"github.com/gofiber/fiber/v2"
 )
+
+func createFilename(track *dbv1.FullTrack, isOriginal bool) string {
+	origFilename := track.OrigFilename
+	if origFilename.String == "" {
+		origFilename = track.Title
+	}
+
+	if isOriginal {
+		return origFilename.String
+	}
+
+	// Remove extension and add .mp3
+	ext := filepath.Ext(origFilename.String)
+	nameWithoutExt := strings.TrimSuffix(origFilename.String, ext)
+	return nameWithoutExt + ".mp3"
+}
 
 func (app *ApiServer) v1TrackDownload(c *fiber.Ctx) error {
 	myId := app.getMyId(c)
 	trackId := c.Locals("trackId").(int)
 	filename := c.Query("filename")
+	isOriginal := c.Query("is_original") == "true"
 
 	tracks, err := app.queries.FullTracks(c.Context(), dbv1.FullTracksParams{
 		GetTracksParams: dbv1.GetTracksParams{
@@ -35,6 +55,8 @@ func (app *ApiServer) v1TrackDownload(c *fiber.Ctx) error {
 	q.Set("skip_play_count", "true")
 	if filename != "" {
 		q.Set("filename", filename)
+	} else {
+		q.Set("filename", createFilename(&track, isOriginal))
 	}
 	downloadUrl.RawQuery = q.Encode()
 

--- a/api/v1_track_download_test.go
+++ b/api/v1_track_download_test.go
@@ -12,5 +12,6 @@ func TestGetTrackDownload(t *testing.T) {
 	req := httptest.NewRequest("GET", "/v1/tracks/eYZmn/download", nil)
 	res, err := app.Test(req, -1)
 	assert.NoError(t, err)
-	assert.Contains(t, res.Header.Get("Location"), "tracks/cidstream/?signature=%7B%22data%22%3A%22%7B%5C%22cid%5C%22%3A%5C%22%5C%22%2C%5C%22timestamp%5C%22%3")
+	assert.Contains(t, res.Header.Get("Location"), "signature=%7B%22data%22%3A%22%7B%5C%22cid%5C%22%3A%5C%22%5C%22%2C%5C%22timestamp%5C%22%3")
+	assert.Contains(t, res.Header.Get("Location"), "filename=T1.mp3")
 }


### PR DESCRIPTION
In order for downloads to trigger properly, we always need to pass a `filename` param to the node

Tested:
- Add additional test
- Visit 'http://localhost:1323/v1/tracks/E0Rb8/download?user_id=7eP5n&user_signature=0x680f50618c01c919ebccd232b8cb27fee2d8f732fe82bfb6061c0ed2e817ca0109ffba04900344eb19dbb69b001b597f61f60016a74909e69246bddfc6bba50e1b&user_data=Gated+content+user+signature+at+1751394161866&original=true' in the browser and see it trigger a download (with the appropriate file name)