### PR TITLE
Remove missing fields from notifications swagger

### DIFF
--- a/api/swagger/swagger-v1-full.yaml
+++ b/api/swagger/swagger-v1-full.yaml
@@ -8768,14 +8768,11 @@ components:
       required:
       - parent_track_id
       - track_id
-      - track_owner_id
       type: object
       properties:
         parent_track_id:
           type: string
         track_id:
-          type: string
-        track_owner_id:
           type: string
     cosign_notification:
       required:
@@ -8816,14 +8813,11 @@ components:
     cosign_notification_action_data:
       required:
       - parent_track_id
-      - parent_track_owner_id
       - track_id
       - track_owner_id
       type: object
       properties:
         parent_track_id:
-          type: string
-        parent_track_owner_id:
           type: string
         track_id:
           type: string


### PR DESCRIPTION
The remix `track_owner_id` and cosign `parent_track_owner_id` are derived from the `specifier` on DN rather than coming from the action data. Remove these so that we can update sdk and find breaking usages, as we don't have these in the new endpoint.