### PR TITLE
Artist Coins: Add v1/users/:userId/coins

### DIFF
--- a/api/server.go
+++ b/api/server.go
@@ -368,6 +368,7 @@ func NewApiServer(config config.Config) *ApiServer {
 		g.Get("/users/:userId/remixers", app.v1UsersRemixers)
 		g.Get("/users/:userId/recommended-tracks", app.v1UsersRecommendedTracks)
 		g.Get("/users/:userId/now-playing", app.v1UsersNowPlaying)
+		g.Get("/users/:userId/coins", app.v1UsersCoins)
 
 		// Tracks
 		g.Get("/tracks", app.v1Tracks)
@@ -535,6 +536,7 @@ func NewApiServer(config config.Config) *ApiServer {
 
 type BirdeyeClient interface {
 	GetTokenOverview(ctx context.Context, mint string, frames string) (*birdeye.TokenOverview, error)
+	GetPrices(ctx context.Context, mints []string) (*birdeye.TokenPriceMap, error)
 }
 
 type ApiServer struct {

--- a/api/v1_coin_test.go
+++ b/api/v1_coin_test.go
@@ -30,6 +30,25 @@ func (m *MockBirdeyeClient) GetTokenOverview(ctx context.Context, mint string, f
 	return nil, fmt.Errorf("token not found")
 }
 
+func (m *MockBirdeyeClient) GetPrices(ctx context.Context, mints []string) (*birdeye.TokenPriceMap, error) {
+	prices := make(birdeye.TokenPriceMap)
+	for _, mint := range mints {
+		switch mint {
+		case "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v":
+			prices[mint] = birdeye.TokenPriceData{
+				Value: 1.0,
+			}
+		case "9LzCMqDgTKYz9Drzqnpgee3SGa89up3a247ypMj2xrqM":
+			prices[mint] = birdeye.TokenPriceData{
+				Value: 10.0,
+			}
+		default:
+			return nil, fmt.Errorf("price not found for mint %s", mint)
+		}
+	}
+	return &prices, nil
+}
+
 func TestGetCoin(t *testing.T) {
 	app := emptyTestApp(t)
 

--- a/api/v1_users_coins.go
+++ b/api/v1_users_coins.go
@@ -1,0 +1,133 @@
+package api
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/jackc/pgx/v5"
+)
+
+type GetUsersCoinsQueryParams struct {
+	Limit  int `query:"limit" default:"50" validate:"min=1,max=100"`
+	Offset int `query:"offset" default:"0" validate:"min=0"`
+}
+
+type UserCoin struct {
+	Ticker     string  `json:"ticker"`
+	Mint       string  `json:"mint"`
+	Balance    float64 `json:"balance"`
+	BalanceUSD float64 `json:"balance_usd"`
+}
+
+func (app *ApiServer) v1UsersCoins(c *fiber.Ctx) error {
+	queryParams := GetUsersCoinsQueryParams{}
+	if err := app.ParseAndValidateQueryParams(c, &queryParams); err != nil {
+		return err
+	}
+
+	mintSql := `
+		SELECT mint
+		FROM artist_coins;
+	`
+	var mints []string
+	rows, err := app.pool.Query(c.Context(), mintSql)
+	if err != nil {
+		return fmt.Errorf("failed to query mints: %w", err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var mint string
+		if err := rows.Scan(&mint); err != nil {
+			return fmt.Errorf("failed to scan mint: %w", err)
+		}
+		mints = append(mints, mint)
+	}
+
+	prices, err := app.birdeyeClient.GetPrices(c.Context(), mints)
+	if err != nil || prices == nil {
+		return fmt.Errorf("failed to get prices: %w", err)
+	}
+
+	pricesRows := make([]string, 0, len(*prices))
+	for mint, price := range *prices {
+		pricesRows = append(pricesRows, fmt.Sprintf("('%s', %f)", mint, price.Value))
+	}
+
+	sql := `
+		WITH prices (mint, price) AS (
+			VALUES ` + strings.Join(pricesRows, ",\n\t\t\t") + `
+		), balances AS (
+			SELECT
+				user_bank_balances.mint,
+				user_bank_balances.balance AS balance,
+				user_bank_balances.account AS account,
+				user_bank_balances.owner AS owner,
+				TRUE as is_in_app_wallet
+			FROM users
+			JOIN sol_claimable_accounts 
+				ON sol_claimable_accounts.ethereum_address = users.wallet
+			JOIN sol_token_account_balances AS user_bank_balances 
+				ON user_bank_balances.account = sol_claimable_accounts.account
+			WHERE users.user_id = @user_id
+			UNION ALL 
+			SELECT
+				associated_wallet_balances.mint,
+				associated_wallet_balances.balance AS balance,
+				associated_wallet_balances.account AS account,
+				associated_wallet_balances.owner AS owner,
+				FALSE as is_in_app_wallet
+			FROM users
+			JOIN associated_wallets 
+				ON associated_wallets.user_id = users.user_id
+			JOIN sol_token_account_balances AS associated_wallet_balances 
+				ON associated_wallet_balances.owner = associated_wallets.wallet 
+				AND associated_wallets.chain = 'sol'
+			WHERE associated_wallets.user_id = @user_id
+		), balances_by_mint AS (
+			SELECT
+				balances.mint,
+				SUM(balances.balance) AS balance
+			FROM balances
+			GROUP BY balances.mint
+		),
+		balances_with_prices AS (
+			SELECT 
+				artist_coins.ticker,
+				balances_by_mint.mint,
+				balances_by_mint.balance AS balance,
+				(balances_by_mint.balance * prices.price) / POWER(10, artist_coins.decimals) AS balance_usd
+			FROM balances_by_mint
+			JOIN prices ON balances_by_mint.mint = prices.mint
+			JOIN artist_coins ON artist_coins.mint = balances_by_mint.mint
+		)
+		SELECT
+			balances_with_prices.ticker,
+			balances_with_prices.mint,
+			balances_with_prices.balance,
+			balances_with_prices.balance_usd
+		FROM balances_with_prices
+		ORDER BY balances_with_prices.balance_usd DESC, balances_with_prices.mint ASC
+		LIMIT @limit
+		OFFSET @offset
+	;`
+
+	rows, err = app.pool.Query(c.Context(), sql, pgx.NamedArgs{
+		"user_id": app.getUserId(c),
+		"limit":   queryParams.Limit,
+		"offset":  queryParams.Offset,
+	})
+	if err != nil {
+		return err
+	}
+
+	userCoins, err := pgx.CollectRows(rows, pgx.RowToStructByName[UserCoin])
+	if err != nil {
+		return err
+	}
+
+	return c.JSON(fiber.Map{
+		"data": userCoins,
+	})
+}

--- a/api/v1_users_coins_test.go
+++ b/api/v1_users_coins_test.go
@@ -1,0 +1,132 @@
+package api
+
+import (
+	"testing"
+	"time"
+
+	"bridgerton.audius.co/database"
+	"bridgerton.audius.co/trashid"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUserCoins(t *testing.T) {
+	app := emptyTestApp(t)
+
+	fixtures := database.FixtureMap{
+		"artist_coins": {
+			{
+				"ticker":     "$AUDIO",
+				"decimals":   8,
+				"user_id":    1,
+				"mint":       "9LzCMqDgTKYz9Drzqnpgee3SGa89up3a247ypMj2xrqM",
+				"created_at": time.Now().Add(-time.Second),
+			},
+			{
+				"ticker":     "$USDC",
+				"decimals":   6,
+				"user_id":    2,
+				"mint":       "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+				"created_at": time.Now(),
+			},
+		},
+		"users": {
+			{
+				"user_id": 1,
+				"wallet":  "0x1234567890123456789012345678901234567890",
+			},
+			{
+				"user_id": 2,
+				"wallet":  "0x098765432109876543210987654321",
+			},
+		},
+		"associated_wallets": {
+			// holds 10 AUDIO
+			{
+				"id":      1,
+				"user_id": 1,
+				"wallet":  "owner_wallet",
+				"chain":   "sol",
+			},
+			// holds 10 USDC
+			{
+				"id":      2,
+				"user_id": 1,
+				"wallet":  "owner_wallet2",
+				"chain":   "sol",
+			},
+			// holds 5 AUDIO
+			{
+				"id":      3,
+				"user_id": 1,
+				"wallet":  "owner_wallet3",
+				"chain":   "sol",
+			},
+			// ignored (user 2)
+			{
+				"id":      4,
+				"user_id": 2,
+				"wallet":  "ignored_owner",
+				"chain":   "sol",
+			},
+		},
+		"sol_claimable_accounts": {
+			// holds 3 AUDIO
+			{
+				"signature":        "claimable_signature_1",
+				"account":          "claimable",
+				"ethereum_address": "0x1234567890123456789012345678901234567890",
+				"mint":             "9LzCMqDgTKYz9Drzqnpgee3SGa89up3a247ypMj2xrqM",
+			},
+		},
+		"sol_token_account_balances": {
+			{
+				"mint":    "9LzCMqDgTKYz9Drzqnpgee3SGa89up3a247ypMj2xrqM",
+				"account": "associated",
+				"owner":   "owner_wallet",
+				"balance": 1000000000, // 10 AUDIO
+			},
+			{
+				"mint":    "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+				"account": "associated2",
+				"owner":   "owner_wallet2",
+				"balance": 7000000, // 7 USDC
+			},
+			{
+				"mint":    "9LzCMqDgTKYz9Drzqnpgee3SGa89up3a247ypMj2xrqM",
+				"account": "associated3",
+				"owner":   "owner_wallet3",
+				"balance": 500000000, // 5 AUDIO
+			},
+			{
+				"mint":    "9LzCMqDgTKYz9Drzqnpgee3SGa89up3a247ypMj2xrqM",
+				"account": "claimable",
+				"owner":   "claimable_tokens_pda",
+				"balance": 300000000, // 3 AUDIO
+			},
+			{
+				"mint":    "9LzCMqDgTKYz9Drzqnpgee3SGa89up3a247ypMj2xrqM",
+				"account": "ignored",
+				"owner":   "ignored_owner",
+				"balance": 500000000,
+			},
+		},
+	}
+
+	database.Seed(app.pool, fixtures)
+	app.birdeyeClient = &MockBirdeyeClient{}
+
+	status, body := testGet(t, app, "/v1/users/"+trashid.MustEncodeHashID(1)+"/coins")
+	assert.Equal(t, 200, status)
+
+	jsonAssert(t, body, map[string]any{
+		"data.#":             2,
+		"data.0.ticker":      "$AUDIO",
+		"data.0.mint":        "9LzCMqDgTKYz9Drzqnpgee3SGa89up3a247ypMj2xrqM",
+		"data.0.balance":     1800000000, // 18 AUDIO
+		"data.0.balance_usd": 180.0,      // Assuming $10 per AUDIO
+		"data.1.ticker":      "$USDC",
+		"data.1.mint":        "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+		"data.1.balance":     7000000, // 7 USDC
+		"data.1.balance_usd": 7.0,
+	})
+}


### PR DESCRIPTION
- Adds `GetPrices` to `birdeye.Client`
  - Calling `GetTokenOverview` for every mint would be less scalable, slower, and use more credits, and this gives us more flexibility on cache timings too.
- Adds `v1UsersCoins`