### PR TITLE
Fix 400 when all token prices come from cache

### DIFF
--- a/api/birdeye/client.go
+++ b/api/birdeye/client.go
@@ -160,6 +160,9 @@ func (c *Client) GetPrices(ctx context.Context, mints []string) (*TokenPriceMap,
 			mintsToFetch = append(mintsToFetch, mint)
 		}
 	}
+	if len(mintsToFetch) == 0 {
+		return &result, nil
+	}
 
 	url := fmt.Sprintf("https://public-api.birdeye.so/defi/multi_price?list_address=%s", strings.Join(mintsToFetch, ","))
 	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)


### PR DESCRIPTION
If all the token prices are cached, the birdeye client 400s because of an empty list of mints to fetch. Return early if all mints were cached to avoid this.