### PR TITLE
Ignore stdout sync errors in containers, and filter to configured level for axiom

### DIFF
--- a/logging/logger.go
+++ b/logging/logger.go
@@ -54,8 +54,12 @@ func NewZapLogger(config config.Config) *zap.Logger {
 				axiom.SetOrganizationID("audius-Lu52"),
 			),
 			adapter.SetDataset(config.AxiomDataset),
+			adapter.SetLevelEnabler(
+				zap.LevelEnablerFunc(func(lvl zapcore.Level) bool {
+					return lvl >= level
+				}),
+			),
 		)
-		axiomAdapter.Enabled(zap.InfoLevel)
 		if err != nil {
 			panic(err)
 		}

--- a/logging/logger.go
+++ b/logging/logger.go
@@ -55,6 +55,7 @@ func NewZapLogger(config config.Config) *zap.Logger {
 			),
 			adapter.SetDataset(config.AxiomDataset),
 		)
+		axiomAdapter.Enabled(zap.InfoLevel)
 		if err != nil {
 			panic(err)
 		}
@@ -76,7 +77,13 @@ func SyncOnTicks(ctx context.Context, logger *zap.Logger, tickDuration time.Dura
 			return ctx.Err()
 		case <-ticker.C:
 			if err := logger.Sync(); err != nil {
-				logger.Error("failed to sync logger on tick", zap.Error(err))
+				// This specific error occurs when running in a container
+				// where /dev/stdout is not a valid file descriptor.
+				// We can ignore it since it doesn't affect logging to Axiom.
+				// See: https://github.com/uber-go/zap/issues/328#issuecomment-284337436
+				if err != os.ErrInvalid {
+					logger.Error("failed to sync logger on tick", zap.Error(err))
+				}
 			}
 		}
 	}


### PR DESCRIPTION
See also: https://github.com/uber-go/zap/issues/328
