### PR TITLE
Add index on chainid, height

### DIFF
--- a/ddl/migrations/0151_block_height_idx.sql
+++ b/ddl/migrations/0151_block_height_idx.sql
@@ -1,0 +1,8 @@
+begin;
+
+-- Not used
+DROP INDEX IF EXISTS idx_core_blocks_chain_id;
+
+CREATE INDEX IF NOT EXISTS idx_core_blocks_chain_id_height ON core_blocks (chain_id, height);
+
+end;


### PR DESCRIPTION
Queries got mega-slow while the notifications queries were getting hammered on friday. 

This should help a lot because we do a filter on chain_id and then a sweep on height < X. Existing indexes would be fine if we changed the query to = instead of < in the block confirmation route https://github.com/AudiusProject/api/blob/d1fa6dc4be290b6327b4de1ef6fa636b0bd9c34a/api/block_confirmation.go#L26, but supporting that query is also fine