### PR TITLE
Disable member counts and member 24h percent changes for perf reasons

### DIFF
--- a/api/v1_coin.go
+++ b/api/v1_coin.go
@@ -15,103 +15,15 @@ func (app *ApiServer) v1Coin(c *fiber.Ctx) error {
 
 	// See v1_coins for the query explanation.
 	sql := `
-		WITH t_user_balance_changes AS (
-			SELECT
-				sol_token_account_balance_changes.mint,
-				users.user_id,
-				change,
-				0 AS balance
-			FROM sol_token_account_balance_changes
-			JOIN sol_claimable_accounts
-				ON sol_claimable_accounts.account = sol_token_account_balance_changes.account
-			JOIN users
-				ON users.wallet = sol_claimable_accounts.ethereum_address
-			WHERE block_timestamp > NOW() - INTERVAL '24 hours'
-				AND sol_token_account_balance_changes.mint = @mint
-			UNION ALL
-			SELECT
-				sol_token_account_balance_changes.mint,
-				associated_wallets.user_id,
-				change,
-				0 AS balance
-			FROM sol_token_account_balance_changes
-			JOIN associated_wallets
-				ON associated_wallets.wallet = sol_token_account_balance_changes.owner
-				AND associated_wallets.chain = 'sol'	
-			WHERE block_timestamp > NOW() - INTERVAL '24 hours'
-				AND sol_token_account_balance_changes.mint = @mint
-		), t_user_balances AS (
-			SELECT
-				sol_token_account_balances.mint,
-				associated_wallets.user_id,
-				0 AS change,
-				sol_token_account_balances.balance
-			FROM sol_token_account_balances
-			JOIN associated_wallets 
-				ON associated_wallets.wallet = sol_token_account_balances.owner
-				AND associated_wallets.chain = 'sol'
-			WHERE sol_token_account_balances.mint = @mint
-			UNION ALL
-			SELECT
-				sol_token_account_balances.mint,
-				users.user_id,
-				0 AS change,
-				sol_token_account_balances.balance
-			FROM sol_token_account_balances
-			JOIN sol_claimable_accounts
-				ON sol_claimable_accounts.account = sol_token_account_balances.account
-			JOIN users 
-				ON users.wallet = sol_claimable_accounts.ethereum_address
-			WHERE sol_token_account_balances.mint = @mint
-		), total_user_balance_changes AS (
-			SELECT
-				t.mint,
-				t.user_id,
-				SUM(t.change) AS change,
-				SUM(t.balance) AS balance
-			FROM (
-				SELECT * FROM t_user_balance_changes 
-				UNION ALL 
-				SELECT * FROM t_user_balances
-			) t
-			GROUP BY
-				t.mint,
-				t.user_id
-		), member_changes AS (
-			SELECT
-				mint,
-				(
-					COUNT(DISTINCT user_id) FILTER (WHERE change = balance AND balance > 0) -
-					COUNT(DISTINCT user_id) FILTER (WHERE change < 0 AND balance = 0)
-				) AS net
-			FROM total_user_balance_changes
-			GROUP BY 
-				mint
-		), members AS (
-			SELECT
-				mint,
-				COUNT(DISTINCT user_id) AS count
-			FROM t_user_balances
-			WHERE balance > 0
-			GROUP BY mint
-		)
 		SELECT 
 			artist_coins.ticker,
 			artist_coins.mint,
 			artist_coins.decimals,
 			artist_coins.user_id,
 			artist_coins.created_at,
-			COALESCE(members.count, 0) AS members,
-			COALESCE(
-				(member_changes.net * 100.0) / 
-				NULLIF(
-					COALESCE(members.count, 0) - 
-					COALESCE(member_changes.net, 0)
-				, 0)
-			, 0) AS members_24h_change_percent
+			123 as members, -- Placeholder for members count
+			50 as members_24h_change_percent -- Placeholder for 24h change percent
 		FROM artist_coins
-		LEFT JOIN members ON artist_coins.mint = members.mint
-		LEFT JOIN member_changes ON artist_coins.mint = member_changes.mint
 		WHERE artist_coins.mint = @mint
 		LIMIT 1
 	`

--- a/api/v1_coin_test.go
+++ b/api/v1_coin_test.go
@@ -50,6 +50,7 @@ func (m *mockBirdeyeClient) GetPrices(ctx context.Context, mints []string) (*bir
 }
 
 func TestGetCoin(t *testing.T) {
+	t.Skip("Skipping testGetCoin due to member counting being temporarily disabled for performance reasons")
 	app := emptyTestApp(t)
 
 	fixtures := database.FixtureMap{

--- a/api/v1_coins.go
+++ b/api/v1_coins.go
@@ -49,122 +49,16 @@ func (app *ApiServer) v1Coins(c *fiber.Ctx) error {
 		tickerFilter = `AND artist_coins.ticker = ANY(@tickers)`
 	}
 
-	/*
-	 * The bulk of this query is calculating the member changes for the last 24h.
-	 *
-	 * t_user_balance_changes
-	 * 		collects all balance changes for the last 24h for both userbank and
-	 * 		associated wallets and joins to get user_ids.
-	 * t_user_balances
-	 * 		collects the current balances for both userbank and associated wallets
-	 * 		and joins to get user_ids.
-	 * total_user_balance_changes
-	 * 		sums the 24h change and total balance over all wallets for each
-	 *		user per mint.
-	 * member_changes
-	 * 		calculates the net member changes by counting how many user balances
-	 * 		went from 0 to >0 (new members) and how many went from >0 to 0
-	 * 		(members lost) for each mint.
-	 * members
-	 * 		calculates the total number of members for each mint by counting distinct
-	 * 		user_ids with a balance > 0
-	 * Finally, the main query selects the artist coins and joins the member counts
-	 * and member changes, calculating the percentage change in members over the last 24h.
-	 */
 	sql := `
-		WITH t_user_balance_changes AS (
-			SELECT
-				sol_token_account_balance_changes.mint,
-				users.user_id,
-				change,
-				0 AS balance
-			FROM sol_token_account_balance_changes
-			JOIN sol_claimable_accounts
-				ON sol_claimable_accounts.account = sol_token_account_balance_changes.account
-			JOIN users
-				ON users.wallet = sol_claimable_accounts.ethereum_address
-			WHERE block_timestamp > NOW() - INTERVAL '24 hours'
-			UNION ALL
-			SELECT
-				sol_token_account_balance_changes.mint,
-				associated_wallets.user_id,
-				change,
-				0 AS balance
-			FROM sol_token_account_balance_changes
-			JOIN associated_wallets
-				ON associated_wallets.wallet = sol_token_account_balance_changes.owner
-				AND associated_wallets.chain = 'sol'	
-			WHERE block_timestamp > NOW() - INTERVAL '24 hours'
-		), t_user_balances AS (
-			SELECT
-				sol_token_account_balances.mint,
-				associated_wallets.user_id,
-				0 AS change,
-				sol_token_account_balances.balance
-			FROM sol_token_account_balances
-			JOIN associated_wallets 
-				ON associated_wallets.wallet = sol_token_account_balances.owner
-				AND associated_wallets.chain = 'sol'
-			UNION ALL
-			SELECT
-				sol_token_account_balances.mint,
-				users.user_id,
-				0 AS change,
-				sol_token_account_balances.balance
-			FROM sol_token_account_balances
-			JOIN sol_claimable_accounts
-				ON sol_claimable_accounts.account = sol_token_account_balances.account
-			JOIN users 
-				ON users.wallet = sol_claimable_accounts.ethereum_address
-		), total_user_balance_changes AS (
-			SELECT
-				t.mint,
-				t.user_id,
-				SUM(t.change) AS change,
-				SUM(t.balance) AS balance
-			FROM (
-				SELECT * FROM t_user_balance_changes 
-				UNION ALL 
-				SELECT * FROM t_user_balances
-			) t
-			GROUP BY
-				t.mint,
-				t.user_id
-		), member_changes AS (
-			SELECT
-				mint,
-				(
-					COUNT(DISTINCT user_id) FILTER (WHERE change = balance AND balance > 0) -
-					COUNT(DISTINCT user_id) FILTER (WHERE change < 0 AND balance = 0)
-				) AS net
-			FROM total_user_balance_changes
-			GROUP BY 
-				mint
-		), members AS (
-			SELECT
-				mint,
-				COUNT(DISTINCT user_id) AS count
-			FROM t_user_balances
-			WHERE balance > 0
-			GROUP BY mint
-		)
 		SELECT 
 			artist_coins.ticker,
 			artist_coins.mint,
 			artist_coins.decimals,
 			artist_coins.user_id,
 			artist_coins.created_at,
-			COALESCE(members.count, 0) AS members,
-			COALESCE(
-				(member_changes.net * 100.0) / 
-				NULLIF(
-					COALESCE(members.count, 0) - 
-					COALESCE(member_changes.net, 0)
-				, 0)
-			, 0) AS members_24h_change_percent
+			123 as members, -- Placeholder for members count
+			50 as members_24h_change_percent -- Placeholder for 24h change percent
 		FROM artist_coins
-		LEFT JOIN members ON artist_coins.mint = members.mint
-		LEFT JOIN member_changes ON artist_coins.mint = member_changes.mint
 		WHERE 1=1
 			` + mintFilter + `
 			` + ownerIdFilter + `

--- a/api/v1_coins_test.go
+++ b/api/v1_coins_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestGetCoins(t *testing.T) {
+	t.Skip("Skipping testGetCoins due to member counting being temporarily disabled for performance reasons")
 	app := emptyTestApp(t)
 
 	fixtures := database.FixtureMap{


### PR DESCRIPTION
Skips calculating members and member change 24h percent to prevent insane slowdown.

Will reland later after fixing perf issues.