### PR TITLE
Boost exact title matches for users

### DIFF
--- a/api/searchv1/user_search.go
+++ b/api/searchv1/user_search.go
@@ -32,7 +32,7 @@ func (q *UserSearchQuery) Map() map[string]any {
 		builder.Should(
 			esquery.MultiMatch().Query(q.Query).
 				Fields("name", "handle").
-				Boost(10).
+				Boost(1000).
 				Operator(esquery.OperatorAnd),
 		)
 

--- a/esindexer/reindex.go
+++ b/esindexer/reindex.go
@@ -17,7 +17,7 @@ import (
 )
 
 func mustDialPostgres() *pgxpool.Pool {
-	connConfig, err := pgxpool.ParseConfig(config.Cfg.WriteDbUrl)
+	connConfig, err := pgxpool.ParseConfig(config.Cfg.ReadDbUrl)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
Socials were getting a 1000 boost, which pushes them way past exact matches for title/handle. I matched that boost here. I also used the readDbUrl instead of write for the elastic search instance since we don't write to the DB in the es-indexer, and I didn't want to accidentally write something when doing this work against prod

Before:
```
await fetch('http://api.audius.co/v1/users/search?query=mia maya').then(r => r.json()).then(r => r.data.map(u => u.handle))
(10) ['elayarson', 'MAiWORLD', 'mayaa', 'mizterbonezzmusic', 'mayasmusic', 'meagmakesmusic', 'Lia', 'mayasurmusic', 'dayag', 'jayark']
```

After:
```
await fetch('http://localhost:1323/v1/users/search?query=mia maya').then(r => r.json()).then(r => r.data.map(u => u.handle))
(10) ['dj_mia_maya', 'elayarson', 'MAiWORLD', 'mayaa', 'mizterbonezzmusic', 'mayasmusic', 'meagmakesmusic', 'Lia', 'mayasurmusic', 'dayag']
```