### PR TITLE
[API-168] Expose history endpoint in non-full api

### DIFF
--- a/api/swagger/swagger-v1.yaml
+++ b/api/swagger/swagger-v1.yaml
@@ -2126,6 +2126,87 @@ paths:
         "500":
           description: Server error
           content: {}
+  /users/{id}/history/tracks:
+    get:
+      tags:
+      - users
+      description: Get the tracks the user recently listened to.
+      operationId: Get User's Track History
+      parameters:
+      - name: id
+        in: path
+        description: A User ID
+        required: true
+        schema:
+          type: string
+      - name: offset
+        in: query
+        description: The number of items to skip. Useful for pagination (page number
+          * limit)
+        schema:
+          type: integer
+      - name: limit
+        in: query
+        description: The number of items to fetch
+        schema:
+          type: integer
+      - name: query
+        in: query
+        description: The filter query
+        schema:
+          type: string
+      - name: sort_method
+        in: query
+        description: The sort method
+        schema:
+          type: string
+          enum:
+          - title
+          - artist_name
+          - release_date
+          - last_listen_date
+          - added_date
+          - plays
+          - reposts
+          - saves
+          - most_listens_by_user
+      - name: sort_direction
+        in: query
+        description: The sort direction
+        schema:
+          type: string
+          enum:
+          - asc
+          - desc
+      - name: Encoded-Data-Message
+        in: header
+        description: The data that was signed by the user for signature recovery
+        schema:
+          type: string
+      - name: Encoded-Data-Signature
+        in: header
+        description: "The signature of data, used for signature recovery"
+        schema:
+          type: string
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/history_response'
+        "400":
+          description: Bad request
+          content: {}
+        "401":
+          description: Unauthorized
+          content: {}
+        "403":
+          description: Forbidden
+          content: {}
+        "500":
+          description: Server error
+          content: {}
   /users/{id}/listen_counts_monthly:
     get:
       tags:
@@ -3511,6 +3592,13 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/user'
+    history_response:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/track_activity'
     subscribers_response:
       type: object
       properties:


### PR DESCRIPTION
We already have this endpoint, we just don't have it exposed properly in swagger.
Although we _could_ say this shouldn't be a non-full endpoint if we think that it should only be callable in its full form.