### PR TITLE
Use stats table for coin prices in user/coins endpoints

### DIFF
--- a/api/v1_users_coin.go
+++ b/api/v1_users_coin.go
@@ -36,11 +36,6 @@ func (app *ApiServer) v1UsersCoin(c *fiber.Ctx) error {
 		return fiber.NewError(fiber.StatusBadRequest, fmt.Sprintf("invalid mint address: %s", params.Mint))
 	}
 
-	prices, err := app.birdeyeClient.GetPrices(c.Context(), []string{params.Mint})
-	if err != nil || prices == nil {
-		return fmt.Errorf("failed to get price: %w", err)
-	}
-
 	sql := `
 		WITH balances AS (
 			SELECT
@@ -84,20 +79,21 @@ func (app *ApiServer) v1UsersCoin(c *fiber.Ctx) error {
 			artist_coins.decimals,
 			artist_coins.user_id AS owner_id,
 			COALESCE(balances_by_mint.balance, 0) AS balance,
-			COALESCE((balances_by_mint.balance * @price) / POWER(10, artist_coins.decimals), 0) AS balance_usd,
+			COALESCE((balances_by_mint.balance * stats.price) / POWER(10, artist_coins.decimals), 0) AS balance_usd,
 			COALESCE(
 				JSON_AGG(
 					JSON_BUILD_OBJECT(
 						'account', balances.account,
 						'owner', balances.owner,
 						'balance', balances.balance,
-						'balance_usd', (balances.balance * @price) / POWER(10, artist_coins.decimals),
+						'balance_usd', (balances.balance * stats.price) / POWER(10, artist_coins.decimals),
 						'is_in_app_wallet', balances.is_in_app_wallet
 					)
 				) FILTER (WHERE balances.account IS NOT NULL),
 				'[]'::json
 			) AS accounts
 		FROM artist_coins
+		JOIN artist_coin_stats stats ON artist_coins.mint = stats.mint
 		LEFT JOIN balances_by_mint ON artist_coins.mint = balances_by_mint.mint
 		LEFT JOIN (
 			SELECT *
@@ -110,13 +106,13 @@ func (app *ApiServer) v1UsersCoin(c *fiber.Ctx) error {
 			artist_coins.mint,
 			artist_coins.decimals,
 			artist_coins.user_id,
-			balances_by_mint.balance
+			balances_by_mint.balance,
+			stats.price
 	;`
 
 	rows, err := app.pool.Query(c.Context(), sql, pgx.NamedArgs{
 		"user_id": app.getUserId(c),
 		"mint":    params.Mint,
-		"price":   prices[params.Mint].Value,
 	})
 	if err != nil {
 		return err

--- a/api/v1_users_coin_test.go
+++ b/api/v1_users_coin_test.go
@@ -29,6 +29,18 @@ func TestUserCoin(t *testing.T) {
 				"created_at": time.Now(),
 			},
 		},
