### PR TITLE
id3 tags

### DIFF
--- a/api/dbv1/full_tracks.go
+++ b/api/dbv1/full_tracks.go
@@ -128,9 +128,14 @@ func (q *Queries) FullTracksKeyed(ctx context.Context, arg FullTracksParams) (ma
 		// Get access from the bulk access map
 		access := accessMap[track.TrackID]
 
+		id3Tags := &Id3Tags{
+			Title:  track.Title.String,
+			Artist: user.Name.String,
+		}
+
 		var stream *MediaLink
 		if access.Stream {
-			stream, err = mediaLink(track.TrackCid.String, track.TrackID, arg.MyID.(int32))
+			stream, err = mediaLink(track.TrackCid.String, track.TrackID, arg.MyID.(int32), id3Tags)
 			if err != nil {
 				return nil, err
 			}
@@ -138,7 +143,7 @@ func (q *Queries) FullTracksKeyed(ctx context.Context, arg FullTracksParams) (ma
 
 		var download *MediaLink
 		if track.IsDownloadable && access.Download {
-			download, err = mediaLink(track.OrigFileCid.String, track.TrackID, arg.MyID.(int32))
+			download, err = mediaLink(track.OrigFileCid.String, track.TrackID, arg.MyID.(int32), id3Tags)
 			if err != nil {
 				return nil, err
 			}
@@ -146,7 +151,7 @@ func (q *Queries) FullTracksKeyed(ctx context.Context, arg FullTracksParams) (ma
 
 		var preview *MediaLink
 		if track.PreviewCid.String != "" {
-			preview, err = mediaLink(track.PreviewCid.String, track.TrackID, arg.MyID.(int32))
+			preview, err = mediaLink(track.PreviewCid.String, track.TrackID, arg.MyID.(int32), id3Tags)
 			if err != nil {
 				return nil, err
 			}

--- a/api/dbv1/media_link.go
+++ b/api/dbv1/media_link.go
@@ -51,14 +51,14 @@ func mediaLink(cid string, trackId int32, userId int32, id3Tags *Id3Tags) (*Medi
 	queryParams := url.Values{}
 	queryParams.Set("signature", string(signatureJSON))
 
-	basePath := fmt.Sprintf("tracks/cidstream/%s", cid)
-	path := fmt.Sprintf("%s?%s", basePath, queryParams.Encode())
-
 	if id3Tags != nil {
 		queryParams.Set("id3", "true")
 		queryParams.Set("id3_artist", id3Tags.Artist)
 		queryParams.Set("id3_title", id3Tags.Title)
 	}
+
+	basePath := fmt.Sprintf("tracks/cidstream/%s", cid)
+	path := fmt.Sprintf("%s?%s", basePath, queryParams.Encode())
 
 	return &MediaLink{
 		Url:     fmt.Sprintf("%s/%s", first, path),

--- a/api/dbv1/media_link.go
+++ b/api/dbv1/media_link.go
@@ -19,7 +19,12 @@ type MediaLink struct {
 	Mirrors []string `json:"mirrors"`
 }
 
-func mediaLink(cid string, trackId int32, userId int32) (*MediaLink, error) {
+type Id3Tags struct {
+	Title  string `json:"title"`
+	Artist string `json:"artist"`
+}
+
+func mediaLink(cid string, trackId int32, userId int32, id3Tags *Id3Tags) (*MediaLink, error) {
 	first, rest := rendezvous.GlobalHasher.ReplicaSet3(cid)
 
 	timestamp := time.Now().Unix() * 1000
@@ -48,6 +53,12 @@ func mediaLink(cid string, trackId int32, userId int32) (*MediaLink, error) {
 
 	basePath := fmt.Sprintf("tracks/cidstream/%s", cid)
 	path := fmt.Sprintf("%s?%s", basePath, queryParams.Encode())
+
+	if id3Tags != nil {
+		queryParams.Set("id3", "true")
+		queryParams.Set("id3_artist", id3Tags.Artist)
+		queryParams.Set("id3_title", id3Tags.Title)
+	}
 
 	return &MediaLink{
 		Url:     fmt.Sprintf("%s/%s", first, path),

--- a/api/stream_util.go
+++ b/api/stream_util.go
@@ -32,6 +32,8 @@ func tryFindWorkingUrl(mediaLink *dbv1.MediaLink) *url.URL {
 	for _, u := range urls {
 		q := u.Query()
 		q.Set("skip_play_count", "true")
+		// skip id3 tags when checking if the stream is working
+		q.Set("id3", "false")
 		u.RawQuery = q.Encode()
 
 		req, err := http.NewRequest("GET", u.String(), nil)

--- a/api/v1_track_stream.go
+++ b/api/v1_track_stream.go
@@ -30,11 +30,18 @@ func (app *ApiServer) v1TrackStream(c *fiber.Ctx) error {
 
 	streamURL := tryFindWorkingUrl(track.Stream)
 
+	q := streamURL.Query()
 	if skipPlayCount := c.Query("skip_play_count"); skipPlayCount != "" {
-		q := streamURL.Query()
 		q.Set("skip_play_count", skipPlayCount)
-		streamURL.RawQuery = q.Encode()
 	}
+
+	// set id3 tags as query params in stream url
+	// audiusd will set the id3 tags on the fly
+	q.Set("id3", "true")
+	q.Set("id3_artist", track.User.Handle.String)
+	q.Set("id3_title", track.Title.String)
+
+	streamURL.RawQuery = q.Encode()
 
 	return c.Redirect(streamURL.String(), fiber.StatusFound)
 }

--- a/api/v1_track_stream.go
+++ b/api/v1_track_stream.go
@@ -30,18 +30,11 @@ func (app *ApiServer) v1TrackStream(c *fiber.Ctx) error {
 
 	streamURL := tryFindWorkingUrl(track.Stream)
 
-	q := streamURL.Query()
 	if skipPlayCount := c.Query("skip_play_count"); skipPlayCount != "" {
+		q := streamURL.Query()
 		q.Set("skip_play_count", skipPlayCount)
+		streamURL.RawQuery = q.Encode()
 	}
-
-	// set id3 tags as query params in stream url
-	// audiusd will set the id3 tags on the fly
-	q.Set("id3", "true")
-	q.Set("id3_artist", track.User.Handle.String)
-	q.Set("id3_title", track.Title.String)
-
-	streamURL.RawQuery = q.Encode()
 
 	return c.Redirect(streamURL.String(), fiber.StatusFound)
 }

--- a/api/v1_track_stream_test.go
+++ b/api/v1_track_stream_test.go
@@ -12,5 +12,5 @@ func TestGetTrackStream(t *testing.T) {
 	req := httptest.NewRequest("GET", "/v1/tracks/eYJyn/stream", nil)
 	res, err := app.Test(req, -1)
 	assert.NoError(t, err)
-	assert.Contains(t, res.Header.Get("Location"), "tracks/cidstream/?signature=%7B%22data%22%3A%22%7B%5C%22cid%5C%22%3A%5C%22%5C%22%2C%5C%22timestamp%5C%22%3")
+	assert.Contains(t, res.Header.Get("Location"), "tracks/cidstream/?id3=false&id3_artist=&id3_title=Culca+Canyon&signature=%7B%22data%22%3A%22%7B%5C%22cid%5C%22%3A%5C%22%5C%22%2C%5C%22timestamp%5C%22%3")
 }


### PR DESCRIPTION
- passes id3 tags from the stream endpoint down to an audiusd validator, that validator then adds these to the streamed response.
- in the future the audiusd instance will be able to do this on it's own with ddex resources/releases

I think the `track.User` is the artist of the track but I could be wrong. Maybe there's a better field we want for this?

audiusd PR: https://github.com/AudiusProject/audiusd/pull/152