### PR TITLE
Solana Indexer: Process messages in parallel

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -47,7 +47,7 @@ var Cfg = Config{
 	NetworkTakeRate:      10,
 	AudiusdURL:           os.Getenv("audiusdUrl"),
 	BirdeyeToken:         os.Getenv("birdeyeToken"),
-	SolanaIndexerWorkers: 20,
+	SolanaIndexerWorkers: 50,
 }
 
 func init() {

--- a/config/config.go
+++ b/config/config.go
@@ -10,42 +10,44 @@ import (
 )
 
 type Config struct {
-	Env                string
-	Git                string
-	LogLevel           string
-	ReadDbUrl          string
-	WriteDbUrl         string
-	RunMigrations      bool
-	EsUrl              string
-	Nodes              []Node
-	DeadNodes          []string
-	DelegatePrivateKey string
-	AxiomToken         string
-	AxiomDataset       string
-	PythonUpstreams    []string
-	NetworkTakeRate    float64
-	SolanaConfig       SolanaConfig
-	AntiAbuseOracles   []string
-	Rewards            []rewards.Reward
-	AudiusdURL         string
-	ChainId            string
-	BirdeyeToken       string
+	Env                  string
+	Git                  string
+	LogLevel             string
+	ReadDbUrl            string
+	WriteDbUrl           string
+	RunMigrations        bool
+	EsUrl                string
+	Nodes                []Node
+	DeadNodes            []string
+	DelegatePrivateKey   string
+	AxiomToken           string
+	AxiomDataset         string
+	PythonUpstreams      []string
+	NetworkTakeRate      float64
+	SolanaConfig         SolanaConfig
+	AntiAbuseOracles     []string
+	Rewards              []rewards.Reward
+	AudiusdURL           string
+	ChainId              string
+	BirdeyeToken         string
+	SolanaIndexerWorkers int
 }
 
 var Cfg = Config{
-	Git:                os.Getenv("GIT_SHA"),
-	Env:                os.Getenv("ENV"),
-	LogLevel:           os.Getenv("logLevel"),
-	ReadDbUrl:          os.Getenv("readDbUrl"),
-	WriteDbUrl:         os.Getenv("writeDbUrl"),
-	RunMigrations:      os.Getenv("runMigrations") == "true",
-	EsUrl:              os.Getenv("elasticsearchUrl"),
-	DelegatePrivateKey: os.Getenv("delegatePrivateKey"),
-	AxiomToken:         os.Getenv("axiomToken"),
-	AxiomDataset:       os.Getenv("axiomDataset"),
-	NetworkTakeRate:    10,
-	AudiusdURL:         os.Getenv("audiusdUrl"),
-	BirdeyeToken:       os.Getenv("birdeyeToken"),
+	Git:                  os.Getenv("GIT_SHA"),
+	Env:                  os.Getenv("ENV"),
+	LogLevel:             os.Getenv("logLevel"),
+	ReadDbUrl:            os.Getenv("readDbUrl"),
+	WriteDbUrl:           os.Getenv("writeDbUrl"),
+	RunMigrations:        os.Getenv("runMigrations") == "true",
+	EsUrl:                os.Getenv("elasticsearchUrl"),
+	DelegatePrivateKey:   os.Getenv("delegatePrivateKey"),
+	AxiomToken:           os.Getenv("axiomToken"),
+	AxiomDataset:         os.Getenv("axiomDataset"),
+	NetworkTakeRate:      10,
+	AudiusdURL:           os.Getenv("audiusdUrl"),
+	BirdeyeToken:         os.Getenv("birdeyeToken"),
+	SolanaIndexerWorkers: 20,
 }
 
 func init() {
@@ -66,6 +68,7 @@ func init() {
 		Cfg.Rewards = core_config.MakeRewards(core_config.DevClaimAuthorities, core_config.DevRewardExtensions)
 		Cfg.AudiusdURL = "http://audius-protocol-creator-node-1"
 		Cfg.ChainId = "audius-mainnet-alpha-beta"
+		Cfg.SolanaIndexerWorkers = 1
 	case "stage":
 		fallthrough
 	case "staging":

--- a/solana/indexer/checkpoints.go
+++ b/solana/indexer/checkpoints.go
@@ -77,7 +77,8 @@ func updateCheckpoint(ctx context.Context, db database.DBTX, id string, slot uin
 			UPDATE sol_slot_checkpoints
 			SET to_slot = @to_slot,
 				updated_at = NOW()
-			WHERE id = @id;
+			WHERE id = @id
+				AND to_slot < @to_slot;
 		`, pgx.NamedArgs{
 		"to_slot": slot,
 		"id":      id,

--- a/solana/indexer/processor.go
+++ b/solana/indexer/processor.go
@@ -108,12 +108,6 @@ func (p *DefaultProcessor) ProcessTransaction(
 	blockTime time.Time,
 	logger *zap.Logger,
 ) error {
-	sqlTx, err := p.pool.Begin(ctx)
-	if err != nil {
-		return fmt.Errorf("failed to begin sql transaction: %w", err)
-	}
-	defer sqlTx.Rollback(ctx)
-
 	if tx == nil {
 		return fmt.Errorf("no transaction to process")
 	}
@@ -147,7 +141,7 @@ func (p *DefaultProcessor) ProcessTransaction(
 
 	signature := tx.Signatures[0].String()
 
-	err = processBalanceChanges(ctx, p.pool, slot, meta, tx, blockTime, txLogger)
+	err := processBalanceChanges(ctx, p.pool, slot, meta, tx, blockTime, txLogger)
 	if err != nil {
 		return fmt.Errorf("failed to process balance changes: %w", err)
 	}
@@ -183,10 +177,6 @@ func (p *DefaultProcessor) ProcessTransaction(
 		}
 	}
 
-	err = sqlTx.Commit(ctx)
-	if err != nil {
-		return fmt.Errorf("failed to commit sql transaction: %w", err)
-	}
 	return nil
 }
 

--- a/solana/indexer/solana_indexer.go
+++ b/solana/indexer/solana_indexer.go
@@ -70,7 +70,7 @@ func New(config config.Config) *SolanaIndexer {
 	// The min write pool size is set to 2x the number of workers
 	// plus 1 for the connection that listens for artist_coins changes.
 	workerCount := int32(config.SolanaIndexerWorkers)
-	connConfig.MaxConns = workerCount*2 + 1
+	connConfig.MaxConns = max(workerCount*2+1, 10)
 
 	pool, err := pgxpool.NewWithConfig(context.Background(), connConfig)
 	if err != nil {

--- a/solana/indexer/solana_indexer.go
+++ b/solana/indexer/solana_indexer.go
@@ -46,8 +46,9 @@ type SolanaIndexer struct {
 	grpcClient GrpcClient
 	processor  Processor
 
-	config config.Config
-	pool   DbPool
+	config      config.Config
+	pool        DbPool
+	workerCount int32
 
 	checkpointId string
 
@@ -66,6 +67,11 @@ func New(config config.Config) *SolanaIndexer {
 		panic(fmt.Errorf("error parsing database URL: %w", err))
 	}
 
+	// The min write pool size is set to 2x the number of workers
+	// plus 1 for the connection that listens for artist_coins changes.
+	workerCount := int32(config.SolanaIndexerWorkers)
+	connConfig.MaxConns = workerCount*2 + 1
+
 	pool, err := pgxpool.NewWithConfig(context.Background(), connConfig)
 	if err != nil {
 		panic(fmt.Errorf("error connecting to database: %w", err))
@@ -78,11 +84,12 @@ func New(config config.Config) *SolanaIndexer {
 	})
 
 	s := &SolanaIndexer{
-		rpcClient:  rpcClient,
-		grpcClient: grpcClient,
-		logger:     logger,
-		config:     config,
-		pool:       pool,
+		rpcClient:   rpcClient,
+		grpcClient:  grpcClient,
+		logger:      logger,
+		config:      config,
+		pool:        pool,
+		workerCount: workerCount,
 		processor: NewDefaultProcessor(
 			rpcClient,
 			pool,

--- a/solana/indexer/solana_indexer.go
+++ b/solana/indexer/solana_indexer.go
@@ -67,10 +67,11 @@ func New(config config.Config) *SolanaIndexer {
 		panic(fmt.Errorf("error parsing database URL: %w", err))
 	}
 
-	// The min write pool size is set to 2x the number of workers
-	// plus 1 for the connection that listens for artist_coins changes.
+	// The min write pool size is set to the number of workers
+	// plus 1 for the connection that listens for artist_coins changes,
+	// and add 10 as a buffer.
 	workerCount := int32(config.SolanaIndexerWorkers)
-	connConfig.MaxConns = max(workerCount*2+1, 10)
+	connConfig.MaxConns = workerCount + 1 + 10
 
 	pool, err := pgxpool.NewWithConfig(context.Background(), connConfig)
 	if err != nil {

--- a/solana/indexer/subscription.go
+++ b/solana/indexer/subscription.go
@@ -24,7 +24,31 @@ type artistCoinsChangedNotification struct {
 }
 
 func (s *SolanaIndexer) Subscribe(ctx context.Context) error {
+	// Set up workers to process updates concurrently
+	msgChan := make(chan *pb.SubscribeUpdate, 3000)
+	for i := range s.workerCount {
+		go func(workerId int32) {
+			for msg := range msgChan {
+				s.handleMessage(ctx, msg)
+			}
+		}(i)
+	}
+	defer close(msgChan)
+
+	// On a new message, queue the message to the worker pool
+	onMessage := func(ctx context.Context, msg *pb.SubscribeUpdate) {
+		select {
+		case <-ctx.Done():
+			s.logger.Warn("subscription context cancelled, stopping message processing")
+			return
+		case msgChan <- msg:
+		}
+	}
+
+	// Flush the logger every 15 seconds to ensure logs are written out
 	go logging.SyncOnTicks(ctx, s.logger, time.Second*15)
+
+	// Acquire a connection to the database and listen for artist coins changes
 	conn, err := s.pool.Acquire(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to acquire database connection: %w", err)
@@ -37,10 +61,12 @@ func (s *SolanaIndexer) Subscribe(ctx context.Context) error {
 		return fmt.Errorf("failed to listen for artist coins changes: %w", err)
 	}
 
+	// Log when we receive a shutdown signal
 	defer func() {
 		s.logger.Info("received shutdown signal, stopping subscription")
 	}()
 
+	// Loop to reset subscription when the artist coins notification is received
 	for {
 		select {
 		case <-ctx.Done():
@@ -57,6 +83,9 @@ func (s *SolanaIndexer) Subscribe(ctx context.Context) error {
 		if err != nil {
 			return fmt.Errorf("failed to create subscription: %w", err)
 		}
+
+		// Check if a backfill is needed with the new subscription
+		// and find the slot to continue from.
 
 		lastIndexedSlot, err := getCheckpointSlot(ctx, s.pool, subscription)
 		if err != nil {
@@ -101,7 +130,8 @@ func (s *SolanaIndexer) Subscribe(ctx context.Context) error {
 
 		subCtx, cancel := context.WithCancel(ctx)
 		defer cancel()
-		if err := s.grpcClient.Subscribe(subCtx, subscription, s.onMessage, s.onError); err != nil {
+
+		if err := s.grpcClient.Subscribe(subCtx, subscription, onMessage, s.onError); err != nil {
 			return fmt.Errorf("failed to subscribe to gRPC server: %w", err)
 		}
 
@@ -125,7 +155,7 @@ func (s *SolanaIndexer) Subscribe(ctx context.Context) error {
 					continue
 				}
 				if notifData.Operation != "INSERT" && notifData.Operation != "DELETE" {
-					// ignore updates
+					// ignore updates - only care if mints are added or removed
 					continue
 				}
 				s.logger.Info("artist_coins changed, re-starting subscription",
@@ -197,13 +227,17 @@ func buildSubscriptionRequest(mintAddresses []string) (*pb.SubscribeRequest, err
 }
 
 // Handles a message from the gRPC subscription.
-func (s *SolanaIndexer) onMessage(ctx context.Context, msg *pb.SubscribeUpdate) {
+func (s *SolanaIndexer) handleMessage(ctx context.Context, msg *pb.SubscribeUpdate) {
 	logger := s.logger.With(zap.String("indexerSource", "grpc"))
 
 	if slotUpdate := msg.GetSlot(); slotUpdate != nil && slotUpdate.Slot > 0 {
-		err := updateCheckpoint(ctx, s.pool, s.checkpointId, slotUpdate.Slot)
-		if err != nil {
-			logger.Error("failed to update slot checkpoint", zap.Error(err))
+		// only update every 10 slots to reduce db load and write latency
+		if slotUpdate.Slot%10 == 0 {
+			s.logger.Debug("slot update", zap.Uint64("slot", slotUpdate.Slot))
+			err := updateCheckpoint(ctx, s.pool, s.checkpointId, slotUpdate.Slot)
+			if err != nil {
+				logger.Error("failed to update slot checkpoint", zap.Error(err))
+			}
 		}
 	}
 
@@ -215,7 +249,6 @@ func (s *SolanaIndexer) onMessage(ctx context.Context, msg *pb.SubscribeUpdate) 
 			logger.Error("failed to process signature", zap.Error(err))
 		}
 	}
-
 }
 
 func (s *SolanaIndexer) onError(err error) {


### PR DESCRIPTION
- Adds parallelism to solana-indexer.
  - Defaults to 50 workers for stage and prod and 1 for local
  - Tested with 50 workers locally and indexed USDC, wAUDIO, BONK, WEN and was able to catch up from behind 3000 slots. Was seeing numbers of around 50k account balance changes indexed per minute with this many workers. We'll see how our cloud sql db handles this - can always tune the worker count - but this should give us plenty of headroom I think.
- Reduces slot checkpoint writes to every 10 slots and only if the slot is greater than the current one to help reduce load.
- Bails early in processing if found signature in the cache, as it's already processed then.
- Removes sql transaction that wasn't doing anything since it wasn't wired up properly. (Fixing the code to use it causes deadlocks as the concurrency causes the inserts to compete for locks on tables I guess?)