### PR TITLE
[API-273] Add git sha to / route on bridge api

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,6 +40,8 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=registry,ref=audius/api:buildcache
           cache-to: type=registry,ref=audius/api:buildcache,mode=max
+          build-args: |
+            GIT_SHA=${{ github.sha }}
 
       - name: Get short SHA for release
         if: github.ref == 'refs/heads/main'

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,4 +21,7 @@ COPY --from=builder /app/ddl ./ddl
 
 EXPOSE 1323
 
+ARG GIT_SHA
+ENV GIT_SHA=$GIT_SHA
+
 CMD ["bridge"] 

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+export GIT_SHA := $(shell git rev-parse HEAD)
 
 dev::
 	wgo -file sqlc.yaml -file .sql -xfile .go sqlc generate :: wgo run -file .go -file .yaml -debounce 10ms main.go

--- a/api/server.go
+++ b/api/server.go
@@ -567,6 +567,7 @@ type ApiServer struct {
 func (app *ApiServer) home(c *fiber.Ctx) error {
 	return c.JSON(fiber.Map{
 		"env":     config.Cfg.Env,
+		"git":     config.Cfg.Git,
 		"started": app.started,
 		"uptime":  time.Since(app.started).Truncate(time.Second).String(),
 	})

--- a/config/config.go
+++ b/config/config.go
@@ -11,6 +11,7 @@ import (
 
 type Config struct {
 	Env                string
+	Git                string
 	LogLevel           string
 	ReadDbUrl          string
 	WriteDbUrl         string
@@ -32,6 +33,7 @@ type Config struct {
 }
 
 var Cfg = Config{
+	Git:                os.Getenv("GIT_SHA"),
 	Env:                os.Getenv("ENV"),
 	LogLevel:           os.Getenv("logLevel"),
 	ReadDbUrl:          os.Getenv("readDbUrl"),


### PR DESCRIPTION
Tested:
```
❯ export GIT_SHA=$(git rev-parse HEAD)

❯ docker build --build-arg "GIT_SHA=$GIT_SHA" -t rj-api-273 .   

❯ docker run -p 1323:1323 --env-file .env rj-api-273

❯ curl localhost:1323/ | jq
{
  "env": "production",
  "git": "183c72f86486f55341a94b431b29b43e7339dd41",
  "started": "2025-07-17T00:03:51.299406709Z",
  "uptime": "15s"
}

```

Also, for local dev

```
❯  make

❯ curl localhost:1323/ | jq
{
  "env": "production",
  "git": "09eb629a3add692bfe6720983675fa2b1342dd34",
  "started": "2025-07-16T17:05:40.695216-07:00",
  "uptime": "2s"
}

```