### PR TITLE
Fix errors on subscription change

### DIFF
--- a/solana/indexer/solana_indexer.go
+++ b/solana/indexer/solana_indexer.go
@@ -97,10 +97,6 @@ func (s *SolanaIndexer) Close() {
 	if p, ok := s.processor.(*DefaultProcessor); ok {
 		p.ReportCacheStats(s.logger)
 	}
-	err := s.logger.Sync()
-	if err != nil {
-		s.logger.Error("failed to sync logger", zap.Error(err))
-	}
 	s.grpcClient.Close()
 	s.pool.Close()
 }

--- a/solana/indexer/subscription.go
+++ b/solana/indexer/subscription.go
@@ -130,6 +130,7 @@ func (s *SolanaIndexer) Subscribe(ctx context.Context) error {
 					zap.String("operation", notifData.Operation))
 				cancel()
 				<-subCtx.Done()
+				s.grpcClient.Close()
 				break
 			}
 		}

--- a/solana/indexer/subscription.go
+++ b/solana/indexer/subscription.go
@@ -129,8 +129,8 @@ func (s *SolanaIndexer) Subscribe(ctx context.Context) error {
 					zap.String("newMint", notifData.NewMint),
 					zap.String("operation", notifData.Operation))
 				cancel()
-				<-subCtx.Done()
 				s.grpcClient.Close()
+				<-subCtx.Done()
 				break
 			}
 		}


### PR DESCRIPTION
- The logger syncs itself on context cancellation
- gRPC client should be manually closed before resubscribing