### PR TITLE
Handle empty fee payers

### DIFF
--- a/api/v1_claim_rewards.go
+++ b/api/v1_claim_rewards.go
@@ -362,7 +362,10 @@ func sendRewardClaimTransactions(
 	// If partialTx is sent, remainderTx contains only the rest of the instructions
 	remainderTx := solana.NewTransactionBuilder()
 
-	feePayer := transactionSender.GetFeePayer()
+	feePayer, err := transactionSender.GetFeePayer()
+	if err != nil {
+		return nil, err
+	}
 	partialTx.SetFeePayer(feePayer.PublicKey())
 	remainderTx.SetFeePayer(feePayer.PublicKey())
 
@@ -426,7 +429,7 @@ func sendRewardClaimTransactions(
 		// If not, send the attestations in a separate transaction.
 		// Minimum 4 new accounts + instruction data containing
 		// amount, challengeId, specifier
-		estimatedEvaluateInstructionSize := 205
+		estimatedEvaluateInstructionSize := 210
 		threshold := spl.MAX_TRANSACTION_SIZE - estimatedEvaluateInstructionSize
 		if len(partialTxBinary) > threshold {
 			sig, err := transactionSender.SendTransactionWithRetries(ctx, partialTx, rpc.CommitmentConfirmed, rpc.TransactionOpts{})

--- a/config/solana_config.go
+++ b/config/solana_config.go
@@ -78,9 +78,11 @@ func NewSolanaConfig() SolanaConfig {
 		walletKeys := strings.Split(keyString, ",")
 		cfg.FeePayers = make([]solana.Wallet, len(walletKeys))
 		for i, privkeyString := range walletKeys {
-			privkey := solana.MustPrivateKeyFromBase58(privkeyString)
-			cfg.FeePayers[i] = solana.Wallet{
-				PrivateKey: privkey,
+			if privkeyString != "" {
+				privkey := solana.MustPrivateKeyFromBase58(privkeyString)
+				cfg.FeePayers[i] = solana.Wallet{
+					PrivateKey: privkey,
+				}
 			}
 		}
 	} else {

--- a/solana/spl/programs/claimable_tokens/client.go
+++ b/solana/spl/programs/claimable_tokens/client.go
@@ -30,7 +30,10 @@ func (cc *ClaimableTokensClient) CreateUserBank(
 	ethAddress common.Address,
 	mint solana.PublicKey,
 ) error {
-	payer := cc.sender.GetFeePayer()
+	payer, err := cc.sender.GetFeePayer()
+	if err != nil {
+		return err
+	}
 	inst, err := NewCreateTokenAccountInstruction(ethAddress, mint, payer.PublicKey())
 	if err != nil {
 		return err

--- a/solana/spl/transaction_sender.go
+++ b/solana/spl/transaction_sender.go
@@ -140,8 +140,11 @@ func (ts *TransactionSender) AddPriorityFees(ctx context.Context, tx *solana.Tra
 	return nil
 }
 
-func (ts *TransactionSender) GetFeePayer() solana.Wallet {
-	return ts.feePayers[rand.IntN(len(ts.feePayers))]
+func (ts *TransactionSender) GetFeePayer() (*solana.Wallet, error) {
+	if len(ts.feePayers) == 0 {
+		return nil, errors.New("no fee payers available")
+	}
+	return &ts.feePayers[rand.IntN(len(ts.feePayers))], nil
 }
 
 func (ts *TransactionSender) SendTransactionWithRetries(ctx context.Context, txBuilder *solana.TransactionBuilder, commitment rpc.CommitmentType, opts rpc.TransactionOpts) (*solana.Signature, error) {


### PR DESCRIPTION
```
curl -X POST http://localhost:1323/v1/rewards/claim \
  -H "Content-Type: application/json" \
  -d '{
    "challengeId": "b",
    "specifier": "1:7e42b5b1",
    "userId": "7eP5n"
  }'
{"data":[{"challengeId":"b","specifier":"1:7e42b5b1","amount":5,"signatures":null,"error":"no fee payers available"}]}
```