### PR TITLE
[API-235] Improve library/playlists performance

### DIFF
--- a/api/testdata/save_fixtures.go
+++ b/api/testdata/save_fixtures.go
@@ -9,7 +9,7 @@ var SaveFixtures = []map[string]any{
 	{
 		"user_id":      1,
 		"save_item_id": 2,
-		"save_type":    "album",
+		"save_type":    "playlist",
 	},
 	{
 		"user_id":      1,
@@ -20,5 +20,5 @@ var SaveFixtures = []map[string]any{
 
 // user_id,save_item_id,save_item_type
 // 1,1,'playlist'
-// 1,2,'album'
+// 1,2,'playlist'
 // 1,100,'track'

--- a/api/v1_users_library_playlists_test.go
+++ b/api/v1_users_library_playlists_test.go
@@ -1,0 +1,75 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUsersLibraryPlaylists(t *testing.T) {
+	app := testAppWithFixtures(t)
+	var response struct {
+		Data []struct {
+			Class     string `json:"class"`
+			ItemType  string `json:"item_type"`
+			ItemID    int32  `json:"item_id"`
+			Timestamp string `json:"timestamp"`
+			Item      any    `json:"item"`
+		} `json:"data"`
+	}
+
+	status, body := testGet(t, app, "/v1/full/users/7eP5n/library/playlists", &response)
+	assert.Equal(t, 200, status)
+	assert.Len(t, response.Data, 1)
+
+	jsonAssert(t, body, map[string]any{
+		"data.0.class":              "collection_activity_full_without_tracks",
+		"data.0.item_type":          "playlist",
+		"data.0.item_id":            1,
+		"data.0.item.playlist_name": "First",
+	})
+
+	status, body = testGet(t, app, "/v1/full/users/7eP5n/library/playlists?type=favorite", &response)
+	assert.Equal(t, 200, status)
+	assert.Len(t, response.Data, 1)
+
+	jsonAssert(t, body, map[string]any{
+		"data.0.class":              "collection_activity_full_without_tracks",
+		"data.0.item_type":          "playlist",
+		"data.0.item_id":            1,
+		"data.0.item.playlist_name": "First",
+	})
+}
+
+func TestUsersLibraryAlbums(t *testing.T) {
+	app := testAppWithFixtures(t)
+	var response struct {
+		Data []struct {
+			Class     string `json:"class"`
+			ItemType  string `json:"item_type"`
+			ItemID    int32  `json:"item_id"`
+			Timestamp string `json:"timestamp"`
+			Item      any    `json:"item"`
+		} `json:"data"`
+	}
+
+	// Test albums endpoint
+	// User 1 owns album 3 ("SecondAlbum") and saves album 2 ("Follow Gated Stream")
+	status, body := testGet(t, app, "/v1/full/users/7eP5n/library/albums", &response)
+	assert.Equal(t, 200, status)
+	assert.Len(t, response.Data, 2)
+
+	jsonAssert(t, body, map[string]any{
+		"data.0.class":              "collection_activity_full_without_tracks",
+		"data.0.item_type":          "playlist",
+		"data.0.item_id":            3,
+		"data.0.item.playlist_name": "SecondAlbum",
+	})
+
+	jsonAssert(t, body, map[string]any{
+		"data.1.class":              "collection_activity_full_without_tracks",
+		"data.1.item_type":          "playlist",
+		"data.1.item_id":            2,
+		"data.1.item.playlist_name": "Follow Gated Stream",
+	})
+}


### PR DESCRIPTION
Improve library playlists/albums performance
1. Filter on save_type = playlist instead of != track. albums fall under save_type = playlist anyway (checked prod db). This makes use of the index and takes the first query from ~1.5s to 2-300ms.
2. Conditionally join on users
3. Omit tracks in the fullplaylistskeyed query rather than post-facto

Tested:
- Add new test (no coverage before)
- Prod request with replaced URL