### PR TITLE
fix db teardown

### DIFF
--- a/api/server_test.go
+++ b/api/server_test.go
@@ -68,7 +68,7 @@ func emptyTestApp(t *testing.T) *ApiServer {
 	t.Cleanup(func() {
 		app.pool.Close()
 		testMutex.Lock()
-		_, err := testPoolForCreatingChildDatabases.Exec(ctx, "DROP DATABASE IF EXISTS test")
+		_, err := testPoolForCreatingChildDatabases.Exec(ctx, "DROP DATABASE IF EXISTS "+dbName)
 		testMutex.Unlock()
 		require.NoError(t, err)
 	})


### PR DESCRIPTION
Wasn't actually dropping test db.

This will fix:
```
No space left on device (SQLSTATE 53100)
```