### PR TITLE
send id3 tags on all stream

### DIFF
--- a/api/stream_util.go
+++ b/api/stream_util.go
@@ -32,8 +32,6 @@ func tryFindWorkingUrl(mediaLink *dbv1.MediaLink) *url.URL {
 	for _, u := range urls {
 		q := u.Query()
 		q.Set("skip_play_count", "true")
-		// skip id3 tags when checking if the stream is working
-		q.Set("id3", "false")
 		u.RawQuery = q.Encode()
 
 		req, err := http.NewRequest("GET", u.String(), nil)

--- a/api/v1_track_stream_test.go
+++ b/api/v1_track_stream_test.go
@@ -12,5 +12,5 @@ func TestGetTrackStream(t *testing.T) {
 	req := httptest.NewRequest("GET", "/v1/tracks/eYJyn/stream", nil)
 	res, err := app.Test(req, -1)
 	assert.NoError(t, err)
-	assert.Contains(t, res.Header.Get("Location"), "tracks/cidstream/?id3=false&id3_artist=&id3_title=Culca+Canyon&signature=%7B%22data%22%3A%22%7B%5C%22cid%5C%22%3A%5C%22%5C%22%2C%5C%22timestamp%5C%22%3")
+	assert.Contains(t, res.Header.Get("Location"), "tracks/cidstream/?id3=true&id3_artist=&id3_title=Culca+Canyon&signature=%7B%22data%22%3A%22%7B%5C%22cid%5C%22%3A%5C%22%5C%22%2C%5C%22timestamp%5C%22%3")
 }


### PR DESCRIPTION
to test:
run `make` against prod
hit this track on the local server https://api.audius.co/v1/tracks/ryJpOa9/stream
it will still stream but with ffprobe you also get the id3 tags back