### PR TITLE
Only restart indexer if an artist coin was added or removed

### DIFF
--- a/solana/indexer/subscription.go
+++ b/solana/indexer/subscription.go
@@ -124,6 +124,10 @@ func (s *SolanaIndexer) Subscribe(ctx context.Context) error {
 					s.logger.Error("failed to unmarshal artist_coins changed notification", zap.Error(err))
 					continue
 				}
+				if notifData.Operation != "INSERT" && notifData.Operation != "DELETE" {
+					// ignore updates
+					continue
+				}
 				s.logger.Info("artist_coins changed, re-starting subscription",
 					zap.String("oldMint", notifData.OldMint),
 					zap.String("newMint", notifData.NewMint),


### PR DESCRIPTION
Don't restart indexer on updates, eg if the description or something else irrelevant changes.

Notably, this means updating the mint address will not restart the indexer. Delete and reinsert in order to change mint address.