### PR TITLE
Include Decimals in v1UsersCoins and others

### DIFF
--- a/api/swagger/swagger-v1.yaml
+++ b/api/swagger/swagger-v1.yaml
@@ -5266,6 +5266,7 @@ components:
       required:
         - mint
         - ticker
+        - decimals
         - balance
         - balance_usd
       type: object
@@ -5278,6 +5279,10 @@ components:
           type: string
           description: The coin symbol
           example: "$AUDIO"
+        decimals:
+          type: integer
+          description: The number of decimals for the coin
+          example: 8
         balance:
           type: integer
           description: The balance of the coin in the user's account (in wei)
@@ -5298,15 +5303,30 @@ components:
     user_coin_with_accounts:
       type: object
       required:
-        - totalBalance
-        - totalBalanceUSD
+        - mint
+        - ticker
+        - decimals
+        - balance
+        - balance_usd
         - accounts
       properties:
-        totalBalance: 
+        mint:
+          type: string
+          description: The coin mint address
+          example: "9LzCMqDgTKYz9Drzqnpgee3SGa89up3a247ypMj2xrqM"
+        ticker:
+          type: string
+          description: The coin symbol
+          example: "$AUDIO"
+        decimals:
+          type: integer
+          description: The number of decimals for the coin
+          example: 8
+        balance:
           type: integer
           description: The total balance of the coin in the user's account (in wei)
           example: 1000000000
-        totalBalanceUSD:
+        balanceUSD:
           type: number
           description: The total balance of the coin in the user's account in USD
           example: 1.23

--- a/api/swagger/swagger-v1.yaml
+++ b/api/swagger/swagger-v1.yaml
@@ -5326,7 +5326,7 @@ components:
           type: integer
           description: The total balance of the coin in the user's account (in wei)
           example: 1000000000
-        balanceUSD:
+        balance_usd:
           type: number
           description: The total balance of the coin in the user's account in USD
           example: 1.23

