### PR TITLE
Add userId param to listening history endpoints

### DIFF
--- a/api/swagger/swagger-v1-full.yaml
+++ b/api/swagger/swagger-v1-full.yaml
@@ -3283,6 +3283,11 @@ paths:
           enum:
           - asc
           - desc
+      - name: user_id
+        in: query
+        description: The user ID of the user making the request
+        schema:
+          type: string
       - name: Encoded-Data-Message
         in: header
         description: The data that was signed by the user for signature recovery

--- a/api/swagger/swagger-v1.yaml
+++ b/api/swagger/swagger-v1.yaml
@@ -2471,6 +2471,11 @@ paths:
           enum:
           - asc
           - desc
+      - name: user_id
+        in: query
+        description: The user ID of the user making the request
+        schema:
+          type: string
       - name: Encoded-Data-Message
         in: header
         description: The data that was signed by the user for signature recovery
@@ -5419,7 +5424,7 @@ components:
           example: 1.23
         accounts:
           type: array
-          items:            
+          items:
             $ref: '#/components/schemas/user_coin_account'
     user_coin_account:
       type: object


### PR DESCRIPTION
This is used by the endpoint code to personalize results, but it's not in the swagger spec and is thus missing from SDK.