### PR TITLE
[QA-2197] Bring back collaborative filtering for related artists

### DIFF
--- a/api/fixture_test.go
+++ b/api/fixture_test.go
@@ -447,7 +447,9 @@ func createFixtures(app *ApiServer, fixtures FixtureMap) {
 	// because map key iteration order is randomized...
 	// explicitly do the "entity" tables first
 	// so that data dependencies exist before attempting to do saves, follows, etc.
-	entityTables := []string{"users", "tracks", "playlists"}
+	// note: aggregate_user appears first because users create aggregate rows which would lead to
+	// duplicates
+	entityTables := []string{"aggregate_user", "users", "tracks", "playlists"}
 	for _, tableName := range entityTables {
 		if rows, ok := fixtures[tableName]; ok {
 			insertFixturesFromArray(app, tableName, rows)

--- a/api/testdata/aggregate_user_fixtures.go
+++ b/api/testdata/aggregate_user_fixtures.go
@@ -3,7 +3,7 @@ package testdata
 var AggregateUser = []map[string]any{
 	{
 		"user_id":          1,
-		"follower_count":   98,
+		"follower_count":   100,
 		"following_count":  25,
 		"dominant_genre":   "Electronic",
 		"track_save_count": 20,

--- a/api/v1_users_related_test.go
+++ b/api/v1_users_related_test.go
@@ -8,7 +8,82 @@ import (
 )
 
 func TestV1UsersRelated(t *testing.T) {
-	app := testAppWithFixtures(t)
+	app := emptyTestApp(t)
+	fixtures := FixtureMap{
+		"aggregate_user": []map[string]any{
+			{
+				"user_id":          1,
+				"follower_count":   98,
+				"following_count":  25,
+				"dominant_genre":   "Electronic",
+				"track_save_count": 20,
+			},
+			{
+				"user_id":          2,
+				"follower_count":   50,
+				"following_count":  15,
+				"dominant_genre":   "Electronic",
+				"track_save_count": 0,
+			},
+			{
+				"user_id":          3,
+				"follower_count":   20,
+				"following_count":  10,
+				"dominant_genre":   "Electronic",
+				"track_save_count": 0,
+			},
+		},
+		"tracks": []map[string]any{
+			{
+				"track_id":        100,
+				"genre":           "Electronic",
+				"owner_id":        1,
+				"title":           "T1",
+				"is_unlisted":     false,
+				"is_downloadable": true,
+			},
+		},
+		"users": []map[string]any{
+			{
+				"user_id":          1,
+				"handle":           "rayjacobson",
+				"handle_lc":        "rayjacobson",
+				"name":             "Ray Jacobson",
+				"is_deactivated":   false,
+				"wallet":           "0x7d273271690538cf855e5b3002a0dd8c154bb060",
+				"playlist_library": []byte(`{"contents":[{"type":"playlist","playlist_id":"123"},{"type":"explore_playlist","playlist_id":"Audio NFTs"},{"type":"folder","id":"bbcae31a-7cd2-4a1a-8b54-fdc979a34435","name":"My Nested Playlists","contents":[{"type":"playlist","playlist_id":"345"}]}]}`),
+			},
+			{
+				"user_id":        2,
+				"handle":         "stereosteve",
+				"handle_lc":      "stereosteve",
+				"is_deactivated": false,
+				"wallet":         "0x1234567890abcdef",
+			},
+			{
+				"user_id":        3,
+				"handle":         "someseller",
+				"handle_lc":      "someseller",
+				"is_deactivated": false,
+				"wallet":         "0xc3d1d41e6872ffbd15c473d14fc3a9250be5b5e0",
+			},
+		},
+		"follows": []map[string]any{
+			{
+				"follower_user_id": 1,
+				"followee_user_id": 2,
+			},
+			{
+				"follower_user_id": 2,
+				"followee_user_id": 1,
+			},
+			{
+				"follower_user_id": 4,
+				"followee_user_id": 3,
+			},
+		},
+	}
+	createFixtures(app, fixtures)
 
 	var userResponse struct {
 		Data []dbv1.FullUser


### PR DESCRIPTION
Stoked about this query. Results are quite good!

Boils down to just trying to get as fast an implementation of collaborative filtering as I could get

do nothing for artists < 100 followers. use existing genre based query

for artist > 100 followers

- get a sample of followers. as ids are random, this is a reasonable sample
- for each follower, get the top 200 artists they follow
- score candidates based on how many of our sample follow them (jaccard-style) with some genre boost
- return the top n