### PR TITLE
Re-land "[API-306] Filter deactivated tracks on recommended (#314)"

### DIFF
--- a/api/v1_tracks_most_shared.go
+++ b/api/v1_tracks_most_shared.go
@@ -43,11 +43,13 @@ func (app *ApiServer) v1TracksMostShared(c *fiber.Ctx) error {
 		SELECT t.track_id
 		FROM most_shared ms
 		JOIN tracks t ON ms.share_item_id = t.track_id
+		JOIN users u ON t.owner_id = u.user_id
 		WHERE
 			t.is_current = true AND
 			t.is_unlisted = false AND
 			t.is_available = true AND
-			t.is_delete = false
+			t.is_delete = false AND
+			u.is_deactivated = false
 		LIMIT @limit
 		OFFSET @offset;
 		`

--- a/api/v1_users_recommended_tracks.go
+++ b/api/v1_users_recommended_tracks.go
@@ -72,10 +72,12 @@ func (app *ApiServer) v1UsersRecommendedTracks(c *fiber.Ctx) error {
 		SELECT t.track_id
 		FROM top_tracks_per_genre
 		JOIN tracks t ON top_tracks_per_genre.track_id = t.track_id
+		JOIN users u ON t.owner_id = u.user_id
 		WHERE
 			t.is_unlisted = false
 			AND t.is_current = true
 			AND t.is_delete = false
+			AND u.is_deactivated = false
 		ORDER BY random()
 		LIMIT 10
 	`


### PR DESCRIPTION
Re-land w/o segment removal

the SDK & FE depend on segments here
[https://github.com/AudiusProject/audius-protocol/blob/3554bb24ffce274da24861e556c0[…]743/packages/sdk/src/sdk/api/generated/full/models/TrackFull.ts](https://github.com/AudiusProject/audius-protocol/blob/3554bb24ffce274da24861e556c0b5cd16b2a743/packages/sdk/src/sdk/api/generated/full/models/TrackFull.ts#L686)
and
https://github.com/AudiusProject/audius-protocol/blob/3554bb24ffce274da24861e556c0b5cd16b2a743/packages/common/src/adapters/track.ts#L112
and then on packages/web here
https://github.com/AudiusProject/audius-protocol/blob/3554bb24ffce274da24861e556c0b5cd16b2a743/packages/web/src/common/store/player/sagas.ts#L152