### PR TITLE
[API-171] Add feeling lucky endpoint

### DIFF
--- a/api/server.go
+++ b/api/server.go
@@ -332,7 +332,7 @@ func NewApiServer(config config.Config) *ApiServer {
 		g.Get("/tracks/recent-premium", app.v1TracksRecentPremium)
 		g.Get("/tracks/usdc-purchase", app.v1TracksUsdcPurchase)
 		g.Get("/tracks/inspect", app.v1TracksInspect)
-		g.Get("/tracks/feeling_lucky", app.v1TracksFeelingLucky)
+		g.Get("/tracks/feeling-lucky", app.v1TracksFeelingLucky)
 
 		g.Use("/tracks/:trackId", app.requireTrackIdMiddleware)
 		g.Get("/tracks/:trackId", app.v1Track)

--- a/api/swagger/swagger-v1-full.yaml
+++ b/api/swagger/swagger-v1-full.yaml
@@ -1233,7 +1233,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/full_tracks_response'
-  /tracks/feeling_lucky:
+  /tracks/feeling-lucky:
     get:
       tags:
       - tracks
@@ -1266,7 +1266,6 @@ paths:
         schema:
           type: integer
           minimum: 1
-          maximum: 100000
       responses:
         "200":
           description: Success

--- a/api/swagger/swagger-v1.yaml
+++ b/api/swagger/swagger-v1.yaml
@@ -873,7 +873,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/tracks_response'
-  /tracks/feeling_lucky:
+  /tracks/feeling-lucky:
     get:
       tags:
       - tracks
@@ -899,7 +899,6 @@ paths:
         schema:
           type: integer
           minimum: 1
-          maximum: 100000
       responses:
         "200":
           description: Success

--- a/api/v1_tracks_feeling_lucky.go
+++ b/api/v1_tracks_feeling_lucky.go
@@ -10,7 +10,7 @@ import (
 
 type GetFeelingLuckyParams struct {
 	Limit        int `query:"limit" default:"10" validate:"min=1,max=100"`
-	MinFollowers int `query:"min_followers" validate:"omitempty,min=1,max=100000"`
+	MinFollowers int `query:"min_followers" validate:"omitempty,min=1"`
 }
 
 func (app *ApiServer) v1TracksFeelingLucky(c *fiber.Ctx) error {

--- a/api/v1_tracks_feeling_lucky_test.go
+++ b/api/v1_tracks_feeling_lucky_test.go
@@ -79,7 +79,7 @@ func TestV1TracksFeelingLucky(t *testing.T) {
 			Data []dbv1.FullTrack
 		}
 
-		status, body := testGet(t, app, "/v1/tracks/feeling_lucky", &resp)
+		status, body := testGet(t, app, "/v1/tracks/feeling-lucky", &resp)
 		assert.Equal(t, 200, status)
 
 		jsonAssert(t, body, map[string]any{
@@ -92,7 +92,7 @@ func TestV1TracksFeelingLucky(t *testing.T) {
 	}
 
 	{
-		status, body := testGet(t, app, "/v1/tracks/feeling_lucky?min_followers=1")
+		status, body := testGet(t, app, "/v1/tracks/feeling-lucky?min_followers=1")
 		assert.Equal(t, 200, status)
 
 		// Should only be track 3 due to follower requirement


### PR DESCRIPTION
`/v1/tracks/feeling_lucky`

The original implementation in discovery just used a min_followers filter that defaulted to 100. For the new Search/Explore page, we're changing this to be an always-on filter that requires 250+ streams on a track to help filter down the result set before we select a random number of them. Local testing against prod db has this pretty reliably under 500ms. There might be some optimizations that could bring this down another 100ms or so, but it feels totally usable for now.

I chose to _not_ use the min_followers filter by default, as it actually makes the query slower. But to preserve compatibility with the existing endpoint, I implemented it as an optional query param that will add in a JOIN and additional filter condition if you specify it.



