### PR TITLE
Fix blocktimestamp index

### DIFF
--- a/ddl/migrations/0153_fix_blocktimestamp_index.sql
+++ b/ddl/migrations/0153_fix_blocktimestamp_index.sql
@@ -1,0 +1,3 @@
+DROP INDEX IF EXISTS sol_token_account_balance_changes_block_timestamp;
+CREATE INDEX IF NOT EXISTS sol_token_account_balance_changes_mint_block_timestamp
+    ON sol_token_account_balance_changes (mint, block_timestamp DESC);


### PR DESCRIPTION
Last attempt before I punt this entirely and move to SDK/solana-relay plan but i took a look at this query plan https://explain.depesz.com/s/ZGM5 and saw the seq scans that shouldn't be there... then realized that the takeaway from the "block_passed" investigation was also related to `<>` not being usable in indexes if they're in the wrong order.. and AI also confirmed this index was backwards...

So I tried it on local db w/ some prod data with 1mil+ balance changes and it seemed to really speed things up. Hoping that it works well in actual prod too.