### PR TITLE
[API-135] Fix various notification issues

### DIFF
--- a/api/swagger/swagger-v1-full.yaml
+++ b/api/swagger/swagger-v1-full.yaml
@@ -242,7 +242,7 @@ paths:
         description: The number of notifications to return
         schema:
           type: integer
-      - name: valid_types
+      - name: types
         in: query
         description: Additional valid notification types to return
         style: form
@@ -295,26 +295,6 @@ paths:
             - artist_remix_contest_ended
             - artist_remix_contest_ending_soon
             - artist_remix_contest_submissions
-          default: [
-                "repost",
-                "save",
-                "follow",
-                "tip_send",
-                "tip_receive",
-                "milestone",
-                "supporter_rank_up",
-                "supporting_rank_up",
-                "challenge_reward",
-                "tier_change",
-                "create",
-                "remix",
-                "cosign",
-                "trending",
-                "supporter_dethroned",
-                "announcement",
-                "reaction",
-                "track_added_to_playlist"
-              ]
       responses:
         "200":
           description: Success


### PR DESCRIPTION
Commits can be reviewed separately if you'd like.

3 Changes:

1. Fix bug in seen_at grouping from previous implementation in https://github.com/AudiusProject/api/pull/287. Currently with the checked in code, we are not grouping unread messages. Add some comments in the sql to make this more obvious to future readers

2. Always return all notification types (change the param from validTypes to types in future to prevent regression). Protocol PR here: https://github.com/AudiusProject/audius-protocol/pull/12669

3. Filter out notifications for deleted tracks / playlists (API-135) from a few months ago, which we said we could patch in the new bridge impl when that shipped.