### PR TITLE
Add new Solana indexing tables

### DIFF
--- a/ddl/migrations/0147_add_new_solana_indexing_tables.sql
+++ b/ddl/migrations/0147_add_new_solana_indexing_tables.sql
@@ -43,6 +43,7 @@ CREATE TABLE IF NOT EXISTS sol_token_account_balance_changes (
     slot BIGINT NOT NULL,
     updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
     created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    block_timestamp TIMESTAMP NOT NULL,
 
     PRIMARY KEY (signature, mint, account)
 );


### PR DESCRIPTION
Creates the following tables with mint agnosticism for Artist Coins:
- `sol_slot_checkpoint`
- `artist_coins`
- `sol_token_account_balance_changes`
- `sol_claimable_accounts`
  - For any CreateTokenAccount from claimable tokens program
- `sol_claimable_account_transfers`
  - For any Transfer from claimable tokens program
- `sol_reward_disbursements`
  - For any EvaluateAttestations by reward manager program
- `sol_payments`
  - For each individual payment route of a payment router program Route
- `sol_purchases`
  - For each purchase via payment router program Route
- `sol_swaps`
  - For each Jupiter Swap
- `sol_token_transfers`
  - For each SPL Token transfer