### PR TITLE
Make 24h members calculation faster

### DIFF
--- a/api/birdeye/client.go
+++ b/api/birdeye/client.go
@@ -20,7 +20,7 @@ type Client struct {
 
 func New(token string) *Client {
 	tokenOverviewCache, err := otter.MustBuilder[string, *TokenOverview](100).
-		WithTTL(10 * time.Second).
+		WithTTL(60 * time.Second).
 		CollectStats().
 		Build()
 	if err != nil {
@@ -28,7 +28,7 @@ func New(token string) *Client {
 	}
 
 	pricesCache, err := otter.MustBuilder[string, *TokenPriceData](100).
-		WithTTL(10 * time.Second).
+		WithTTL(60 * time.Second).
 		CollectStats().
 		Build()
 	if err != nil {

--- a/api/v1_coin.go
+++ b/api/v1_coin.go
@@ -13,24 +13,14 @@ func (app *ApiServer) v1Coin(c *fiber.Ctx) error {
 		})
 	}
 
-	/*
-	 * The bulk of this query is calculating the member changes for the last
-	 * 24 hours. It calculates how many balances went from 0 to >0 (new members)
-	 * and how many went from >0 to 0 (members lost) for both userbank and associated wallets.
-	 * It then combines these counts to get the net member changes.
-	 * Finally, it calculates the total number of members and the percentage change
-	 * in members over the last 24 hours (net changes / (current members + net changes)).
-	 */
+	// See v1_coins for the query explanation.
 	sql := `
-		WITH member_changes_userbank AS (
+		WITH t_user_balance_changes AS (
 			SELECT
 				sol_token_account_balance_changes.mint,
-				(
-					COUNT(DISTINCT users.user_id) 
-						FILTER (WHERE balance > 0 AND change = balance)
-				 	- COUNT(DISTINCT users.user_id) 
-						FILTER (WHERE balance = 0 AND change < 0)
-				) AS net_new_members
+				users.user_id,
+				change,
+				0 AS balance
 			FROM sol_token_account_balance_changes
 			JOIN sol_claimable_accounts
 				ON sol_claimable_accounts.account = sol_token_account_balance_changes.account
@@ -38,69 +28,89 @@ func (app *ApiServer) v1Coin(c *fiber.Ctx) error {
 				ON users.wallet = sol_claimable_accounts.ethereum_address
 			WHERE block_timestamp > NOW() - INTERVAL '24 hours'
 				AND sol_token_account_balance_changes.mint = @mint
-			GROUP BY sol_token_account_balance_changes.mint
-		), member_changes_associated_wallets AS (
+			UNION ALL
 			SELECT
 				sol_token_account_balance_changes.mint,
-				(
-					COUNT(DISTINCT associated_wallets.user_id) 
-						FILTER (WHERE balance > 0 AND change = balance)
-				 	- COUNT(DISTINCT associated_wallets.user_id) 
-						FILTER (WHERE balance = 0 AND change < 0)
-				) AS net_new_members
+				associated_wallets.user_id,
+				change,
+				0 AS balance
 			FROM sol_token_account_balance_changes
 			JOIN associated_wallets
 				ON associated_wallets.wallet = sol_token_account_balance_changes.owner
-				AND associated_wallets.chain = 'sol'
+				AND associated_wallets.chain = 'sol'	
 			WHERE block_timestamp > NOW() - INTERVAL '24 hours'
 				AND sol_token_account_balance_changes.mint = @mint
-			GROUP BY sol_token_account_balance_changes.mint	
-		), net_member_changes AS (
+		), t_user_balances AS (
 			SELECT
-				member_changes.mint,
-				COALESCE(SUM(member_changes.net_new_members), 0) AS change
-			FROM (
-				SELECT * FROM member_changes_userbank
-				UNION ALL SELECT * FROM member_changes_associated_wallets
-			) member_changes
-			GROUP BY member_changes.mint
-		), member_counts AS (
+				sol_token_account_balances.mint,
+				associated_wallets.user_id,
+				0 AS change,
+				sol_token_account_balances.balance
+			FROM sol_token_account_balances
+			JOIN associated_wallets 
+				ON associated_wallets.wallet = sol_token_account_balances.owner
+				AND associated_wallets.chain = 'sol'
+			WHERE sol_token_account_balances.mint = @mint
+			UNION ALL
 			SELECT
-				member_balances.mint,
-				COUNT(DISTINCT member_balances.user_id) AS members
+				sol_token_account_balances.mint,
+				users.user_id,
+				0 AS change,
+				sol_token_account_balances.balance
+			FROM sol_token_account_balances
+			JOIN sol_claimable_accounts
+				ON sol_claimable_accounts.account = sol_token_account_balances.account
+			JOIN users 
+				ON users.wallet = sol_claimable_accounts.ethereum_address
+			WHERE sol_token_account_balances.mint = @mint
+		), total_user_balance_changes AS (
+			SELECT
+				t.mint,
+				t.user_id,
+				SUM(t.change) AS change,
+				SUM(t.balance) AS balance
 			FROM (
-				SELECT sol_token_account_balances.mint,
-					COALESCE(associated_wallets.user_id, users.user_id) AS user_id
-				FROM sol_token_account_balances
-				LEFT JOIN associated_wallets 
-					ON associated_wallets.wallet = sol_token_account_balances.owner
-				LEFT JOIN sol_claimable_accounts 
-					ON sol_claimable_accounts.account = sol_token_account_balances.account
-				LEFT JOIN users 
-					ON users.wallet = sol_claimable_accounts.ethereum_address
-				WHERE sol_token_account_balances.balance > 0
-					AND (associated_wallets.wallet IS NOT NULL 
-							OR sol_claimable_accounts.account IS NOT NULL)
-					AND sol_token_account_balances.mint = @mint
-			) AS member_balances
-			GROUP BY member_balances.mint
+				SELECT * FROM t_user_balance_changes 
+				UNION ALL 
+				SELECT * FROM t_user_balances
+			) t
+			GROUP BY
+				t.mint,
+				t.user_id
+		), member_changes AS (
+			SELECT
+				mint,
+				(
+					COUNT(DISTINCT user_id) FILTER (WHERE change = balance AND balance > 0) -
+					COUNT(DISTINCT user_id) FILTER (WHERE change < 0 AND balance = 0)
+				) AS net
+			FROM total_user_balance_changes
+			GROUP BY 
+				mint
+		), members AS (
+			SELECT
+				mint,
+				COUNT(DISTINCT user_id) AS count
+			FROM t_user_balances
+			WHERE balance > 0
+			GROUP BY mint
 		)
 		SELECT 
 			artist_coins.ticker,
 			artist_coins.mint,
 			artist_coins.user_id,
 			artist_coins.created_at,
-			COALESCE(member_counts.members, 0) AS members,
+			COALESCE(members.count, 0) AS members,
 			COALESCE(
-				(net_member_changes.change * 100.0) / 
+				(member_changes.net * 100.0) / 
 				NULLIF(
-					COALESCE(member_counts.members, 0) - 
-					COALESCE(net_member_changes.change, 0)
+					COALESCE(members.count, 0) - 
+					COALESCE(member_changes.net, 0)
 				, 0)
 			, 0) AS members_24h_change_percent
 		FROM artist_coins
-		LEFT JOIN member_counts ON artist_coins.mint = member_counts.mint
-		LEFT JOIN net_member_changes ON artist_coins.mint = net_member_changes.mint
+		LEFT JOIN members ON artist_coins.mint = members.mint
+		LEFT JOIN member_changes ON artist_coins.mint = member_changes.mint
 		WHERE artist_coins.mint = @mint
 		LIMIT 1
 	`

--- a/api/v1_coin.go
+++ b/api/v1_coin.go
@@ -22,13 +22,16 @@ func (app *ApiServer) v1Coin(c *fiber.Ctx) error {
 	 * in members over the last 24 hours (net changes / (current members + net changes)).
 	 */
 	sql := `
+
 		WITH member_changes_userbank AS (
 			SELECT
 				sol_token_account_balance_changes.mint,
-				COUNT(DISTINCT users.user_id) 
-					FILTER (WHERE balance > 0 AND change = balance) AS new_members,
-				COUNT(DISTINCT users.user_id) 
-					FILTER (WHERE balance = 0 AND change < 0) AS members_lost
+				(
+					COUNT(DISTINCT users.user_id) 
+						FILTER (WHERE balance > 0 AND change = balance)
+				 	- COUNT(DISTINCT users.user_id) 
+						FILTER (WHERE balance = 0 AND change < 0)
+				) AS net_new_members
 			FROM sol_token_account_balance_changes
 			JOIN sol_claimable_accounts
 				ON sol_claimable_accounts.account = sol_token_account_balance_changes.account
@@ -40,10 +43,12 @@ func (app *ApiServer) v1Coin(c *fiber.Ctx) error {
 		), member_changes_associated_wallets AS (
 			SELECT
 				sol_token_account_balance_changes.mint,
-				COUNT(DISTINCT associated_wallets.user_id) 
-					FILTER (WHERE balance > 0 AND change = balance) AS new_members,
-				COUNT(DISTINCT associated_wallets.user_id) 
-					FILTER (WHERE balance = 0 AND change < 0) AS members_lost
+				(
+					COUNT(DISTINCT associated_wallets.user_id) 
+						FILTER (WHERE balance > 0 AND change = balance)
+				 	- COUNT(DISTINCT associated_wallets.user_id) 
+						FILTER (WHERE balance = 0 AND change < 0)
+				) AS net_new_members
 			FROM sol_token_account_balance_changes
 			JOIN associated_wallets
 				ON associated_wallets.wallet = sol_token_account_balance_changes.owner
@@ -55,11 +60,8 @@ func (app *ApiServer) v1Coin(c *fiber.Ctx) error {
 			GROUP BY sol_token_account_balance_changes.mint	
 		), net_member_changes AS (
 			SELECT
-				(
-					COALESCE(SUM(member_changes.new_members), 0) - 
-					COALESCE(SUM(member_changes.members_lost), 0)		
-				) AS members,
-				member_changes.mint
+				member_changes.mint,
+				COALESCE(SUM(member_changes.net_new_members), 0) AS change
 			FROM (
 				SELECT * FROM member_changes_userbank
 				UNION ALL SELECT * FROM member_changes_associated_wallets
@@ -93,8 +95,8 @@ func (app *ApiServer) v1Coin(c *fiber.Ctx) error {
 			artist_coins.created_at,
 			COALESCE(member_counts.members, 0) AS members,
 			COALESCE(
-				(net_member_changes.members * 100.0) / 
-				NULLIF(member_counts.members - net_member_changes.members, 0)
+				(net_member_changes.change * 100.0) / 
+				NULLIF(member_counts.members - net_member_changes.change, 0)
 			, 0) AS members_24h_change_percent
 		FROM artist_coins
 		LEFT JOIN member_counts ON artist_coins.mint = member_counts.mint

--- a/api/v1_coin.go
+++ b/api/v1_coin.go
@@ -13,38 +13,58 @@ func (app *ApiServer) v1Coin(c *fiber.Ctx) error {
 		})
 	}
 
+	/*
+	 * The bulk of this query is calculating the member changes for the last
+	 * 24 hours. It calculates how many balances went from 0 to >0 (new members)
+	 * and how many went from >0 to 0 (members lost) for both userbank and associated wallets.
+	 * It then combines these counts to get the net member changes.
+	 * Finally, it calculates the total number of members and the percentage change
+	 * in members over the last 24 hours (net changes / (current members + net changes)).
+	 */
 	sql := `
-		WITH member_counts_24h_ago AS (
-			SELECT 
-				COUNT(DISTINCT balances_24h_ago.user_id) AS members,
-				balances_24h_ago.mint
+		WITH member_changes_userbank AS (
+			SELECT
+				sol_token_account_balance_changes.mint,
+				COUNT(DISTINCT users.user_id) 
+					FILTER (WHERE balance > 0 AND change = balance) AS new_members,
+				COUNT(DISTINCT users.user_id) 
+					FILTER (WHERE balance = 0 AND change < 0) AS members_lost
+			FROM sol_token_account_balance_changes
+			JOIN sol_claimable_accounts
+				ON sol_claimable_accounts.account = sol_token_account_balance_changes.account
+			JOIN users
+				ON users.wallet = sol_claimable_accounts.ethereum_address
+			WHERE block_timestamp > NOW() - INTERVAL '24 hours'
+				AND sol_token_account_balance_changes.mint = @mint
+			GROUP BY sol_token_account_balance_changes.mint
+		), member_changes_associated_wallets AS (
+			SELECT
+				sol_token_account_balance_changes.mint,
+				COUNT(DISTINCT associated_wallets.user_id) 
+					FILTER (WHERE balance > 0 AND change = balance) AS new_members,
+				COUNT(DISTINCT associated_wallets.user_id) 
+					FILTER (WHERE balance = 0 AND change < 0) AS members_lost
+			FROM sol_token_account_balance_changes
+			JOIN associated_wallets
+				ON associated_wallets.wallet = sol_token_account_balance_changes.owner
+				AND associated_wallets.chain = 'sol'
+			JOIN blocks
+				ON associated_wallets.blockhash = blocks.blockhash
+			WHERE block_timestamp > NOW() - INTERVAL '24 hours'
+				AND sol_token_account_balance_changes.mint = @mint
+			GROUP BY sol_token_account_balance_changes.mint	
+		), net_member_changes AS (
+			SELECT
+				(
+					COALESCE(SUM(member_changes.new_members), 0) - 
+					COALESCE(SUM(member_changes.members_lost), 0)		
+				) AS members,
+				member_changes.mint
 			FROM (
-				SELECT DISTINCT ON (
-						sol_token_account_balance_changes.mint, 
-						sol_token_account_balance_changes.account,
-						users.user_id, associated_wallets.user_id
-					)
-					sol_token_account_balance_changes.mint,
-					sol_token_account_balance_changes.account,
-					sol_token_account_balance_changes.balance,
-					COALESCE(associated_wallets.user_id, users.user_id) AS user_id
-				FROM sol_token_account_balance_changes
-				LEFT JOIN associated_wallets
-					ON associated_wallets.wallet = sol_token_account_balance_changes.owner
-				LEFT JOIN sol_claimable_accounts 
-					ON sol_claimable_accounts.account = sol_token_account_balance_changes.account
-				LEFT JOIN users ON users.wallet = sol_claimable_accounts.ethereum_address
-				WHERE block_timestamp < NOW() - INTERVAL '24 hours'
-					AND (associated_wallets.user_id IS NOT NULL OR users.user_id IS NOT NULL)
-					AND sol_token_account_balance_changes.mint = @mint
-				ORDER BY
-					sol_token_account_balance_changes.mint, 
-					sol_token_account_balance_changes.account,
-					users.user_id, associated_wallets.user_id, 
-					block_timestamp DESC
-			) AS balances_24h_ago
-			WHERE balance > 0
-			GROUP BY balances_24h_ago.mint
+				SELECT * FROM member_changes_userbank
+				UNION ALL SELECT * FROM member_changes_associated_wallets
+			) member_changes
+			GROUP BY member_changes.mint
 		), member_counts AS (
 			SELECT
 				member_balances.mint,
@@ -73,12 +93,12 @@ func (app *ApiServer) v1Coin(c *fiber.Ctx) error {
 			artist_coins.created_at,
 			COALESCE(member_counts.members, 0) AS members,
 			COALESCE(
-				(COALESCE(member_counts.members, 0) - member_counts_24h_ago.members) * 100.0 /
-				 NULLIF(member_counts_24h_ago.members, 0)
+				(net_member_changes.members * 100.0) / 
+				NULLIF(member_counts.members - net_member_changes.members, 0)
 			, 0) AS members_24h_change_percent
 		FROM artist_coins
 		LEFT JOIN member_counts ON artist_coins.mint = member_counts.mint
-		LEFT JOIN member_counts_24h_ago ON artist_coins.mint = member_counts_24h_ago.mint
+		LEFT JOIN net_member_changes ON artist_coins.mint = net_member_changes.mint
 		WHERE artist_coins.mint = @mint
 		LIMIT 1
 	`

--- a/api/v1_coin_test.go
+++ b/api/v1_coin_test.go
@@ -53,7 +53,6 @@ func TestGetCoin(t *testing.T) {
 	app := emptyTestApp(t)
 
 	fixtures := database.FixtureMap{
-
 		"artist_coins": {
 			{
 				"ticker":     "$AUDIO",
@@ -72,31 +71,22 @@ func TestGetCoin(t *testing.T) {
 		},
 		"users": {
 			{
-				"user_id": 3,
+				"user_id": 1,
 				"wallet":  "0x1234567890123456789012345678901234567890",
 			},
 		},
 		"associated_wallets": {
-			// holds 10 AUDIO
-			{
-				"id":      1,
-				"user_id": 1,
-				"wallet":  "owner_wallet",
-				"chain":   "sol",
-			},
-			// holds 0 USDC
 			{
 				"id":      2,
 				"user_id": 2,
-				"wallet":  "owner_wallet2",
 				"chain":   "sol",
+				"wallet":  "user_2_owner_1",
 			},
-			// holds 10 AUDIO, should be deduped as user 1
 			{
 				"id":      3,
-				"user_id": 1,
-				"wallet":  "owner_wallet3",
+				"user_id": 3,
 				"chain":   "sol",
+				"wallet":  "user_3_owner_1",
 			},
 		},
 		"sol_claimable_accounts": {
@@ -108,56 +98,119 @@ func TestGetCoin(t *testing.T) {
 			},
 		},
 		"sol_token_account_balance_changes": {
-			// claimable tokens wallet that received tokens yesterday
+			// user_1: new $AUDIO member
+			// $AUDIO claimable tokens account
+			// received, sent it all, received more
 			{
-				"signature":       "change1",
+				"slot":            1,
+				"signature":       "user_1_sig_1",
 				"mint":            "9LzCMqDgTKYz9Drzqnpgee3SGa89up3a247ypMj2xrqM",
 				"account":         "claimable",
 				"owner":           "claimable_pda",
 				"change":          1000000000,
 				"balance":         1000000000,
-				"block_timestamp": time.Now().Add(-time.Hour * 25),
+				"block_timestamp": time.Now().Add(-time.Hour * 3),
 			},
-			// wallet that was not empty yesterday, but empty today
+			{
+				"slot":            2,
+				"signature":       "user_1_sig_2",
+				"mint":            "9LzCMqDgTKYz9Drzqnpgee3SGa89up3a247ypMj2xrqM",
+				"account":         "claimable",
+				"owner":           "claimable_pda",
+				"change":          -1000000000,
+				"balance":         0,
+				"block_timestamp": time.Now().Add(-time.Hour * 2),
+			},
+			{
+				"slot":            3,
+				"signature":       "user_1_sig_3",
+				"mint":            "9LzCMqDgTKYz9Drzqnpgee3SGa89up3a247ypMj2xrqM",
+				"account":         "claimable",
+				"owner":           "claimable_pda",
+				"change":          100000000,
+				"balance":         100000000,
+				"block_timestamp": time.Now().Add(-time.Hour * 1),
+			},
+			// user_2: existing $AUDIO member
+			// $AUDIO associated wallet 1
 			{
 				"slot":            1,
-				"signature":       "change2",
-				"mint":            "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
-				"account":         "associated2",
-				"owner":           "owner_wallet2",
+				"signature":       "user_2_sig_1",
+				"mint":            "9LzCMqDgTKYz9Drzqnpgee3SGa89up3a247ypMj2xrqM",
+				"account":         "user_2_account_1",
+				"owner":           "user_2_owner_1",
+				"change":          1000000000,
+				"balance":         1000000000,
+				"block_timestamp": time.Now().Add(-time.Hour * 25),
+			},
+			// $AUDIO associated wallet 2
+			// sent it all today, but still a member because other account
+			{
+				"slot":            1,
+				"signature":       "user_2_sig_2",
+				"mint":            "9LzCMqDgTKYz9Drzqnpgee3SGa89up3a247ypMj2xrqM",
+				"account":         "user_2_account_2",
+				"owner":           "user_2_owner_1",
 				"change":          1000000000,
 				"balance":         1000000000,
 				"block_timestamp": time.Now().Add(-time.Hour * 25),
 			},
 			{
 				"slot":            2,
-				"signature":       "change3",
-				"mint":            "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
-				"account":         "associated2",
-				"owner":           "owner_wallet2",
+				"signature":       "user_2_sig_3",
+				"mint":            "9LzCMqDgTKYz9Drzqnpgee3SGa89up3a247ypMj2xrqM",
+				"account":         "user_2_account_2",
+				"owner":           "user_2_owner_1",
 				"change":          -1000000000,
 				"balance":         0,
-				"block_timestamp": time.Now().Add(-time.Hour * 1),
+				"block_timestamp": time.Now().Add(-time.Hour * 2),
 			},
-			// wallet that was added today
+			// user_3: existing $AUDIO member, former $USDC member
+			// $AUDIO associated wallet 1
+			// existing account
 			{
-				"signature":       "change4",
+				"slot":            1,
+				"signature":       "user_3_sig_1",
 				"mint":            "9LzCMqDgTKYz9Drzqnpgee3SGa89up3a247ypMj2xrqM",
-				"account":         "associated",
-				"owner":           "owner_wallet",
+				"account":         "user_3_account_1",
+				"owner":           "user_3_owner_1",
 				"change":          1000000000,
 				"balance":         1000000000,
-				"block_timestamp": time.Now().Add(-time.Hour * 1),
+				"block_timestamp": time.Now().Add(-time.Hour * 25),
 			},
-			// wallet added today that should be deduped as user 1 above
+			// $AUDIO associated wallet 2
+			// new account, but already a member
 			{
-				"signature":       "change5",
+				"slot":            2,
+				"signature":       "user_3_sig_2",
 				"mint":            "9LzCMqDgTKYz9Drzqnpgee3SGa89up3a247ypMj2xrqM",
-				"account":         "associated3",
-				"owner":           "owner_wallet3",
+				"account":         "user_3_account_2",
+				"owner":           "user_3_owner_1",
 				"change":          1000000000,
 				"balance":         1000000000,
-				"block_timestamp": time.Now().Add(-time.Hour * 1),
+				"block_timestamp": time.Now().Add(-time.Hour * 2),
+			},
+			// $USDC associated wallet
+			// sent it all today, no longer a member
+			{
+				"slot":            1,
+				"signature":       "user_3_sig_3",
+				"mint":            "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+				"account":         "user_3_account_3",
+				"owner":           "user_3_owner_1",
+				"change":          1000000000,
+				"balance":         1000000000,
+				"block_timestamp": time.Now().Add(-time.Hour * 25),
+			},
+			{
+				"slot":            2,
+				"signature":       "user_3_sig_4",
+				"mint":            "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+				"account":         "user_3_account_3",
+				"owner":           "user_3_owner_1",
+				"change":          -1000000000,
+				"balance":         0,
+				"block_timestamp": time.Now().Add(-time.Hour * 3),
 			},
 		},
 	}
@@ -189,8 +242,8 @@ func TestGetCoin(t *testing.T) {
 			"data.ticker":                     "$AUDIO",
 			"data.owner_id":                   trashid.MustEncodeHashID(1),
 			"data.mint":                       "9LzCMqDgTKYz9Drzqnpgee3SGa89up3a247ypMj2xrqM",
-			"data.members":                    2,
-			"data.members_24h_change_percent": 100.0,
+			"data.members":                    3,
+			"data.members_24h_change_percent": 50.0,
 		})
 	}
 }

--- a/api/v1_coin_test.go
+++ b/api/v1_coin_test.go
@@ -12,9 +12,9 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-type MockBirdeyeClient struct{}
+type mockBirdeyeClient struct{}
 
-func (m *MockBirdeyeClient) GetTokenOverview(ctx context.Context, mint string, frames string) (*birdeye.TokenOverview, error) {
+func (m *mockBirdeyeClient) GetTokenOverview(ctx context.Context, mint string, frames string) (*birdeye.TokenOverview, error) {
 	switch mint {
 	case "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v":
 		return &birdeye.TokenOverview{
@@ -30,7 +30,7 @@ func (m *MockBirdeyeClient) GetTokenOverview(ctx context.Context, mint string, f
 	return nil, fmt.Errorf("token not found")
 }
 
-func (m *MockBirdeyeClient) GetPrices(ctx context.Context, mints []string) (*birdeye.TokenPriceMap, error) {
+func (m *mockBirdeyeClient) GetPrices(ctx context.Context, mints []string) (*birdeye.TokenPriceMap, error) {
 	prices := make(birdeye.TokenPriceMap)
 	for _, mint := range mints {
 		switch mint {
@@ -53,6 +53,7 @@ func TestGetCoin(t *testing.T) {
 	app := emptyTestApp(t)
 
 	fixtures := database.FixtureMap{
+
 		"artist_coins": {
 			{
 				"ticker":     "$AUDIO",
@@ -106,26 +107,6 @@ func TestGetCoin(t *testing.T) {
 				"mint":             "9LzCMqDgTKYz9Drzqnpgee3SGa89up3a247ypMj2xrqM",
 			},
 		},
-		"sol_token_account_balances": {
-			{
-				"mint":    "9LzCMqDgTKYz9Drzqnpgee3SGa89up3a247ypMj2xrqM",
-				"account": "associated",
-				"owner":   "owner_wallet",
-				"balance": 1000000000,
-			},
-			{
-				"mint":    "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
-				"account": "associated2",
-				"owner":   "owner_wallet2",
-				"balance": 0, // should be ignored as a member
-			},
-			{
-				"mint":    "9LzCMqDgTKYz9Drzqnpgee3SGa89up3a247ypMj2xrqM",
-				"account": "associated3",
-				"owner":   "owner_wallet3", // should be deduped as user 1
-				"balance": 1000000000,
-			},
-		},
 		"sol_token_account_balance_changes": {
 			// claimable tokens wallet that received tokens yesterday
 			{
@@ -139,6 +120,7 @@ func TestGetCoin(t *testing.T) {
 			},
 			// wallet that was not empty yesterday, but empty today
 			{
+				"slot":            1,
 				"signature":       "change2",
 				"mint":            "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
 				"account":         "associated2",
@@ -147,12 +129,42 @@ func TestGetCoin(t *testing.T) {
 				"balance":         1000000000,
 				"block_timestamp": time.Now().Add(-time.Hour * 25),
 			},
+			{
+				"slot":            2,
+				"signature":       "change3",
+				"mint":            "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+				"account":         "associated2",
+				"owner":           "owner_wallet2",
+				"change":          -1000000000,
+				"balance":         0,
+				"block_timestamp": time.Now().Add(-time.Hour * 1),
+			},
+			// wallet that was added today
+			{
+				"signature":       "change4",
+				"mint":            "9LzCMqDgTKYz9Drzqnpgee3SGa89up3a247ypMj2xrqM",
+				"account":         "associated",
+				"owner":           "owner_wallet",
+				"change":          1000000000,
+				"balance":         1000000000,
+				"block_timestamp": time.Now().Add(-time.Hour * 1),
+			},
+			// wallet added today that should be deduped as user 1 above
+			{
+				"signature":       "change5",
+				"mint":            "9LzCMqDgTKYz9Drzqnpgee3SGa89up3a247ypMj2xrqM",
+				"account":         "associated3",
+				"owner":           "owner_wallet3",
+				"change":          1000000000,
+				"balance":         1000000000,
+				"block_timestamp": time.Now().Add(-time.Hour * 1),
+			},
 		},
 	}
 
 	database.Seed(app.pool, fixtures)
 
-	app.birdeyeClient = &MockBirdeyeClient{}
+	app.birdeyeClient = &mockBirdeyeClient{}
 
 	// negative change
 	{

--- a/api/v1_coins.go
+++ b/api/v1_coins.go
@@ -86,8 +86,6 @@ func (app *ApiServer) v1Coins(c *fiber.Ctx) error {
 			JOIN associated_wallets
 				ON associated_wallets.wallet = sol_token_account_balance_changes.owner
 				AND associated_wallets.chain = 'sol'
-			JOIN blocks
-				ON associated_wallets.blockhash = blocks.blockhash
 			WHERE block_timestamp > NOW() - INTERVAL '24 hours'
 			GROUP BY sol_token_account_balance_changes.mint	
 		), net_member_changes AS (
@@ -127,7 +125,10 @@ func (app *ApiServer) v1Coins(c *fiber.Ctx) error {
 			COALESCE(member_counts.members, 0) AS members,
 			COALESCE(
 				(net_member_changes.change * 100.0) / 
-				NULLIF(member_counts.members - net_member_changes.change, 0)
+				NULLIF(
+					COALESCE(member_counts.members, 0) - 
+					COALESCE(net_member_changes.change, 0)
+				, 0)
 			, 0) AS members_24h_change_percent
 		FROM artist_coins
 		LEFT JOIN member_counts ON artist_coins.mint = member_counts.mint

--- a/api/v1_coins.go
+++ b/api/v1_coins.go
@@ -49,90 +49,120 @@ func (app *ApiServer) v1Coins(c *fiber.Ctx) error {
 	}
 
 	/*
-	 * The bulk of this query is calculating the member changes for the last
-	 * 24 hours. It calculates how many balances went from 0 to >0 (new members)
-	 * and how many went from >0 to 0 (members lost) for both userbank and associated wallets.
-	 * It then combines these counts to get the net member changes.
-	 * Finally, it calculates the total number of members and the percentage change
-	 * in members over the last 24 hours (net changes / (current members + net changes)).
+	 * The bulk of this query is calculating the member changes for the last 24h.
+	 *
+	 * t_user_balance_changes
+	 * 		collects all balance changes for the last 24h for both userbank and
+	 * 		associated wallets and joins to get user_ids.
+	 * t_user_balances
+	 * 		collects the current balances for both userbank and associated wallets
+	 * 		and joins to get user_ids.
+	 * total_user_balance_changes
+	 * 		sums the 24h change and total balance over all wallets for each
+	 *		user per mint.
+	 * member_changes
+	 * 		calculates the net member changes by counting how many user balances
+	 * 		went from 0 to >0 (new members) and how many went from >0 to 0
+	 * 		(members lost) for each mint.
+	 * members
+	 * 		calculates the total number of members for each mint by counting distinct
+	 * 		user_ids with a balance > 0
+	 * Finally, the main query selects the artist coins and joins the member counts
+	 * and member changes, calculating the percentage change in members over the last 24h.
 	 */
 	sql := `
-		WITH member_changes_userbank AS (
+		WITH t_user_balance_changes AS (
 			SELECT
 				sol_token_account_balance_changes.mint,
-				(
-					COUNT(DISTINCT users.user_id) 
-						FILTER (WHERE balance > 0 AND change = balance)
-				 	- COUNT(DISTINCT users.user_id) 
-						FILTER (WHERE balance = 0 AND change < 0)
-				) AS net_new_members
+				users.user_id,
+				change,
+				0 AS balance
 			FROM sol_token_account_balance_changes
 			JOIN sol_claimable_accounts
 				ON sol_claimable_accounts.account = sol_token_account_balance_changes.account
 			JOIN users
 				ON users.wallet = sol_claimable_accounts.ethereum_address
 			WHERE block_timestamp > NOW() - INTERVAL '24 hours'
-			GROUP BY sol_token_account_balance_changes.mint
-		), member_changes_associated_wallets AS (
+			UNION ALL
 			SELECT
 				sol_token_account_balance_changes.mint,
-				(
-					COUNT(DISTINCT associated_wallets.user_id) 
-						FILTER (WHERE balance > 0 AND change = balance)
-				 	- COUNT(DISTINCT associated_wallets.user_id) 
-						FILTER (WHERE balance = 0 AND change < 0)
-				) AS net_new_members
+				associated_wallets.user_id,
+				change,
+				0 AS balance
 			FROM sol_token_account_balance_changes
 			JOIN associated_wallets
 				ON associated_wallets.wallet = sol_token_account_balance_changes.owner
-				AND associated_wallets.chain = 'sol'
+				AND associated_wallets.chain = 'sol'	
 			WHERE block_timestamp > NOW() - INTERVAL '24 hours'
-			GROUP BY sol_token_account_balance_changes.mint	
-		), net_member_changes AS (
+		), t_user_balances AS (
 			SELECT
-				member_changes.mint,
-				COALESCE(SUM(member_changes.net_new_members), 0) AS change
-			FROM (
-				SELECT * FROM member_changes_userbank
-				UNION ALL SELECT * FROM member_changes_associated_wallets
-			) member_changes
-			GROUP BY member_changes.mint
-		), member_counts AS (
+				sol_token_account_balances.mint,
+				associated_wallets.user_id,
+				0 AS change,
+				sol_token_account_balances.balance
+			FROM sol_token_account_balances
+			JOIN associated_wallets 
+				ON associated_wallets.wallet = sol_token_account_balances.owner
+				AND associated_wallets.chain = 'sol'
+			UNION ALL
 			SELECT
-				member_balances.mint,
-				COUNT(DISTINCT member_balances.user_id) AS members
+				sol_token_account_balances.mint,
+				users.user_id,
+				0 AS change,
+				sol_token_account_balances.balance
+			FROM sol_token_account_balances
+			JOIN sol_claimable_accounts
+				ON sol_claimable_accounts.account = sol_token_account_balances.account
+			JOIN users 
+				ON users.wallet = sol_claimable_accounts.ethereum_address
+		), total_user_balance_changes AS (
+			SELECT
+				t.mint,
+				t.user_id,
+				SUM(t.change) AS change,
+				SUM(t.balance) AS balance
 			FROM (
-				SELECT sol_token_account_balances.mint,
-					COALESCE(associated_wallets.user_id, users.user_id) AS user_id
-				FROM sol_token_account_balances
-				LEFT JOIN associated_wallets 
-					ON associated_wallets.wallet = sol_token_account_balances.owner
-				LEFT JOIN sol_claimable_accounts 
-					ON sol_claimable_accounts.account = sol_token_account_balances.account
-				LEFT JOIN users 
-					ON users.wallet = sol_claimable_accounts.ethereum_address
-				WHERE sol_token_account_balances.balance > 0
-					AND (associated_wallets.wallet IS NOT NULL 
-							OR sol_claimable_accounts.account IS NOT NULL)
-			) AS member_balances
-			GROUP BY member_balances.mint
+				SELECT * FROM t_user_balance_changes 
+				UNION ALL 
+				SELECT * FROM t_user_balances
+			) t
+			GROUP BY
+				t.mint,
+				t.user_id
+		), member_changes AS (
+			SELECT
+				mint,
+				(
+					COUNT(DISTINCT user_id) FILTER (WHERE change = balance AND balance > 0) -
+					COUNT(DISTINCT user_id) FILTER (WHERE change < 0 AND balance = 0)
+				) AS net
+			FROM total_user_balance_changes
+			GROUP BY 
+				mint
+		), members AS (
+			SELECT
+				mint,
+				COUNT(DISTINCT user_id) AS count
+			FROM t_user_balances
+			WHERE balance > 0
+			GROUP BY mint
 		)
 		SELECT 
 			artist_coins.ticker,
 			artist_coins.mint,
 			artist_coins.user_id,
 			artist_coins.created_at,
-			COALESCE(member_counts.members, 0) AS members,
+			COALESCE(members.count, 0) AS members,
 			COALESCE(
-				(net_member_changes.change * 100.0) / 
+				(member_changes.net * 100.0) / 
 				NULLIF(
-					COALESCE(member_counts.members, 0) - 
-					COALESCE(net_member_changes.change, 0)
+					COALESCE(members.count, 0) - 
+					COALESCE(member_changes.net, 0)
 				, 0)
 			, 0) AS members_24h_change_percent
 		FROM artist_coins
-		LEFT JOIN member_counts ON artist_coins.mint = member_counts.mint
-		LEFT JOIN net_member_changes ON artist_coins.mint = net_member_changes.mint
+		LEFT JOIN members ON artist_coins.mint = members.mint
+		LEFT JOIN member_changes ON artist_coins.mint = member_changes.mint
 		WHERE 1=1
 			` + mintFilter + `
 			` + ownerIdFilter + `

--- a/api/v1_coins_test.go
+++ b/api/v1_coins_test.go
@@ -31,31 +31,22 @@ func TestGetCoins(t *testing.T) {
 		},
 		"users": {
 			{
-				"user_id": 3,
+				"user_id": 1,
 				"wallet":  "0x1234567890123456789012345678901234567890",
 			},
 		},
 		"associated_wallets": {
-			// holds 10 AUDIO
-			{
-				"id":      1,
-				"user_id": 1,
-				"wallet":  "owner_wallet",
-				"chain":   "sol",
-			},
-			// holds 0 USDC
 			{
 				"id":      2,
 				"user_id": 2,
-				"wallet":  "owner_wallet2",
 				"chain":   "sol",
+				"wallet":  "user_2_owner_1",
 			},
-			// holds 10 AUDIO, should be deduped as user 1
 			{
 				"id":      3,
-				"user_id": 1,
-				"wallet":  "owner_wallet3",
+				"user_id": 3,
 				"chain":   "sol",
+				"wallet":  "user_3_owner_1",
 			},
 		},
 		"sol_claimable_accounts": {
@@ -67,62 +58,131 @@ func TestGetCoins(t *testing.T) {
 			},
 		},
 		"sol_token_account_balance_changes": {
-			// claimable tokens wallet that received tokens yesterday
+			// user_1: new $AUDIO member
+			// $AUDIO claimable tokens account
+			// received, sent it all, received more
 			{
-				"signature":       "change1",
+				"slot":            1,
+				"signature":       "user_1_sig_1",
 				"mint":            "9LzCMqDgTKYz9Drzqnpgee3SGa89up3a247ypMj2xrqM",
 				"account":         "claimable",
 				"owner":           "claimable_pda",
 				"change":          1000000000,
 				"balance":         1000000000,
-				"block_timestamp": time.Now().Add(-time.Hour * 25),
+				"block_timestamp": time.Now().Add(-time.Hour * 3),
 			},
-			// wallet that was not empty yesterday, but empty today
+			{
+				"slot":            2,
+				"signature":       "user_1_sig_2",
+				"mint":            "9LzCMqDgTKYz9Drzqnpgee3SGa89up3a247ypMj2xrqM",
+				"account":         "claimable",
+				"owner":           "claimable_pda",
+				"change":          -1000000000,
+				"balance":         0,
+				"block_timestamp": time.Now().Add(-time.Hour * 2),
+			},
+			{
+				"slot":            3,
+				"signature":       "user_1_sig_3",
+				"mint":            "9LzCMqDgTKYz9Drzqnpgee3SGa89up3a247ypMj2xrqM",
+				"account":         "claimable",
+				"owner":           "claimable_pda",
+				"change":          100000000,
+				"balance":         100000000,
+				"block_timestamp": time.Now().Add(-time.Hour * 1),
+			},
+			// user_2: existing $AUDIO member
+			// $AUDIO associated wallet 1
 			{
 				"slot":            1,
-				"signature":       "change2",
-				"mint":            "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
-				"account":         "associated2",
-				"owner":           "owner_wallet2",
+				"signature":       "user_2_sig_1",
+				"mint":            "9LzCMqDgTKYz9Drzqnpgee3SGa89up3a247ypMj2xrqM",
+				"account":         "user_2_account_1",
+				"owner":           "user_2_owner_1",
+				"change":          1000000000,
+				"balance":         1000000000,
+				"block_timestamp": time.Now().Add(-time.Hour * 25),
+			},
+			// $AUDIO associated wallet 2
+			// sent it all today, but still a member because other account
+			{
+				"slot":            1,
+				"signature":       "user_2_sig_2",
+				"mint":            "9LzCMqDgTKYz9Drzqnpgee3SGa89up3a247ypMj2xrqM",
+				"account":         "user_2_account_2",
+				"owner":           "user_2_owner_1",
 				"change":          1000000000,
 				"balance":         1000000000,
 				"block_timestamp": time.Now().Add(-time.Hour * 25),
 			},
 			{
 				"slot":            2,
-				"signature":       "change3",
-				"mint":            "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
-				"account":         "associated2",
-				"owner":           "owner_wallet2",
+				"signature":       "user_2_sig_3",
+				"mint":            "9LzCMqDgTKYz9Drzqnpgee3SGa89up3a247ypMj2xrqM",
+				"account":         "user_2_account_2",
+				"owner":           "user_2_owner_1",
 				"change":          -1000000000,
 				"balance":         0,
-				"block_timestamp": time.Now().Add(-time.Hour * 1),
+				"block_timestamp": time.Now().Add(-time.Hour * 2),
 			},
-			// wallet that was added today
+			// user_3: existing $AUDIO member, former $USDC member
+			// $AUDIO associated wallet 1
+			// existing account
 			{
-				"signature":       "change4",
+				"slot":            1,
+				"signature":       "user_3_sig_1",
 				"mint":            "9LzCMqDgTKYz9Drzqnpgee3SGa89up3a247ypMj2xrqM",
-				"account":         "associated",
-				"owner":           "owner_wallet",
+				"account":         "user_3_account_1",
+				"owner":           "user_3_owner_1",
 				"change":          1000000000,
 				"balance":         1000000000,
-				"block_timestamp": time.Now().Add(-time.Hour * 1),
+				"block_timestamp": time.Now().Add(-time.Hour * 25),
 			},
-			// wallet added today that should be deduped as user 1 above
+			// $AUDIO associated wallet 2
+			// new account, but already a member
 			{
-				"signature":       "change5",
+				"slot":            2,
+				"signature":       "user_3_sig_2",
 				"mint":            "9LzCMqDgTKYz9Drzqnpgee3SGa89up3a247ypMj2xrqM",
-				"account":         "associated3",
-				"owner":           "owner_wallet3",
+				"account":         "user_3_account_2",
+				"owner":           "user_3_owner_1",
 				"change":          1000000000,
 				"balance":         1000000000,
-				"block_timestamp": time.Now().Add(-time.Hour * 1),
+				"block_timestamp": time.Now().Add(-time.Hour * 2),
+			},
+			// $USDC associated wallet
+			// sent it all today, no longer a member
+			{
+				"slot":            1,
+				"signature":       "user_3_sig_3",
+				"mint":            "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+				"account":         "user_3_account_3",
+				"owner":           "user_3_owner_1",
+				"change":          1000000000,
+				"balance":         1000000000,
+				"block_timestamp": time.Now().Add(-time.Hour * 25),
+			},
+			{
+				"slot":            2,
+				"signature":       "user_3_sig_4",
+				"mint":            "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+				"account":         "user_3_account_3",
+				"owner":           "user_3_owner_1",
+				"change":          -1000000000,
+				"balance":         0,
+				"block_timestamp": time.Now().Add(-time.Hour * 3),
 			},
 		},
 	}
 
 	database.Seed(app.pool, fixtures)
+
 	app.birdeyeClient = &mockBirdeyeClient{}
+
+	// User 1 is a new $AUDIO member, with users 2 and 3 being existing members.
+	// User 3 is a former $USDC member, with no other members remaining
+	// $AUDIO gained 1 member (2 remaining), $USDC lost 1 member (0 remaining)
+	// $AUDIO gained 50% members, $USDC lost 100% members
 
 	// no filters
 	{
@@ -133,8 +193,8 @@ func TestGetCoins(t *testing.T) {
 			"data.0.ticker":                     "$AUDIO",
 			"data.0.owner_id":                   trashid.MustEncodeHashID(1),
 			"data.0.mint":                       "9LzCMqDgTKYz9Drzqnpgee3SGa89up3a247ypMj2xrqM",
-			"data.0.members":                    2,
-			"data.0.members_24h_change_percent": 100.0,
+			"data.0.members":                    3,
+			"data.0.members_24h_change_percent": 50.0,
 			"data.1.ticker":                     "$USDC",
 			"data.1.owner_id":                   trashid.MustEncodeHashID(2),
 			"data.1.mint":                       "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
@@ -152,8 +212,8 @@ func TestGetCoins(t *testing.T) {
 			"data.0.ticker":                     "$AUDIO",
 			"data.0.owner_id":                   trashid.MustEncodeHashID(1),
 			"data.0.mint":                       "9LzCMqDgTKYz9Drzqnpgee3SGa89up3a247ypMj2xrqM",
-			"data.0.members":                    2,
-			"data.0.members_24h_change_percent": 100.0,
+			"data.0.members":                    3,
+			"data.0.members_24h_change_percent": 50.0,
 			"data.1":                            nil,
 		})
 	}

--- a/api/v1_coins_test.go
+++ b/api/v1_coins_test.go
@@ -66,26 +66,6 @@ func TestGetCoins(t *testing.T) {
 				"mint":             "9LzCMqDgTKYz9Drzqnpgee3SGa89up3a247ypMj2xrqM",
 			},
 		},
-		"sol_token_account_balances": {
-			{
-				"mint":    "9LzCMqDgTKYz9Drzqnpgee3SGa89up3a247ypMj2xrqM",
-				"account": "associated",
-				"owner":   "owner_wallet",
-				"balance": 1000000000,
-			},
-			{
-				"mint":    "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
-				"account": "associated2",
-				"owner":   "owner_wallet2",
-				"balance": 0, // should be ignored as a member
-			},
-			{
-				"mint":    "9LzCMqDgTKYz9Drzqnpgee3SGa89up3a247ypMj2xrqM",
-				"account": "associated3",
-				"owner":   "owner_wallet3", // should be deduped as user 1
-				"balance": 1000000000,
-			},
-		},
 		"sol_token_account_balance_changes": {
 			// claimable tokens wallet that received tokens yesterday
 			{
@@ -99,6 +79,7 @@ func TestGetCoins(t *testing.T) {
 			},
 			// wallet that was not empty yesterday, but empty today
 			{
+				"slot":            1,
 				"signature":       "change2",
 				"mint":            "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
 				"account":         "associated2",
@@ -107,11 +88,41 @@ func TestGetCoins(t *testing.T) {
 				"balance":         1000000000,
 				"block_timestamp": time.Now().Add(-time.Hour * 25),
 			},
+			{
+				"slot":            2,
+				"signature":       "change3",
+				"mint":            "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+				"account":         "associated2",
+				"owner":           "owner_wallet2",
+				"change":          -1000000000,
+				"balance":         0,
+				"block_timestamp": time.Now().Add(-time.Hour * 1),
+			},
+			// wallet that was added today
+			{
+				"signature":       "change4",
+				"mint":            "9LzCMqDgTKYz9Drzqnpgee3SGa89up3a247ypMj2xrqM",
+				"account":         "associated",
+				"owner":           "owner_wallet",
+				"change":          1000000000,
+				"balance":         1000000000,
+				"block_timestamp": time.Now().Add(-time.Hour * 1),
+			},
+			// wallet added today that should be deduped as user 1 above
+			{
+				"signature":       "change5",
+				"mint":            "9LzCMqDgTKYz9Drzqnpgee3SGa89up3a247ypMj2xrqM",
+				"account":         "associated3",
+				"owner":           "owner_wallet3",
+				"change":          1000000000,
+				"balance":         1000000000,
+				"block_timestamp": time.Now().Add(-time.Hour * 1),
+			},
 		},
 	}
 
 	database.Seed(app.pool, fixtures)
-	app.birdeyeClient = &MockBirdeyeClient{}
+	app.birdeyeClient = &mockBirdeyeClient{}
 
 	// no filters
 	{

--- a/api/v1_users_coin_test.go
+++ b/api/v1_users_coin_test.go
@@ -113,7 +113,7 @@ func TestUserCoin(t *testing.T) {
 	}
 
 	database.Seed(app.pool, fixtures)
-	app.birdeyeClient = &MockBirdeyeClient{}
+	app.birdeyeClient = &mockBirdeyeClient{}
 
 	// AUDIO
 	{

--- a/api/v1_users_coins_test.go
+++ b/api/v1_users_coins_test.go
@@ -113,7 +113,7 @@ func TestUserCoins(t *testing.T) {
 	}
 
 	database.Seed(app.pool, fixtures)
-	app.birdeyeClient = &MockBirdeyeClient{}
+	app.birdeyeClient = &mockBirdeyeClient{}
 
 	status, body := testGet(t, app, "/v1/users/"+trashid.MustEncodeHashID(1)+"/coins")
 	assert.Equal(t, 200, status)


### PR DESCRIPTION
Previously, the `v1Coins` and `v1Coin` endpoints were calculating the total number of members that existed 24hrs ago. This is unnecessary. In this PR, we instead calculate how many members were added and removed in the last 24hrs, and use that to derive how many members there were 24hrs ago.

This brings the $AUDIO coin query down from 20s to 1.2s. It gets around 2.5s if missing the cache for the token overviews from birdeye, so I increased the cache time there too.

NOTE: This doesn't take into account added/removed associated wallets.