### PR TITLE
Add audience to chat_message response

### DIFF
--- a/api/comms_chats_messages.go
+++ b/api/comms_chats_messages.go
@@ -26,6 +26,7 @@ func (app *ApiServer) getChatMessages(c *fiber.Ctx) error {
 		chat_message.chat_id,
 		chat_message.user_id,
 		chat_message.created_at,
+		audience,
 		COALESCE(chat_message.ciphertext, chat_blast.plaintext) AS ciphertext,
 		chat_blast.plaintext IS NOT NULL as is_plaintext,
 		to_json(array(SELECT row_to_json(r) FROM chat_message_reactions r WHERE chat_message.message_id = r.message_id)) AS reactions

--- a/api/dbv1/chat_messages_row.go
+++ b/api/dbv1/chat_messages_row.go
@@ -13,6 +13,7 @@ type ChatMessageAndReactionsRow struct {
 	ChatID      string                   `db:"chat_id" json:"-"`
 	UserID      trashid.HashId           `db:"user_id" json:"sender_user_id"`
 	CreatedAt   time.Time                `db:"created_at" json:"created_at"`
+	Audience    string                   `db:"audience" json:"audience"`
 	Ciphertext  string                   `db:"ciphertext" json:"message"`
 	IsPlaintext bool                     `db:"is_plaintext" json:"is_plaintext"`
 	Reactions   []ChatMessageReactionRow `json:"reactions"`


### PR DESCRIPTION
Add `audience` field to `chat_message` response so we can determine when to show the custom "token holders" UI.

Not tested, will test on stage.