### PR TITLE
Fix multi-tag output on main

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,6 +28,7 @@ jobs:
         with:
           images: audius/api
           tags: |
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }},suffix=-amd64
             type=sha,prefix=,suffix=-amd64
 
       - name: Build and push
@@ -66,6 +67,7 @@ jobs:
         with:
           images: audius/api
           tags: |
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }},suffix=-arm64
             type=sha,prefix=,suffix=-arm64
 
       - name: Build and push
@@ -116,8 +118,11 @@ jobs:
 
       - name: Create and push Docker manifest
         run: |
-          docker buildx imagetools create --tag ${{ steps.meta.outputs.tags }} \
-            ${{ steps.arch-meta.outputs.tags }}
+            TAG_ARGS=""
+            for tag in ${{ steps.meta.outputs.tags }}; do
+              TAG_ARGS="$TAG_ARGS --tag $tag"
+            done
+            docker buildx imagetools create $TAG_ARGS ${{ steps.arch-meta.outputs.tags }}
 
       - name: Get short SHA for release
         if: github.ref == 'refs/heads/main'


### PR DESCRIPTION
The output of the meta step produced a space delimited list of tags. One of those was being used as an _input_ due to the space. This updates this to add each as a separate tag arg.

Also reintroduces platform specific latest images.