### PR TITLE
Search query for /coins, add name to coin

### DIFF
--- a/api/swagger/swagger-v1.yaml
+++ b/api/swagger/swagger-v1.yaml
@@ -5048,11 +5048,16 @@ components:
     coin:
       type: object
       required:
+        - name
         - mint
         - decimals
         - owner_id
         - created_at
       properties:
+        name:
+          type: string
+          description: The coin name
+          example: "Bonk Inu"
         ticker:
           type: string
           description: The coin symbol

--- a/api/swagger/swagger-v1.yaml
+++ b/api/swagger/swagger-v1.yaml
@@ -3464,6 +3464,11 @@ paths:
           type: array
           items:
             type: string
+      - name: query
+        in: query
+        description: Search by the coin name or ticker
+        schema:
+          type: string
       - name: offset
         in: query
         description: The number of items to skip. Useful for pagination (page number

--- a/api/v1_coin.go
+++ b/api/v1_coin.go
@@ -14,7 +14,8 @@ func (app *ApiServer) v1Coin(c *fiber.Ctx) error {
 	}
 
 	sql := `
-		SELECT 
+		SELECT
+			artist_coins.name,
 			artist_coins.ticker,
 			artist_coins.mint,
 			artist_coins.decimals,

--- a/ddl/migrations/0157_artist_coin_names.sql
+++ b/ddl/migrations/0157_artist_coin_names.sql
@@ -1,0 +1,2 @@
+ALTER TABLE artist_coins
+    ADD COLUMN name TEXT NOT NULL DEFAULT '';

--- a/sql/01_schema.sql
+++ b/sql/01_schema.sql
@@ -5757,7 +5757,8 @@ CREATE TABLE public.artist_coins (
     created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
     logo_uri text,
     description text,
-    website text
+    website text,
+    name text DEFAULT ''::text NOT NULL
 );
 
 


### PR DESCRIPTION
- Adds `name` to coins in the db
- Allows searching by name or ticker using the `query` query parameter on the `/coins` endpoint