### PR TITLE
Add a should for query without spaces

### DIFF
--- a/api/searchv1/playlist_search.go
+++ b/api/searchv1/playlist_search.go
@@ -2,6 +2,7 @@ package searchv1
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/aquasecurity/esquery"
 )
@@ -28,6 +29,20 @@ func (q *PlaylistSearchQuery) Map() map[string]any {
 			MinimumShouldMatch("80%").
 			Fuzziness("AUTO").
 			Type(esquery.MatchTypeBoolPrefix))
+
+		// for exact title / handle / artist name match
+		builder.Should(
+			esquery.MultiMatch().Query(q.Query).Fields("title^10", "user.name", "user.handle").
+				Operator(esquery.OperatorAnd).
+				Type(esquery.MatchTypePhrasePrefix),
+		)
+
+		// exact match, but remove spaces from query
+		builder.Should(
+			esquery.MultiMatch().Query(strings.ReplaceAll(q.Query, " ", "")).Fields("title^10", "user.name", "user.handle").
+				Operator(esquery.OperatorAnd).
+				Type(esquery.MatchTypePhrasePrefix),
+		)
 	} else {
 		builder.Must(esquery.MatchAll())
 	}

--- a/api/searchv1/track_search.go
+++ b/api/searchv1/track_search.go
@@ -2,6 +2,7 @@ package searchv1
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/aquasecurity/esquery"
 )
@@ -37,7 +38,15 @@ func (q *TrackSearchQuery) Map() map[string]any {
 
 		// for exact title / handle / artist name match
 		builder.Should(
-			esquery.MultiMatch().Query(q.Query).Fields("title", "user.name", "user.handle").
+			esquery.MultiMatch().Query(q.Query).Fields("title^10", "user.name", "user.handle").
+				Operator(esquery.OperatorAnd).
+				Type(esquery.MatchTypePhrasePrefix),
+		)
+
+		// exact match, but remove spaces from query
+		// so 'Pure Component' ranks 'PureComponent' higher
+		builder.Should(
+			esquery.MultiMatch().Query(strings.ReplaceAll(q.Query, " ", "")).Fields("title^10", "user.name", "user.handle").
 				Operator(esquery.OperatorAnd).
 				Type(esquery.MatchTypePhrasePrefix),
 		)

--- a/api/searchv1/user_search.go
+++ b/api/searchv1/user_search.go
@@ -2,6 +2,7 @@ package searchv1
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/aquasecurity/esquery"
 )
@@ -30,6 +31,14 @@ func (q *UserSearchQuery) Map() map[string]any {
 		builder.Should(
 			esquery.MultiMatch().Query(q.Query).
 				Fields("name", "handle").
+				Operator(esquery.OperatorAnd).
+				Type(esquery.MatchTypePhrasePrefix),
+		)
+
+		// exact match, but remove spaces from query
+		// so 'Stereo Steve' ranks 'StereoSteve' higher
+		builder.Should(
+			esquery.MultiMatch().Query(strings.ReplaceAll(q.Query, " ", "")).Fields("name", "handle").
 				Operator(esquery.OperatorAnd).
 				Type(esquery.MatchTypePhrasePrefix),
 		)

--- a/api/v1_search_test.go
+++ b/api/v1_search_test.go
@@ -16,7 +16,7 @@ func TestSearch(t *testing.T) {
 			{
 				"user_id": 1001,
 				"handle":  "StereoSteve",
-				"name":    "Stereo Steve",
+				"name":    "StereoSteve",
 			},
 			{
 				"user_id": 1002,
@@ -285,6 +285,7 @@ func TestSearch(t *testing.T) {
 		status, body := testGet(t, app, "/v1/search/autocomplete?query=stereo+steve")
 		require.Equal(t, 200, status)
 		jsonAssert(t, body, map[string]any{
+			"data.users.0.handle": "StereoSteve",
 			"data.tracks.#":       1,
 			"data.tracks.0.title": "sunny side",
 		})


### PR DESCRIPTION
We did something similar in python to handle spurious spaces in the user entered query.

This ensures searching `Pure Component` matches track `PureComponent`... which is important.