### PR TITLE
[API-290][API-311] Stub out deprecated comms RPC endpoints

### DIFF
--- a/api/comms_rpc_stubs.go
+++ b/api/comms_rpc_stubs.go
@@ -1,0 +1,13 @@
+package api
+
+import "github.com/gofiber/fiber/v2"
+
+func (app *ApiServer) getRpcBulkStub(c *fiber.Ctx) error {
+	app.logger.Warn("Received unexpected request to stubbed endpoint /rpc/bulk")
+	return c.JSON([]any{})
+}
+
+func (app *ApiServer) postRpcReceiveStub(c *fiber.Ctx) error {
+	app.logger.Warn("Received unexpected request to stubbed endpoint /rpc/receive")
+	return c.SendString("OK")
+}

--- a/api/server.go
+++ b/api/server.go
@@ -511,6 +511,10 @@ func NewApiServer(config config.Config) *ApiServer {
 
 	comms.Post("/mutate", app.mutateChat)
 
+	// These are stubbed in case they are called and will log warnings
+	comms.Get("/rpc/bulk", app.getRpcBulkStub)
+	comms.Post("/rpc/receive", app.postRpcReceiveStub)
+
 	// Block confirmation
 	app.Get("/block_confirmation", app.BlockConfirmation)
 	app.Get("/block-confirmation", app.BlockConfirmation)


### PR DESCRIPTION
We aren't doing peering in the bridge implementation of comms, so these aren't needed.
However, for the initial implementation, I think it's a good idea to implement them to maintain backwards compatibility. They will return empty responses and log warnings if called so that we can track down any bad routing that happens.