### PR TITLE
Add v1/users/address to find user IDs by associated wallet or account addresses

### DIFF
--- a/api/server.go
+++ b/api/server.go
@@ -316,6 +316,7 @@ func NewApiServer(config config.Config) *ApiServer {
 	for _, g := range []fiber.Router{v1, v1Full} {
 		// Users
 		g.Get("/users", app.v1Users)
+		g.Get("/users/addresses", app.v1UserIdsByAddresses)
 		g.Get("/users/search", app.v1UsersSearch)
 		g.Get("/users/unclaimed_id", app.v1UsersUnclaimedId)
 		g.Get("/users/top", app.v1UsersTop)

--- a/api/server.go
+++ b/api/server.go
@@ -316,7 +316,7 @@ func NewApiServer(config config.Config) *ApiServer {
 	for _, g := range []fiber.Router{v1, v1Full} {
 		// Users
 		g.Get("/users", app.v1Users)
-		g.Get("/users/addresses", app.v1UserIdsByAddresses)
+		g.Get("/users/address", app.v1UserIdsByAddresses)
 		g.Get("/users/search", app.v1UsersSearch)
 		g.Get("/users/unclaimed_id", app.v1UsersUnclaimedId)
 		g.Get("/users/top", app.v1UsersTop)

--- a/api/swagger/swagger-v1.yaml
+++ b/api/swagger/swagger-v1.yaml
@@ -1698,6 +1698,33 @@ paths:
         "500":
           description: Server error
           content: {}
+  /users/address:
+    get:
+      tags:
+      - users
+      description: Gets User IDs from any Ethereum wallet address or Solana account address associated with their Audius account.
+      operationId: Get User IDs by Wallet Addresses
+      parameters:
+      - name: address
+        in: query
+        description: Wallet address
+        required: true
+        style: form
+        explode: true
+        example:
+          - "0x1234567890abcdef1234567890abcdef12345678"
+          - "E2LCbKdo2L3ikt1gK6pwp1pDLuhAfHBNf6fEQXpAqrf9"
+        schema:
+          type: array
+          items:
+            type: string
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/user_addresses_response'
   /users/handle/{handle}:
     get:
       tags:
@@ -4055,6 +4082,21 @@ components:
       properties:
         user_id:
           type: string
+    user_addresses_response:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            type: object
+            required:
+            - user_id
+            - address
+            properties:
+              user_id:
+                type: string
+              address:
+                type: string
     connected_wallets_response:
       type: object
       properties:

--- a/api/v1_users_addresses.go
+++ b/api/v1_users_addresses.go
@@ -1,0 +1,72 @@
+package api
+
+import (
+	"bridgerton.audius.co/trashid"
+	"github.com/gofiber/fiber/v2"
+	"github.com/jackc/pgx/v5"
+)
+
+type GetUserIdQueryParams struct {
+	Addresses []string `query:"address"`
+}
+
+func (app *ApiServer) v1UserIdsByAddresses(c *fiber.Ctx) error {
+	queryParams := GetUserIdQueryParams{}
+	if err := app.ParseAndValidateQueryParams(c, &queryParams); err != nil {
+		return err
+	}
+
+	sql := `
+		-- User account wallets
+		SELECT
+			users.user_id,
+			users.wallet AS address
+		FROM users
+		WHERE users.wallet = ANY(@addresses) 
+			AND users.is_deactivated = FALSE
+			AND users.is_current = TRUE
+
+		UNION
+
+		-- Associated wallets
+		SELECT 
+			associated_wallets.user_id,
+			associated_wallets.wallet AS address
+		FROM associated_wallets
+		WHERE associated_wallets.wallet = ANY(@addresses)
+			AND associated_wallets.is_current = TRUE
+			AND associated_wallets.is_delete = FALSE
+
+		UNION
+
+		-- User bank accounts
+		SELECT 
+			users.user_id, 
+			sol_claimable_accounts.account AS address	
+		FROM sol_claimable_accounts
+		JOIN users 
+			ON users.wallet = sol_claimable_accounts.ethereum_address
+		WHERE sol_claimable_accounts.account = ANY(@addresses)
+	;`
+
+	rows, err := app.pool.Query(c.Context(), sql, pgx.NamedArgs{
+		"addresses": queryParams.Addresses,
+	})
+	if err != nil {
+		return err
+	}
+
+	type addressRow struct {
+		UserId  trashid.HashId `db:"user_id" json:"user_id"`
+		Address string         `db:"address" json:"address"`
+	}
+
+	res, err := pgx.CollectRows(rows, pgx.RowToStructByName[addressRow])
+	if err != nil {
+		return err
+	}
+
+	return c.JSON(fiber.Map{
+		"data": res,
+	})
+}

--- a/api/v1_users_addresses.go
+++ b/api/v1_users_addresses.go
@@ -26,7 +26,7 @@ func (app *ApiServer) v1UserIdsByAddresses(c *fiber.Ctx) error {
 			AND users.is_deactivated = FALSE
 			AND users.is_current = TRUE
 
-		UNION
+		UNION ALL
 
 		-- Associated wallets
 		SELECT 
@@ -37,7 +37,7 @@ func (app *ApiServer) v1UserIdsByAddresses(c *fiber.Ctx) error {
 			AND associated_wallets.is_current = TRUE
 			AND associated_wallets.is_delete = FALSE
 
-		UNION
+		UNION ALL
 
 		-- User bank accounts
 		SELECT 

--- a/api/v1_users_addresses_test.go
+++ b/api/v1_users_addresses_test.go
@@ -1,0 +1,54 @@
+package api
+
+import (
+	"testing"
+
+	"bridgerton.audius.co/database"
+	"bridgerton.audius.co/trashid"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestV1UserIdsByAddresses(t *testing.T) {
+	app := emptyTestApp(t)
+
+	// Seed with users, associated_wallets, and sol_claimable_accounts
+	fixtures := database.FixtureMap{
+		"users": []map[string]any{
+			{"user_id": 1, "wallet": "0xabc"},
+			{"user_id": 2, "wallet": "0xdef"},
+		},
+		"associated_wallets": []map[string]any{
+			{"id": 1, "user_id": 1, "wallet": "0xaaa", "chain": "sol"},
+			{"id": 2, "user_id": 2, "wallet": "0xbbb", "chain": "sol"},
+		},
+		"sol_claimable_accounts": []map[string]any{
+			{"account": "sol_acc_1", "ethereum_address": "0xabc", "mint": "mint1", "signature": "sig1"},
+			{"account": "sol_acc_2", "ethereum_address": "0xdef", "mint": "mint2", "signature": "sig2"},
+		},
+	}
+	database.Seed(app.pool, fixtures)
+
+	{
+		// Query for all types of addresses
+		status, body := testGet(t, app, "/v1/users/address?address=0xabc&address=0xaaa&address=sol_acc_1")
+		assert.Equal(t, 200, status)
+
+		jsonAssert(t, body, map[string]any{
+			"data.#":         3,
+			"data.0.user_id": trashid.MustEncodeHashID(1),
+			"data.1.user_id": trashid.MustEncodeHashID(1),
+			"data.2.user_id": trashid.MustEncodeHashID(1),
+		})
+	}
+
+	{
+		// Query a single address
+		status, body := testGet(t, app, "/v1/users/address?address=0xbbb")
+		assert.Equal(t, 200, status)
+
+		jsonAssert(t, body, map[string]any{
+			"data.#":         1,
+			"data.0.user_id": trashid.MustEncodeHashID(2),
+		})
+	}
+}


### PR DESCRIPTION
Finds user IDs associated with given addresses of wallets or accounts.

This not only enables the Discord bot to do signature recovery and find the relevant account without needing us to change the authentication of the v1/users/account/:wallet route, but also allows for more general user locating based on associated addresses by any means besides just their account wallet, which opens the door to doing "1-click purchase" if a user buys with a connected wallet on a third party site, etc.

TODO:
- [ ] Add test
- [ ] Swagger