### PR TITLE
[PE-6613] Add `/coins/ticker/:ticker` in order to enable asset pages to use ticker 

### DIFF
--- a/api/server.go
+++ b/api/server.go
@@ -478,7 +478,7 @@ func NewApiServer(config config.Config) *ApiServer {
 
 		// Artist coins
 		g.Get("/coins", app.v1Coins)
-		g.Get("/coins/:mint", app.v1Coin)
+		g.Get("/coins/:identifier", app.v1Coin)
 		g.Get("/coins/:mint/insights", app.v1CoinInsights)
 		g.Get("/coins/:mint/members", app.v1CoinsMembers)
 		g.Post("/coins", app.v1CreateCoin)

--- a/api/server.go
+++ b/api/server.go
@@ -478,7 +478,8 @@ func NewApiServer(config config.Config) *ApiServer {
 
 		// Artist coins
 		g.Get("/coins", app.v1Coins)
-		g.Get("/coins/:identifier", app.v1Coin)
+		g.Get("/coins/:mint", app.v1Coin)
+		g.Get("/coins/ticker/:ticker", app.v1CoinByTicker)
 		g.Get("/coins/:mint/insights", app.v1CoinInsights)
 		g.Get("/coins/:mint/members", app.v1CoinsMembers)
 		g.Post("/coins", app.v1CreateCoin)

--- a/api/swagger/swagger-v1.yaml
+++ b/api/swagger/swagger-v1.yaml
@@ -3559,7 +3559,6 @@ paths:
         schema:
           type: string
           example: 9LzCMqDgTKYz9Drzqnpgee3SGa89up3a247ypMj2xrqM
-          example: $AUDIO
       responses:
         '200':
           description: Success

--- a/api/swagger/swagger-v1.yaml
+++ b/api/swagger/swagger-v1.yaml
@@ -3545,20 +3545,21 @@ paths:
         '500':
           description: Server error
           content: {}
-  /coins/{mint}:
+  /coins/{identifier}:
     get:
       tags:
         - coins
       operationId: Get Coin
-      description: 'Gets information about a specific coin by its mint address'
+      description: 'Gets information about a specific coin by its mint address or ticker'
       parameters:
-      - name: mint
+      - name: identifier
         in: path
-        description: The mint address of the coin
+        description: The mint address or ticker of the coin
         required: true
         schema:
           type: string
           example: 9LzCMqDgTKYz9Drzqnpgee3SGa89up3a247ypMj2xrqM
+          example: $AUDIO
       responses:
         '200':
           description: Success

--- a/api/swagger/swagger-v1.yaml
+++ b/api/swagger/swagger-v1.yaml
@@ -3545,16 +3545,16 @@ paths:
         '500':
           description: Server error
           content: {}
-  /coins/{identifier}:
+  /coins/{mint}:
     get:
       tags:
         - coins
       operationId: Get Coin
-      description: 'Gets information about a specific coin by its mint address or ticker'
+      description: 'Gets information about a specific coin by its mint address'
       parameters:
-      - name: identifier
+      - name: mint
         in: path
-        description: The mint address or ticker of the coin
+        description: The mint address of the coin
         required: true
         schema:
           type: string
@@ -3567,6 +3567,33 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/coin_response'
+  /coins/ticker/{ticker}:
+    get:
+      tags:
+        - coins
+      operationId: Get Coin By Ticker
+      description: 'Gets information about a specific coin by its ticker'
+      parameters:
+      - name: ticker
+        in: path
+        description: The ticker of the coin
+        required: true
+        schema:
+          type: string
+          example: $AUDIO
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/coin_response'
+        '400':
+          description: Bad request
+          content: {}
+        '500':
+          description: Server error
+          content: {}
   /coins/{mint}/insights:
     get:
       tags:

--- a/api/v1_coin.go
+++ b/api/v1_coin.go
@@ -6,10 +6,10 @@ import (
 )
 
 func (app *ApiServer) v1Coin(c *fiber.Ctx) error {
-	mint := c.Params("mint")
-	if mint == "" {
+	input := c.Params("identifier")
+	if input == "" {
 		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
-			"error": "mint parameter is required",
+			"error": "identifier parameter is required (either mint or ticker)",
 		})
 	}
 
@@ -25,12 +25,13 @@ func (app *ApiServer) v1Coin(c *fiber.Ctx) error {
 			artist_coins.website,
 			artist_coins.created_at
 		FROM artist_coins
-		WHERE artist_coins.mint = @mint
+		WHERE artist_coins.mint = @input
+		   OR artist_coins.ticker = @input
 		LIMIT 1
 	`
 
 	rows, err := app.pool.Query(c.Context(), sql, pgx.NamedArgs{
-		"mint": mint,
+		"input": input,
 	})
 	if err != nil {
 		return err

--- a/api/v1_coin_test.go
+++ b/api/v1_coin_test.go
@@ -1,0 +1,64 @@
+package api
+
+import (
+	"testing"
+	"time"
+
+	"bridgerton.audius.co/database"
+	"bridgerton.audius.co/trashid"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestV1Coin(t *testing.T) {
+	app := emptyTestApp(t)
+
+	fixtures := database.FixtureMap{
+		"artist_coins": {
+			{
+				"ticker":     "$AUDIO",
+				"decimals":   8,
+				"user_id":    1,
+				"mint":       "9LzCMqDgTKYz9Drzqnpgee3SGa89up3a247ypMj2xrqM",
+				"name":       "Audius",
+				"created_at": time.Now().Add(-time.Second),
+			},
+		},
+	}
+
+	database.Seed(app.pool.Replicas[0], fixtures)
+
+	// Test with mint address
+	{
+		status, body := testGet(t, app, "/v1/coins/9LzCMqDgTKYz9Drzqnpgee3SGa89up3a247ypMj2xrqM")
+		assert.Equal(t, 200, status)
+
+		jsonAssert(t, body, map[string]any{
+			"data.ticker":   "$AUDIO",
+			"data.mint":     "9LzCMqDgTKYz9Drzqnpgee3SGa89up3a247ypMj2xrqM",
+			"data.decimals": 8,
+			"data.name":     "Audius",
+			"data.owner_id": trashid.MustEncodeHashID(1),
+		})
+	}
+
+	// Test with ticker
+	{
+		status, body := testGet(t, app, "/v1/coins/$AUDIO")
+		assert.Equal(t, 200, status)
+
+		jsonAssert(t, body, map[string]any{
+			"data.ticker":   "$AUDIO",
+			"data.mint":     "9LzCMqDgTKYz9Drzqnpgee3SGa89up3a247ypMj2xrqM",
+			"data.decimals": 8,
+			"data.name":     "Audius",
+			"data.owner_id": trashid.MustEncodeHashID(1),
+		})
+	}
+
+	// Test with non-existent mint/ticker
+	{
+		status, body := testGet(t, app, "/v1/coins/nonexistent")
+		assert.Equal(t, 404, status)
+		assert.Contains(t, string(body), "no rows")
+	}
+}

--- a/api/v1_coin_test.go
+++ b/api/v1_coin_test.go
@@ -27,7 +27,7 @@ func TestV1Coin(t *testing.T) {
 
 	database.Seed(app.pool.Replicas[0], fixtures)
 
-	// Test with mint address
+	// Test /coins/:mint endpoint with mint address
 	{
 		status, body := testGet(t, app, "/v1/coins/9LzCMqDgTKYz9Drzqnpgee3SGa89up3a247ypMj2xrqM")
 		assert.Equal(t, 200, status)
@@ -41,9 +41,9 @@ func TestV1Coin(t *testing.T) {
 		})
 	}
 
-	// Test with ticker
+	// Test /coins/ticker/:ticker endpoint with ticker
 	{
-		status, body := testGet(t, app, "/v1/coins/$AUDIO")
+		status, body := testGet(t, app, "/v1/coins/ticker/$AUDIO")
 		assert.Equal(t, 200, status)
 
 		jsonAssert(t, body, map[string]any{
@@ -55,9 +55,16 @@ func TestV1Coin(t *testing.T) {
 		})
 	}
 
-	// Test with non-existent mint/ticker
+	// Test with non-existent mint
 	{
 		status, body := testGet(t, app, "/v1/coins/nonexistent")
+		assert.Equal(t, 404, status)
+		assert.Contains(t, string(body), "no rows")
+	}
+
+	// Test with non-existent ticker
+	{
+		status, body := testGet(t, app, "/v1/coins/ticker/$NONEXISTENT")
 		assert.Equal(t, 404, status)
 		assert.Contains(t, string(body), "no rows")
 	}


### PR DESCRIPTION
Currently, we use the `getCoin` endpoint for asset pages, but we go based off of mint. Creating a new endpoint so we can use ticker and avoid any convoluted FE logic to replace mint with ticker.  This will essentially allow us to navigate to audius.co/coins/$AUDIO. The rest of the endpoints are ok with just being mint based.

https://audius-internal.slack.com/archives/C08JHQH11R8/p1757016195240729 