### PR TITLE
Don't use "latest" for arch dependent builds for simplicity

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,15 +28,14 @@ jobs:
         with:
           images: audius/api
           tags: |
-            type=raw,value=latest-amd64,enable=${{ github.ref == 'refs/heads/main' }}
-            type=sha,prefix=
+            type=sha,prefix=,suffix=-amd64
 
       - name: Build and push
         uses: docker/build-push-action@v5
         with:
           context: .
           push: true
-          tags: ${{ steps.meta.outputs.tags }}-amd64
+          tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=registry,ref=audius/api:buildcache-amd64
           cache-to: type=registry,ref=audius/api:buildcache-amd64,mode=max
@@ -67,15 +66,14 @@ jobs:
         with:
           images: audius/api
           tags: |
-            type=raw,value=latest-arm64,enable=${{ github.ref == 'refs/heads/main' }}
-            type=sha,prefix=
+            type=sha,prefix=,suffix=-arm64
 
       - name: Build and push
         uses: docker/build-push-action@v5
         with:
           context: .
           push: true
-          tags: ${{ steps.meta.outputs.tags }}-arm64
+          tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=registry,ref=audius/api:buildcache-arm64
           cache-to: type=registry,ref=audius/api:buildcache-arm64,mode=max
@@ -107,11 +105,19 @@ jobs:
             type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
             type=sha,prefix=
 
+      - name: Extract arch builds metadata for Docker
+        id: arch-meta
+        uses: docker/metadata-action@v5
+        with:
+          images: audius/api
+          tags: |
+            type=sha,prefix=,suffix=-amd64
+            type=sha,prefix=,suffix=-arm64
+
       - name: Create and push Docker manifest
         run: |
           docker buildx imagetools create --tag ${{ steps.meta.outputs.tags }} \
-            ${{ steps.meta.outputs.tags }}-amd64 \
-            ${{ steps.meta.outputs.tags }}-arm64
+            ${{ steps.arch-meta.outputs.tags }}
 
       - name: Get short SHA for release
         if: github.ref == 'refs/heads/main'


### PR DESCRIPTION
In main, the builds were doing both "latest" and sha-based tags on each arch image, then trying to combine all four together into the "latest" and sha-based tag for the combined manifest.

This PR splits it out so that the arch dependent builds are just sha based, and an extra metadata extraction step gets their tags instead of sharing the one for the outputs in the merge phase.