### PR TITLE
[API-205][QA-2309] Limit trending playlists track fetching to 5 items

### DIFF
--- a/api/dbv1/full_playlists.go
+++ b/api/dbv1/full_playlists.go
@@ -11,6 +11,7 @@ import (
 type FullPlaylistsParams struct {
 	GetPlaylistsParams
 	OmitTracks bool
+	TrackLimit int // 0 means use default (200), positive values set the limit
 }
 
 type FullPlaylist struct {
@@ -50,11 +51,15 @@ func (q *Queries) FullPlaylistsKeyed(ctx context.Context, arg FullPlaylistsParam
 		userIds[idx] = p.PlaylistOwnerID
 
 		if !arg.OmitTracks {
+			trackLimit := 200
+			if arg.TrackLimit != 0 {
+				trackLimit = arg.TrackLimit
+			}
 			// some playlists have over a thousand tracks which causes slow load times,
 			// so we limit the track hydration here to prevent bad experience.
 			trackStubs := p.PlaylistContents.TrackIDs
-			if len(trackStubs) > 200 {
-				trackStubs = trackStubs[:200]
+			if len(trackStubs) > trackLimit {
+				trackStubs = trackStubs[:trackLimit]
 			}
 			for _, t := range trackStubs {
 				trackIds = append(trackIds, int32(t.Track))

--- a/api/dbv1/full_playlists.go
+++ b/api/dbv1/full_playlists.go
@@ -130,7 +130,7 @@ func (q *Queries) FullPlaylistsKeyed(ctx context.Context, arg FullPlaylistsParam
 			User:              user,
 			UserID:            user.ID,
 			Tracks:            tracks,
-			TrackCount:        int32(len(tracks)),
+			TrackCount:        int32(len(playlist.PlaylistContents.TrackIDs)),
 			FolloweeFavorites: fullFolloweeFavorites(playlist.FolloweeFavorites),
 			FolloweeReposts:   fullFolloweeReposts(playlist.FolloweeReposts),
 			PlaylistContents:  fullPlaylistContents,

--- a/api/v1_playlists_trending.go
+++ b/api/v1_playlists_trending.go
@@ -112,6 +112,8 @@ func (app *ApiServer) v1PlaylistsTrending(c *fiber.Ctx) error {
 			MyID: myId,
 		},
 		OmitTracks: params.OmitTracks,
+		// Limit these to 5 items to prevent slow load times
+		TrackLimit: 5,
 	})
 	if err != nil {
 		return err

--- a/api/v1_playlists_trending_test.go
+++ b/api/v1_playlists_trending_test.go
@@ -197,7 +197,8 @@ func TestGetTrendingPlaylistsTrackLimit(t *testing.T) {
 		"data.#": 1,
 	})
 	jsonAssert(t, body, map[string]any{
-		"data.0.tracks.#": 5,
+		"data.0.tracks.#":    5,
+		"data.0.track_count": 6,
 	})
 }
 

--- a/api/v1_playlists_trending_test.go
+++ b/api/v1_playlists_trending_test.go
@@ -107,6 +107,100 @@ func TestGetTrendingPlaylists(t *testing.T) {
 	})
 }
 
+func TestGetTrendingPlaylistsTrackLimit(t *testing.T) {
+	app := emptyTestApp(t)
+
+	fixtures := database.FixtureMap{
+		"playlists":                []map[string]any{},
+		"tracks":                   []map[string]any{},
+		"playlist_tracks":          []map[string]any{},
+		"playlist_trending_scores": []map[string]any{},
+		"users":                    []map[string]any{},
+	}
+	// Make sure we have enough unique owners
+	for _, userID := range []int{1, 2, 3, 4, 5, 6} {
+		fixtures["users"] = append(fixtures["users"], map[string]any{
+			"user_id":   userID,
+			"handle":    fmt.Sprintf("testuser%d", userID),
+			"handle_lc": fmt.Sprintf("testuser%d", userID),
+			"wallet":    fmt.Sprintf("0x%064x", userID),
+		})
+	}
+	// 5 tracks with unique owners
+	for _, trackID := range []int{1, 2, 3, 4, 5, 6} {
+		fixtures["tracks"] = append(fixtures["tracks"], map[string]any{
+			"track_id": trackID,
+			"owner_id": trackID,
+		})
+	}
+	fixtures["playlists"] = append(fixtures["playlists"], map[string]any{
+		"playlist_id":       1,
+		"playlist_owner_id": 1,
+		"is_current":        true,
+		"is_delete":         false,
+		"is_private":        false,
+		"playlist_contents": map[string]any{
+			"track_ids": []map[string]any{
+				{
+					"track":         1,
+					"time":          1,
+					"metadata_time": 1,
+				},
+				{
+					"track":         2,
+					"time":          2,
+					"metadata_time": 2,
+				},
+				{
+					"track":         3,
+					"time":          3,
+					"metadata_time": 3,
+				},
+				{
+					"track":         4,
+					"time":          4,
+					"metadata_time": 4,
+				},
+				{
+					"track":         5,
+					"time":          5,
+					"metadata_time": 5,
+				},
+				{
+					"track":         6,
+					"time":          6,
+					"metadata_time": 6,
+				},
+			},
+		},
+		"is_album": false,
+	})
+	fixtures["playlist_trending_scores"] = append(fixtures["playlist_trending_scores"], map[string]any{
+		"playlist_id": 1,
+		"type":        "PLAYLISTS",
+		"version":     "pnagD",
+		"time_range":  "week",
+		"score":       100,
+	})
+	for _, trackID := range []int{1, 2, 3, 4, 5, 6} {
+		fixtures["playlist_tracks"] = append(fixtures["playlist_tracks"], map[string]any{
+			"playlist_id": 1,
+			"track_id":    trackID,
+		})
+	}
+
+	database.Seed(app.pool.Replicas[0], fixtures)
+	status, body := testGet(t, app, "/v1/playlists/trending?limit=1", nil)
+	assert.Equal(t, 200, status)
+
+	jsonAssert(t, body, map[string]any{
+		"data.#": 1,
+	})
+	jsonAssert(t, body, map[string]any{
+		"data.0.tracks.#": 5,
+	})
+}
+
 func TestGetTrendingPlaylists_Albums(t *testing.T) {
 	app := emptyTestApp(t)
 


### PR DESCRIPTION
This restores a behavior we had on DN to limit the number of tracks fetched in the `full` logic to just the first five.
This prevents really large playlists from slowing down the response times. But it does mean playlist tiles are only going to play 5 items from the playlist unless we otherwise fetch the remaining tracks on client.
Chatted with @dylanjeffers about this and it's a reasonable trade off for now.