### PR TITLE
Boost user exact match

### DIFF
--- a/api/searchv1/user_search.go
+++ b/api/searchv1/user_search.go
@@ -23,7 +23,7 @@ func (q *UserSearchQuery) Map() map[string]any {
 		builder.Must(esquery.MultiMatch().Query(q.Query).Fields("tracks.tags").Type(esquery.MatchTypeBoolPrefix))
 	} else if q.Query != "" {
 		builder.Must(esquery.MultiMatch(q.Query).
-			Fields("suggest").
+			Fields("suggest", "name", "handle").
 			MinimumShouldMatch("80%").
 			Fuzziness("AUTO").
 			Type(esquery.MatchTypeBoolPrefix))
@@ -32,13 +32,16 @@ func (q *UserSearchQuery) Map() map[string]any {
 		builder.Should(
 			esquery.MultiMatch().Query(q.Query).
 				Fields("name", "handle").
+				Boost(10).
 				Operator(esquery.OperatorAnd),
 		)
 
 		// exact match, but remove spaces from query
 		// so 'Stereo Steve' ranks 'StereoSteve' higher
 		builder.Should(
-			esquery.MultiMatch().Query(strings.ReplaceAll(q.Query, " ", "")).Fields("name", "handle").
+			esquery.MultiMatch().Query(strings.ReplaceAll(q.Query, " ", "")).
+				Fields("name", "handle").
+				Boost(10).
 				Operator(esquery.OperatorAnd),
 		)
 	} else {

--- a/api/server_test.go
+++ b/api/server_test.go
@@ -31,7 +31,7 @@ func emptyTestApp(t *testing.T) *ApiServer {
 	app := NewApiServer(config.Config{
 		Env:                "test",
 		ReadDbUrl:          pool.Config().ConnString(),
-		EsUrl:              "http://localhost:21400",
+		EsUrl:              "http://localhost:21401",
 		DelegatePrivateKey: "0633fddb74e32b3cbc64382e405146319c11a1a52dc96598e557c5dbe2f31468",
 		SolanaConfig:       config.SolanaConfig{RpcProviders: []string{""}},
 	})

--- a/compose.yml
+++ b/compose.yml
@@ -46,3 +46,20 @@ services:
         hard: -1
     ports:
       - 21400:9200
+
+  elasticsearch-test:
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.10.2
+    environment:
+      - network.host=0.0.0.0
+      - discovery.type=single-node
+      - cluster.name=docker-cluster
+      - node.name=cluster1-node1
+      - xpack.license.self_generated.type=basic
+      - xpack.security.enabled=false
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+    ports:
+      - 21401:9200


### PR DESCRIPTION
* Add more boost to user `should` query to rank exact match higher
* Add second ES instance for testing, so you can keep a prod ES index around and still run `make test`