--- a/api/v1_coin.go
+++ b/api/v1_coin.go
@@ -69,6 +69,7 @@ func (app *ApiServer) v1Coin(c *fiber.Ctx) error {
 		SELECT 
 			artist_coins.ticker,
 			artist_coins.mint,
+			artist_coins.decimals,
 			artist_coins.user_id,
 			artist_coins.created_at,
 			COALESCE(member_counts.members, 0) AS members,

--- a/api/v1_coin_test.go
+++ b/api/v1_coin_test.go
@@ -161,8 +161,9 @@ func TestGetCoin(t *testing.T) {
 
 		jsonAssert(t, body, map[string]any{
 			"data.ticker":                     "$USDC",
-			"data.owner_id":                   trashid.MustEncodeHashID(2),
 			"data.mint":                       "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+			"data.decimals":                   6,
+			"data.owner_id":                   trashid.MustEncodeHashID(2),
 			"data.members":                    0,
 			"data.members_24h_change_percent": -100.0,
 		})
@@ -175,8 +176,9 @@ func TestGetCoin(t *testing.T) {
 
 		jsonAssert(t, body, map[string]any{
 			"data.ticker":                     "$AUDIO",
-			"data.owner_id":                   trashid.MustEncodeHashID(1),
 			"data.mint":                       "9LzCMqDgTKYz9Drzqnpgee3SGa89up3a247ypMj2xrqM",
+			"data.decimals":                   8,
+			"data.owner_id":                   trashid.MustEncodeHashID(1),
 			"data.members":                    2,
 			"data.members_24h_change_percent": 100.0,
 		})

--- a/api/v1_coins.go
+++ b/api/v1_coins.go
@@ -22,6 +22,7 @@ type GetArtistCoinsQueryParams struct {
 type ArtistCoin struct {
 	Ticker                  string                 `json:"ticker"`
 	Mint                    string                 `json:"mint"`
+	Decimals                int                    `json:"decimals"`
 	OwnerId                 trashid.HashId         `db:"user_id" json:"owner_id"`
 	Members                 int                    `json:"members"`
 	Members24hChangePercent *float64               `json:"members_24h_change_percent"`
@@ -104,6 +105,7 @@ func (app *ApiServer) v1Coins(c *fiber.Ctx) error {
 		SELECT 
 			artist_coins.ticker,
 			artist_coins.mint,
+			artist_coins.decimals,
 			artist_coins.user_id,
 			artist_coins.created_at,
 			COALESCE(member_counts.members, 0) AS members,

--- a/api/v1_coins_test.go
+++ b/api/v1_coins_test.go
@@ -120,13 +120,15 @@ func TestGetCoins(t *testing.T) {
 
 		jsonAssert(t, body, map[string]any{
 			"data.0.ticker":                     "$AUDIO",
-			"data.0.owner_id":                   trashid.MustEncodeHashID(1),
 			"data.0.mint":                       "9LzCMqDgTKYz9Drzqnpgee3SGa89up3a247ypMj2xrqM",
+			"data.0.decimals":                   8,
+			"data.0.owner_id":                   trashid.MustEncodeHashID(1),
 			"data.0.members":                    2,
 			"data.0.members_24h_change_percent": 100.0,
 			"data.1.ticker":                     "$USDC",
-			"data.1.owner_id":                   trashid.MustEncodeHashID(2),
 			"data.1.mint":                       "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+			"data.1.decimals":                   6,
+			"data.1.owner_id":                   trashid.MustEncodeHashID(2),
 			"data.1.members":                    0,
 			"data.1.members_24h_change_percent": -100.0,
 		})
@@ -139,8 +141,9 @@ func TestGetCoins(t *testing.T) {
 
 		jsonAssert(t, body, map[string]any{
 			"data.0.ticker":                     "$AUDIO",
-			"data.0.owner_id":                   trashid.MustEncodeHashID(1),
 			"data.0.mint":                       "9LzCMqDgTKYz9Drzqnpgee3SGa89up3a247ypMj2xrqM",
+			"data.0.decimals":                   8,
+			"data.0.owner_id":                   trashid.MustEncodeHashID(1),
 			"data.0.members":                    2,
 			"data.0.members_24h_change_percent": 100.0,
 			"data.1":                            nil,
@@ -154,8 +157,9 @@ func TestGetCoins(t *testing.T) {
 
 		jsonAssert(t, body, map[string]any{
 			"data.0.ticker":                     "$USDC",
-			"data.0.owner_id":                   trashid.MustEncodeHashID(2),
+			"data.0.decimals":                   6,
 			"data.0.mint":                       "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+			"data.0.owner_id":                   trashid.MustEncodeHashID(2),
 			"data.0.members":                    0,
 			"data.0.members_24h_change_percent": -100.0,
 			"data.1":                            nil,
@@ -169,8 +173,9 @@ func TestGetCoins(t *testing.T) {
 
 		jsonAssert(t, body, map[string]any{
 			"data.0.ticker":                     "$USDC",
-			"data.0.owner_id":                   trashid.MustEncodeHashID(2),
 			"data.0.mint":                       "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+			"data.0.decimals":                   6,
+			"data.0.owner_id":                   trashid.MustEncodeHashID(2),
 			"data.0.members":                    0,
 			"data.0.members_24h_change_percent": -100.0,
 			"data.1":                            nil,

--- a/api/v1_users_coin.go
+++ b/api/v1_users_coin.go
@@ -74,6 +74,7 @@ func (app *ApiServer) v1UsersCoin(c *fiber.Ctx) error {
 		SELECT 
 			artist_coins.ticker,
 			balances_by_mint.mint,
+			artist_coins.decimals,
 			balances_by_mint.balance AS balance,
 			(balances_by_mint.balance * @price) / POWER(10, artist_coins.decimals) AS balance_usd,
 			JSON_AGG(

--- a/api/v1_users_coin_test.go
+++ b/api/v1_users_coin_test.go
@@ -123,6 +123,7 @@ func TestUserCoin(t *testing.T) {
 		jsonAssert(t, body, map[string]any{
 			"data.ticker":                      "$AUDIO",
 			"data.mint":                        "9LzCMqDgTKYz9Drzqnpgee3SGa89up3a247ypMj2xrqM",
+			"data.decimals":                    8,
 			"data.balance":                     1800000000, // 18 AUDIO
 			"data.balance_usd":                 180.0,      // Assuming $10 per AUDIO
 			"data.accounts.#":                  3,
@@ -151,6 +152,7 @@ func TestUserCoin(t *testing.T) {
 		jsonAssert(t, body, map[string]any{
 			"data.ticker":                      "$USDC",
 			"data.mint":                        "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+			"data.decimals":                    6,
 			"data.balance":                     7000000, // 7 USDC
 			"data.balance_usd":                 7.0,
 			"data.accounts.#":                  1,

--- a/api/v1_users_coins.go
+++ b/api/v1_users_coins.go
@@ -16,6 +16,7 @@ type GetUsersCoinsQueryParams struct {
 type UserCoin struct {
 	Ticker     string  `json:"ticker"`
 	Mint       string  `json:"mint"`
+	Decimals   int     `json:"decimals"`
 	Balance    float64 `json:"balance"`
 	BalanceUSD float64 `json:"balance_usd"`
 }
@@ -96,6 +97,7 @@ func (app *ApiServer) v1UsersCoins(c *fiber.Ctx) error {
 			SELECT 
 				artist_coins.ticker,
 				balances_by_mint.mint,
+				artist_coins.decimals,
 				balances_by_mint.balance AS balance,
 				(balances_by_mint.balance * prices.price) / POWER(10, artist_coins.decimals) AS balance_usd
 			FROM balances_by_mint
@@ -105,6 +107,7 @@ func (app *ApiServer) v1UsersCoins(c *fiber.Ctx) error {
 		SELECT
 			balances_with_prices.ticker,
 			balances_with_prices.mint,
+			balances_with_prices.decimals,
 			balances_with_prices.balance,
 			balances_with_prices.balance_usd
 		FROM balances_with_prices

--- a/api/v1_users_coins_test.go
+++ b/api/v1_users_coins_test.go
@@ -122,6 +122,7 @@ func TestUserCoins(t *testing.T) {
 		"data.#":             2,
 		"data.0.ticker":      "$AUDIO",
 		"data.0.mint":        "9LzCMqDgTKYz9Drzqnpgee3SGa89up3a247ypMj2xrqM",
+		"data.0.decimals":    8,
 		"data.0.balance":     1800000000, // 18 AUDIO
 		"data.0.balance_usd": 180.0,      // Assuming $10 per AUDIO
 		"data.1.ticker":      "$USDC",


### PR DESCRIPTION
Include decimals as a top level field whenever returning an artist coin, so that `FixedDecimal` on the client has something to work with.

Also updates the schema to rename `total_balance` and `total_balance_usd` to `balance` and `balance_usd`, and include the other fields returned.