### PR TITLE
Update v1UsersCoin to list individual accounts

### DIFF
--- a/api/v1_users_coin.go
+++ b/api/v1_users_coin.go
@@ -15,7 +15,7 @@ type AccountBalance struct {
 	IsInAppWallet bool    `json:"is_in_app_wallet"`
 }
 
-type UserCoinWallets struct {
+type UserCoinAccounts struct {
 	UserCoin
 	Accounts []AccountBalance `json:"accounts"`
 }
@@ -108,7 +108,7 @@ func (app *ApiServer) v1UsersCoin(c *fiber.Ctx) error {
 		return err
 	}
 
-	userCoin, err := pgx.CollectExactlyOneRow(rows, pgx.RowToStructByName[UserCoinWallets])
+	userCoin, err := pgx.CollectExactlyOneRow(rows, pgx.RowToStructByName[UserCoinAccounts])
 	if err != nil {
 		return err
 	}

--- a/api/v1_users_coin_test.go
+++ b/api/v1_users_coin_test.go
@@ -121,10 +121,26 @@ func TestUserCoin(t *testing.T) {
 		assert.Equal(t, 200, status)
 
 		jsonAssert(t, body, map[string]any{
-			"data.ticker":      "$AUDIO",
-			"data.mint":        "9LzCMqDgTKYz9Drzqnpgee3SGa89up3a247ypMj2xrqM",
-			"data.balance":     1800000000, // 18 AUDIO
-			"data.balance_usd": 180.0,      // Assuming $10 per AUDIO
+			"data.ticker":                      "$AUDIO",
+			"data.mint":                        "9LzCMqDgTKYz9Drzqnpgee3SGa89up3a247ypMj2xrqM",
+			"data.balance":                     1800000000, // 18 AUDIO
+			"data.balance_usd":                 180.0,      // Assuming $10 per AUDIO
+			"data.accounts.#":                  3,
+			"data.accounts.0.account":          "associated",
+			"data.accounts.0.owner":            "owner_wallet",
+			"data.accounts.0.balance":          1000000000, // 10
+			"data.accounts.0.balance_usd":      100.0,      // 10 AUDIO at $10 each
+			"data.accounts.0.is_in_app_wallet": false,
+			"data.accounts.1.account":          "associated3",
+			"data.accounts.1.owner":            "owner_wallet3",
+			"data.accounts.1.balance":          500000000, // 5 AUDIO
+			"data.accounts.1.balance_usd":      50.0,      //
+			"data.accounts.1.is_in_app_wallet": false,
+			"data.accounts.2.account":          "claimable",
+			"data.accounts.2.owner":            "claimable_tokens_pda",
+			"data.accounts.2.balance":          300000000, // 3 AUDIO
+			"data.accounts.2.balance_usd":      30.0,      //
+			"data.accounts.2.is_in_app_wallet": true,
 		})
 	}
 	// USDC
@@ -133,10 +149,16 @@ func TestUserCoin(t *testing.T) {
 		assert.Equal(t, 200, status)
 
 		jsonAssert(t, body, map[string]any{
-			"data.ticker":      "$USDC",
-			"data.mint":        "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
-			"data.balance":     7000000, // 7 USDC
-			"data.balance_usd": 7.0,
+			"data.ticker":                      "$USDC",
+			"data.mint":                        "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+			"data.balance":                     7000000, // 7 USDC
+			"data.balance_usd":                 7.0,
+			"data.accounts.#":                  1,
+			"data.accounts.0.account":          "associated2",
+			"data.accounts.0.owner":            "owner_wallet2",
+			"data.accounts.0.balance":          7000000,
+			"data.accounts.0.balance_usd":      7.0,
+			"data.accounts.0.is_in_app_wallet": false,
 		})
 	}
 }


### PR DESCRIPTION
Updates `v1/users/:userId/coins/:mint` to list each individual account and account balance, per the original spec.