+		"artist_coin_stats": {
+			{
+				"mint":       "9LzCMqDgTKYz9Drzqnpgee3SGa89up3a247ypMj2xrqM",
+				"price":      10.0,
+				"updated_at": time.Now(),
+			},
+			{
+				"mint":       "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+				"price":      1.0,
+				"updated_at": time.Now(),
+			},
+		},
 		"users": {
 			{
 				"user_id": 1,
@@ -113,7 +125,6 @@ func TestUserCoin(t *testing.T) {
 	}
 
 	database.Seed(app.pool.Replicas[0], fixtures)
-	app.birdeyeClient = &mockBirdeyeClient{}
 
 	// AUDIO
 	{

--- a/api/v1_users_coins.go
+++ b/api/v1_users_coins.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"fmt"
-	"strings"
 
 	"bridgerton.audius.co/trashid"
 	"github.com/gofiber/fiber/v2"
@@ -54,20 +53,8 @@ func (app *ApiServer) v1UsersCoins(c *fiber.Ctx) error {
 		})
 	}
 
-	prices, err := app.birdeyeClient.GetPrices(c.Context(), mints)
-	if err != nil || prices == nil {
-		return fmt.Errorf("failed to get prices: %w", err)
-	}
-
-	pricesRows := make([]string, 0, len(prices))
-	for mint, price := range prices {
-		pricesRows = append(pricesRows, fmt.Sprintf("('%s', %f)", mint, price.Value))
-	}
-
 	sql := `
-		WITH prices (mint, price) AS (
-			VALUES ` + strings.Join(pricesRows, ",\n\t\t\t") + `
-		), balances AS (
+		WITH balances AS (
 			SELECT
 				user_bank_balances.mint,
 				user_bank_balances.balance AS balance,
@@ -75,12 +62,12 @@ func (app *ApiServer) v1UsersCoins(c *fiber.Ctx) error {
 				user_bank_balances.owner AS owner,
 				TRUE as is_in_app_wallet
 			FROM users
-			JOIN sol_claimable_accounts 
+			JOIN sol_claimable_accounts
 				ON sol_claimable_accounts.ethereum_address = users.wallet
-			JOIN sol_token_account_balances AS user_bank_balances 
+			JOIN sol_token_account_balances AS user_bank_balances
 				ON user_bank_balances.account = sol_claimable_accounts.account
 			WHERE users.user_id = @user_id
-			UNION ALL 
+			UNION ALL
 			SELECT
 				associated_wallet_balances.mint,
 				associated_wallet_balances.balance AS balance,
@@ -88,10 +75,10 @@ func (app *ApiServer) v1UsersCoins(c *fiber.Ctx) error {
 				associated_wallet_balances.owner AS owner,
 				FALSE as is_in_app_wallet
 			FROM users
-			JOIN associated_wallets 
+			JOIN associated_wallets
 				ON associated_wallets.user_id = users.user_id
-			JOIN sol_token_account_balances AS associated_wallet_balances 
-				ON associated_wallet_balances.owner = associated_wallets.wallet 
+			JOIN sol_token_account_balances AS associated_wallet_balances
+				ON associated_wallet_balances.owner = associated_wallets.wallet
 				AND associated_wallets.chain = 'sol'
 			WHERE associated_wallets.user_id = @user_id
 		), balances_by_mint AS (
@@ -102,16 +89,16 @@ func (app *ApiServer) v1UsersCoins(c *fiber.Ctx) error {
 			GROUP BY balances.mint
 		),
 		balances_with_prices AS (
-			SELECT 
+			SELECT
 				artist_coins.ticker,
 				balances_by_mint.mint,
 				artist_coins.decimals,
 				artist_coins.user_id,
 				balances_by_mint.balance AS balance,
-				(balances_by_mint.balance * prices.price) / POWER(10, artist_coins.decimals) AS balance_usd
+				(balances_by_mint.balance * stats.price) / POWER(10, artist_coins.decimals) AS balance_usd
 			FROM balances_by_mint
-			JOIN prices ON balances_by_mint.mint = prices.mint
 			JOIN artist_coins ON artist_coins.mint = balances_by_mint.mint
+			JOIN artist_coin_stats stats ON stats.mint = balances_by_mint.mint
 		)
 		SELECT
 			balances_with_prices.ticker,

--- a/api/v1_users_coins_test.go
+++ b/api/v1_users_coins_test.go
@@ -29,6 +29,18 @@ func TestUserCoins(t *testing.T) {
 				"created_at": time.Now(),
 			},
 		},
+		"artist_coin_stats": {
+			{
+				"mint":       "9LzCMqDgTKYz9Drzqnpgee3SGa89up3a247ypMj2xrqM",
+				"price":      10.0,
+				"updated_at": time.Now(),
+			},
+			{
+				"mint":       "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+				"price":      1.0,
+				"updated_at": time.Now(),
+			},
+		},
 		"users": {
 			{
 				"user_id": 1,
@@ -113,7 +125,6 @@ func TestUserCoins(t *testing.T) {
 	}
 
 	database.Seed(app.pool.Replicas[0], fixtures)
-	app.birdeyeClient = &mockBirdeyeClient{}
 
 	status, body := testGet(t, app, "/v1/users/"+trashid.MustEncodeHashID(1)+"/coins")
 	assert.Equal(t, 200, status)

--- a/database/seed.go
+++ b/database/seed.go
@@ -407,6 +407,11 @@ var (
 			"decimals":   nil,
 			"created_at": time.Now(),
 		},
+		"artist_coin_stats": {
+			"mint":       nil,
+			"created_at": time.Now(),
+			"updated_at": time.Now(),
+		},
 		"sol_token_account_balances": {
 			"account": nil,
 			"owner":   "owner-acc",


### PR DESCRIPTION
We have the stats job updating prices now, so we don't need to reach out to birdeye on every request.