### PR TITLE
Support has_downloads query param, fix stem indexing.

### DIFF
--- a/api/searchv1/track_search.go
+++ b/api/searchv1/track_search.go
@@ -14,6 +14,7 @@ type TrackSearchQuery struct {
 	IsDownloadable bool
 	IsPurchaseable bool
 	IsTagSearch    bool
+	HasDownloads   bool
 	OnlyVerified   bool
 	Genres         []string
 	Moods          []string
@@ -81,8 +82,12 @@ func (q *TrackSearchQuery) Map() map[string]any {
 		builder.Filter(esquery.Term("is_downloadable", true))
 	}
 
-	// todo: only_with_downloads
-	// => downloadable + has stems
+	if q.HasDownloads {
+		builder.Filter(esquery.Bool().Should(
+			esquery.Term("is_downloadable", true),
+			esquery.Term("has_stems", true),
+		))
+	}
 
 	if q.IsPurchaseable {
 		// stream or download

--- a/api/v1_search.go
+++ b/api/v1_search.go
@@ -144,6 +144,7 @@ func (app *ApiServer) searchTracks(c *fiber.Ctx) ([]dbv1.FullTrack, error) {
 		MaxBPM:         maxBpm,
 		MusicalKeys:    queryMutli(c, "key"),
 		IsDownloadable: c.QueryBool("is_downloadable"),
+		HasDownloads:   c.QueryBool("has_downloads"),
 		IsPurchaseable: c.QueryBool("is_purchaseable"),
 		OnlyVerified:   c.QueryBool("only_verified"),
 	}

--- a/api/v1_search_test.go
+++ b/api/v1_search_test.go
@@ -87,6 +87,23 @@ func TestSearch(t *testing.T) {
 				"owner_id": 1003,
 				"title":    "circular thoughts",
 			},
+			{
+				"track_id": 1008,
+				"owner_id": 1004,
+				"title":    "RemixComp",
+			},
+			{
+				"track_id": 1009,
+				"owner_id": 1004,
+				"title":    "RemixComp VocalStem",
+				"stem_of":  []byte(`{"category": "LEAD_VOCALS", "parent_track_id": 1221925895}`),
+			},
+		},
+		"stems": {
+			{
+				"parent_track_id": 1008,
+				"child_track_id":  1009,
+			},
 		},
 		"playlists": {
 			{
@@ -226,6 +243,31 @@ func TestSearch(t *testing.T) {
 	// tracks: filter by genre + mood + bpm
 	{
 		status, body := testGet(t, app, "/v1/search/autocomplete?genre=Trap")
+		require.Equal(t, 200, status)
+		jsonAssert(t, body, map[string]any{
+			"data.tracks.#": 2,
+		})
+	}
+
+	// track with stems
+	{
+		status, body := testGet(t, app, "/v1/search/autocomplete?query=RemixComp")
+		require.Equal(t, 200, status)
+		jsonAssert(t, body, map[string]any{
+			"data.tracks.#": 1,
+		})
+	}
+
+	{
+		status, body := testGet(t, app, "/v1/search/autocomplete?query=RemixComp&has_downloads=true")
+		require.Equal(t, 200, status)
+		jsonAssert(t, body, map[string]any{
+			"data.tracks.#": 1,
+		})
+	}
+
+	{
+		status, body := testGet(t, app, "/v1/search/autocomplete?has_downloads=true")
 		require.Equal(t, 200, status)
 		jsonAssert(t, body, map[string]any{
 			"data.tracks.#": 2,

--- a/esindexer/tracks_index.go
+++ b/esindexer/tracks_index.go
@@ -50,5 +50,6 @@ var tracksConfig = collectionConfig{
 	AND tracks.is_available = true
 	AND users.is_available = true
 	AND users.is_deactivated = false
+	AND stem_of is null
 	`,
 }


### PR DESCRIPTION
* `has_downloads=true` returns tracks that are downloadable or have stems.
* don't index tracks with `stem_of`
