### PR TITLE
[QA-2222] Fix bpm and verified search

### DIFF
--- a/api/searchv1/track_search.go
+++ b/api/searchv1/track_search.go
@@ -9,8 +9,8 @@ import (
 
 type TrackSearchQuery struct {
 	Query          string
-	MinBPM         int
-	MaxBPM         int
+	MinBPM         float64
+	MaxBPM         float64
 	IsDownloadable bool
 	IsPurchaseable bool
 	IsTagSearch    bool

--- a/api/v1_search.go
+++ b/api/v1_search.go
@@ -125,15 +125,15 @@ func (app *ApiServer) searchTracks(c *fiber.Ctx) ([]dbv1.FullTrack, error) {
 	myId := app.getMyId(c)
 
 	// bpm range
-	minBpm := c.QueryInt("bpm_min")
-	maxBpm := c.QueryInt("bpm_max")
+	minBpm := c.QueryFloat("bpm_min")
+	maxBpm := c.QueryFloat("bpm_max")
 	if bpmRange := c.Query("bpm"); bpmRange != "" {
 		parts := strings.Split(bpmRange, "-")
 		if len(parts) == 2 {
-			if min, err := strconv.Atoi(strings.TrimSpace(parts[0])); err == nil {
+			if min, err := strconv.ParseFloat(strings.TrimSpace(parts[0]), 64); err == nil {
 				minBpm = min
 			}
-			if max, err := strconv.Atoi(strings.TrimSpace(parts[1])); err == nil {
+			if max, err := strconv.ParseFloat(strings.TrimSpace(parts[1]), 64); err == nil {
 				maxBpm = max
 			}
 		}
@@ -151,7 +151,7 @@ func (app *ApiServer) searchTracks(c *fiber.Ctx) ([]dbv1.FullTrack, error) {
 		IsDownloadable: c.QueryBool("is_downloadable"),
 		HasDownloads:   c.QueryBool("has_downloads"),
 		IsPurchaseable: c.QueryBool("is_purchaseable"),
-		OnlyVerified:   c.QueryBool("only_verified"),
+		OnlyVerified:   c.QueryBool("is_verified"),
 		SortMethod:     c.Query("sort_method"),
 	}
 
@@ -191,7 +191,7 @@ func (app *ApiServer) searchPlaylists(c *fiber.Ctx) ([]dbv1.FullPlaylist, error)
 		Query:        c.Query("query"),
 		Genres:       queryMutli(c, "genre"),
 		Moods:        queryMutli(c, "mood"),
-		OnlyVerified: c.QueryBool("only_verified"),
+		OnlyVerified: c.QueryBool("is_verified"),
 		SortMethod:   c.Query("sort_method"),
 	}
 
@@ -232,7 +232,7 @@ func (app *ApiServer) searchAlbums(c *fiber.Ctx) ([]dbv1.FullPlaylist, error) {
 		Query:        c.Query("query"),
 		Genres:       queryMutli(c, "genre"),
 		Moods:        queryMutli(c, "mood"),
-		OnlyVerified: c.QueryBool("only_verified"),
+		OnlyVerified: c.QueryBool("is_verified"),
 		SortMethod:   c.Query("sort_method"),
 		IsAlbum:      true,
 	}

--- a/api/v1_search_test.go
+++ b/api/v1_search_test.go
@@ -270,7 +270,7 @@ func TestSearch(t *testing.T) {
 
 	// tracks: only verified
 	{
-		status, body := testGet(t, app, "/v1/search/autocomplete?only_verified=true")
+		status, body := testGet(t, app, "/v1/search/autocomplete?is_verified=true")
 		require.Equal(t, 200, status)
 		jsonAssert(t, body, map[string]any{
 			"data.tracks.0.title": "circular thoughts",
@@ -421,7 +421,7 @@ func TestSearch(t *testing.T) {
 	}
 
 	{
-		status, body := testGet(t, app, "/v1/search/autocomplete?only_verified=true")
+		status, body := testGet(t, app, "/v1/search/autocomplete?is_verified=true")
 		require.Equal(t, 200, status)
 		jsonAssert(t, body, map[string]any{
 			"data.playlists.0.playlist_name": "Hot and New",


### PR DESCRIPTION
* BPM should be float (b/c client uses float for queries, especially for exact matches we do +/- 1bpm, e.g. exact=140 is min=139.5,max=140.5)
* is_verified not only_verified

Was this even tested???