### PR TITLE
Fix coin endpoint behavior with bad input

### DIFF
--- a/api/v1_users_coin.go
+++ b/api/v1_users_coin.go
@@ -3,6 +3,7 @@ package api
 import (
 	"fmt"
 
+	"github.com/gagliardetto/solana-go"
 	"github.com/gofiber/fiber/v2"
 	"github.com/jackc/pgx/v5"
 )
@@ -29,6 +30,12 @@ func (app *ApiServer) v1UsersCoin(c *fiber.Ctx) error {
 	if err := c.ParamsParser(&params); err != nil {
 		return err
 	}
+
+	_, err := solana.PublicKeyFromBase58(params.Mint)
+	if err != nil {
+		return fiber.NewError(fiber.StatusBadRequest, fmt.Sprintf("invalid mint address: %s", params.Mint))
+	}
+
 	prices, err := app.birdeyeClient.GetPrices(c.Context(), []string{params.Mint})
 	if err != nil || prices == nil {
 		return fmt.Errorf("failed to get price: %w", err)
@@ -43,13 +50,13 @@ func (app *ApiServer) v1UsersCoin(c *fiber.Ctx) error {
 				user_bank_balances.owner AS owner,
 				TRUE as is_in_app_wallet
 			FROM users
-			JOIN sol_claimable_accounts 
+			JOIN sol_claimable_accounts
 				ON sol_claimable_accounts.ethereum_address = users.wallet
-			JOIN sol_token_account_balances AS user_bank_balances 
+			JOIN sol_token_account_balances AS user_bank_balances
 				ON user_bank_balances.account = sol_claimable_accounts.account
 			WHERE users.user_id = @user_id
 				AND user_bank_balances.mint = @mint
-			UNION ALL 
+			UNION ALL
 			SELECT
 				associated_wallet_balances.mint,
 				associated_wallet_balances.balance AS balance,
@@ -57,10 +64,10 @@ func (app *ApiServer) v1UsersCoin(c *fiber.Ctx) error {
 				associated_wallet_balances.owner AS owner,
 				FALSE as is_in_app_wallet
 			FROM users
-			JOIN associated_wallets 
+			JOIN associated_wallets
 				ON associated_wallets.user_id = users.user_id
-			JOIN sol_token_account_balances AS associated_wallet_balances 
-				ON associated_wallet_balances.owner = associated_wallets.wallet 
+			JOIN sol_token_account_balances AS associated_wallet_balances
+				ON associated_wallet_balances.owner = associated_wallets.wallet
 				AND associated_wallets.chain = 'sol'
 			WHERE associated_wallets.user_id = @user_id
 				AND associated_wallet_balances.mint = @mint
@@ -71,7 +78,7 @@ func (app *ApiServer) v1UsersCoin(c *fiber.Ctx) error {
 			FROM balances
 			GROUP BY balances.mint
 		)
-		SELECT 
+		SELECT
 			artist_coins.ticker,
 			artist_coins.mint,
 			artist_coins.decimals,

--- a/api/v1_users_coin_test.go
+++ b/api/v1_users_coin_test.go
@@ -165,4 +165,10 @@ func TestUserCoin(t *testing.T) {
 			"data.accounts.0.is_in_app_wallet": false,
 		})
 	}
+
+	// Don't accept tickers on this endpoint
+	{
+		status, _ := testGet(t, app, "/v1/users/"+trashid.MustEncodeHashID(1)+"/coins/AUDIO")
+		assert.Equal(t, 400, status)
+	}
 }

--- a/birdeye/client.go
+++ b/birdeye/client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"strings"
 	"time"
@@ -16,6 +17,16 @@ type Client struct {
 	tokenOverviewCache otter.Cache[string, *TokenOverview]
 	pricesCache        otter.Cache[string, *TokenPriceData]
 	httpClient         *http.Client
+}
+
+func attemptExtractErrorMessage(body io.Reader) string {
+	var respBody struct {
+		Message string `json:"message"`
+	}
+	if err := json.NewDecoder(body).Decode(&respBody); err != nil {
+		return ""
+	}
+	return respBody.Message
 }
 
 func New(token string) *Client {
@@ -165,6 +176,7 @@ func (c *Client) GetPrices(ctx context.Context, mints []string) (TokenPriceMap, 
 	}
 
 	url := fmt.Sprintf("https://public-api.birdeye.so/defi/multi_price?list_address=%s", strings.Join(mintsToFetch, ","))
+	fmt.Println(url)
 	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
 	if err != nil {
 		return nil, err
@@ -180,7 +192,8 @@ func (c *Client) GetPrices(ctx context.Context, mints []string) (TokenPriceMap, 
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+		errMsg := attemptExtractErrorMessage(resp.Body)
+		return nil, fmt.Errorf("unexpected status code: %d (%s)", resp.StatusCode, errMsg)
 	}
 
 	var respBody struct {


### PR DESCRIPTION
`/v1/users/:id/coins/:mint` expects a mint address, not a ticker. But if called with invalid input it still attempts to fetch price data. This will result in a 400 and we will skip adding it to the price cache. This means our next request is going to attempt to fetch it again, and we will use up more quota than we would like due to missing the cache on every request.
This updates the endpoint to bail early if the mint value isn't a valid address.


Bonus change: Added parsing of the returned error message so we can expose that in out logs. Made it easier to track down why we were getting back a 400.