### PR TITLE
SolanaIndexer: Adds deadletter queue

### DIFF
--- a/ddl/migrations/0156_sol_unprocessed_txs.sql
+++ b/ddl/migrations/0156_sol_unprocessed_txs.sql
@@ -1,0 +1,6 @@
+CREATE TABLE IF NOT EXISTS sol_unprocessed_txs (
+    signature TEXT NOT NULL PRIMARY KEY,
+    error_message TEXT,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);

--- a/main.go
+++ b/main.go
@@ -64,7 +64,7 @@ func main() {
 			ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM, syscall.SIGINT, os.Interrupt)
 			defer stop()
 
-			if err := solanaIndexer.Subscribe(ctx); err != nil {
+			if err := solanaIndexer.Start(ctx); err != nil {
 				if !errors.Is(err, context.Canceled) {
 					panic(err)
 				}

--- a/solana/indexer/processor_test.go
+++ b/solana/indexer/processor_test.go
@@ -753,6 +753,6 @@ func TestProcessSignature_HandlesLoadedAddresses(t *testing.T) {
 	row := pool.QueryRow(t.Context(), "SELECT EXISTS (SELECT 1 FROM sol_reward_disbursements WHERE signature = $1)", "58sUxCqs2sbErrZhH1A1YcFrYpK35Ph2AHpySxkCcRkeer1bJmfyCRKxQ7qeR26AA1qEnDb58KJwviDJXGqkAStQ")
 	var exists bool
 	row.Scan(&exists)
-	// Temp disable until next pr
-	// require.True(t, exists, "expected reward disbursement to exist")
+
+	require.True(t, exists, "expected reward disbursement to exist")
 }

--- a/solana/indexer/solana_indexer.go
+++ b/solana/indexer/solana_indexer.go
@@ -101,6 +101,18 @@ func New(config config.Config) *SolanaIndexer {
 	return s
 }
 
+func (s *SolanaIndexer) Start(ctx context.Context) error {
+	err := s.RetryUnprocessedTransactions(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to process unprocessed transactions: %w", err)
+	}
+	err = s.Subscribe(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to subscribe: %w", err)
+	}
+	return nil
+}
+
 func (s *SolanaIndexer) Close() {
 	if p, ok := s.processor.(*DefaultProcessor); ok {
 		p.ReportCacheStats(s.logger)

--- a/solana/indexer/subscription.go
+++ b/solana/indexer/subscription.go
@@ -247,6 +247,9 @@ func (s *SolanaIndexer) handleMessage(ctx context.Context, msg *pb.SubscribeUpda
 		err := s.processor.ProcessSignature(ctx, accUpdate.Slot, txSig, logger)
 		if err != nil {
 			logger.Error("failed to process signature", zap.Error(err))
+			if insertErr := insertUnprocessedTransaction(ctx, s.pool, txSig.String(), err.Error()); insertErr != nil {
+				logger.Error("failed to insert unprocessed transaction", zap.Error(insertErr))
+			}
 		}
 	}
 }

--- a/solana/indexer/unprocessed_transactions.go
+++ b/solana/indexer/unprocessed_transactions.go
@@ -1,0 +1,85 @@
+package indexer
+
+import (
+	"context"
+	"fmt"
+
+	"bridgerton.audius.co/database"
+	"github.com/gagliardetto/solana-go"
+	"github.com/jackc/pgx/v5"
+	"go.uber.org/zap"
+)
+
+func (s *SolanaIndexer) RetryUnprocessedTransactions(ctx context.Context) error {
+	limit := 100
+	offset := 0
+	logger := s.logger.With(
+		zap.String("indexerSource", "retryUnprocessedTransactions"),
+	)
+	for {
+		failedTxs, err := getUnprocessedTransactions(ctx, s.pool, limit, offset)
+		if err != nil {
+			return fmt.Errorf("failed to fetch unprocessed transactions: %w", err)
+		}
+		if len(failedTxs) == 0 {
+			break
+		}
+
+		for _, txSig := range failedTxs {
+			err = s.processor.ProcessSignature(ctx, 0, solana.MustSignatureFromBase58(txSig), logger)
+			if err != nil {
+				logger.Error("failed to process transaction", zap.String("signature", txSig), zap.Error(err))
+				offset++
+				continue
+			}
+			logger.Info("successfully processed transaction", zap.String("signature", txSig))
+			deleteUnprocessedTransaction(ctx, s.pool, txSig)
+		}
+	}
+	return nil
+}
+
+func getUnprocessedTransactions(ctx context.Context, db database.DBTX, limit, offset int) ([]string, error) {
+	sql := `SELECT signature FROM sol_unprocessed_txs LIMIT @limit OFFSET @offset;`
+	rows, err := db.Query(ctx, sql, pgx.NamedArgs{
+		"limit":  limit,
+		"offset": offset,
+	})
+	if err != nil {
+		if err == pgx.ErrNoRows {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to query unprocessed transactions: %w", err)
+	}
+	signatures, err := pgx.CollectRows(rows, pgx.RowTo[string])
+	if err != nil {
+		return nil, fmt.Errorf("failed to collect unprocessed transaction signatures: %w", err)
+	}
+	return signatures, nil
+}
+
+func insertUnprocessedTransaction(ctx context.Context, db database.DBTX, signature, errorMessage string) error {
+	sql := `
+		INSERT INTO sol_unprocessed_txs (signature, error_message) VALUES (@signature, @error_message) 
+		ON CONFLICT (signature) DO UPDATE SET error_message = @error_message, updated_at = NOW()
+	;`
+	_, err := db.Exec(ctx, sql, pgx.NamedArgs{
+		"signature":     signature,
+		"error_message": errorMessage,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to insert unprocessed transaction: %w", err)
+	}
+	return nil
+}
+
+func deleteUnprocessedTransaction(ctx context.Context, db database.DBTX, signature string) error {
+	sql := `DELETE FROM sol_unprocessed_txs WHERE signature = @signature;`
+	_, err := db.Exec(ctx, sql, pgx.NamedArgs{
+		"signature": signature,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to delete unprocessed transaction: %w", err)
+	}
+	return nil
+}

--- a/solana/indexer/unprocessed_transactions_test.go
+++ b/solana/indexer/unprocessed_transactions_test.go
@@ -1,0 +1,85 @@
+package indexer
+
+import (
+	"errors"
+	"strconv"
+	"testing"
+
+	"bridgerton.audius.co/database"
+	"github.com/gagliardetto/solana-go"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"github.com/test-go/testify/assert"
+	"go.uber.org/zap"
+)
+
+func TestUnprocessedTransactions(t *testing.T) {
+	ctx := t.Context()
+	pool := database.CreateTestDatabase(t, "test_solana_indexer")
+	defer pool.Close()
+
+	// Insert a test unprocessed transaction
+	signature := "test_signature"
+	errorMessage := "test error message"
+	err := insertUnprocessedTransaction(ctx, pool, signature, errorMessage)
+	require.NoError(t, err)
+
+	// Verify the transaction was inserted
+	res, err := getUnprocessedTransactions(ctx, pool, 10, 0)
+	require.NoError(t, err)
+	assert.Len(t, res, 1)
+	assert.Equal(t, signature, res[0])
+
+	// Delete the unprocessed transaction
+	err = deleteUnprocessedTransaction(ctx, pool, signature)
+	require.NoError(t, err)
+
+	// Verify the transaction was deleted
+	res, err = getUnprocessedTransactions(ctx, pool, 10, 0)
+	require.NoError(t, err)
+	assert.Len(t, res, 0)
+}
+
+func TestRetryUnprocessedTransactions(t *testing.T) {
+	ctx := t.Context()
+	pool := database.CreateTestDatabase(t, "test_solana_indexer")
+	defer pool.Close()
+
+	unprocessedTransactionsCount := 543
+	processor := &mockProcessor{}
+
+	var failingSigBytes [64]byte
+	copy(failingSigBytes[:], []byte("test_signature_73"))
+	failingSig := solana.SignatureFromBytes(failingSigBytes[:])
+
+	// Mock the processor to fail on a specific signature
+	processor.On("ProcessSignature", ctx, mock.Anything, failingSig, mock.Anything).
+		Return(errors.New("fake failure")).Times(1)
+
+	// Everything else should succeed
+	processor.On("ProcessSignature", ctx, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(nil).Times(unprocessedTransactionsCount - 1)
+
+	s := &SolanaIndexer{
+		processor: processor,
+		pool:      pool,
+		logger:    zap.NewNop(),
+	}
+
+	for i := range unprocessedTransactionsCount {
+		var sigBytes [64]byte
+		copy(sigBytes[:], []byte("test_signature_"+strconv.FormatInt(int64(i), 10)))
+		signature := solana.SignatureFromBytes(sigBytes[:])
+		insertUnprocessedTransaction(ctx, pool, signature.String(), "test error message")
+	}
+
+	err := s.RetryUnprocessedTransactions(ctx)
+	require.NoError(t, err)
+	processor.AssertNumberOfCalls(t, "ProcessSignature", unprocessedTransactionsCount)
+
+	// Verify all transactions but #73 were processed
+	unprocessedTxs, err := getUnprocessedTransactions(ctx, pool, 100, 0)
+	require.NoError(t, err)
+	assert.Len(t, unprocessedTxs, 1, "expected a single unprocessed transaction after retry")
+	assert.Equal(t, failingSig.String(), unprocessedTxs[0], "expected the failing transaction to remain unprocessed")
+}


### PR DESCRIPTION
- Adds new `sol_unprocessed_txs` table to hold transaction signatures that failed to process
- Adds `UnprocessedCount` to health check for solana indexer, and sets the max to 10
- Updates max slot diff to 100 for the health check (was 200)
- Updates `Subscribe` to handle processor failures and stick failing signatures in the deadletter queue
- Adds `Start` method to `SolanaIndexer` to wrap `Subscribe` and `RetryUnprocessedTransactions`
- Retries unprocessed transactions on startup
- Lots of tests
  - Ensure db methods can CRD
  - Ensure failed messages from the subscription are put into DB
  - Ensure RetryUnprocessedTransactions processes them all