### PR TITLE
[API-226] Migrate `/users/:userId/emails/:grantorUserId/key` endpoint

### DIFF
--- a/api/server.go
+++ b/api/server.go
@@ -333,6 +333,7 @@ func NewApiServer(config config.Config) *ApiServer {
 		g.Get("/users/:userId", app.v1User)
 		g.Get("/users/:userId/challenges", app.v1UsersChallenges)
 		g.Get("/users/:userId/comments", app.v1UsersComments)
+		g.Get("/users/:userId/emails/:grantorUserId/key", app.v1UsersEmailsKey)
 		g.Get("/users/:userId/followers", app.v1UsersFollowers)
 		g.Get("/users/:userId/following", app.v1UsersFollowing)
 		g.Get("/users/:userId/favorites", app.v1UsersFavorites)

--- a/api/v1_users_emails_key.go
+++ b/api/v1_users_emails_key.go
@@ -1,0 +1,57 @@
+package api
+
+import (
+	"time"
+
+	"api.audius.co/trashid"
+	"github.com/gofiber/fiber/v2"
+	"github.com/jackc/pgx/v5"
+)
+
+type EmailAccessResponse struct {
+	Id               int32     `json:"id" db:"id"`
+	EmailOwnerUserId int32     `json:"email_owner_user_id" db:"email_owner_user_id"`
+	ReceivingUserId  int32     `json:"receiving_user_id" db:"receiving_user_id"`
+	GrantorUserId    int32     `json:"grantor_user_id" db:"grantor_user_id"`
+	EncryptedKey     string    `json:"encrypted_key" db:"encrypted_key"`
+	IsInitial        bool      `json:"is_initial" db:"is_initial"`
+	CreatedAt        time.Time `json:"created_at" db:"created_at"`
+	UpdatedAt        time.Time `json:"updated_at" db:"updated_at"`
+}
+
+func (app *ApiServer) v1UsersEmailsKey(c *fiber.Ctx) error {
+	userId := app.getUserId(c)
+	hashedGrantorUserId := c.Params("grantorUserId")
+
+	grantorUserId, err := trashid.DecodeHashId(hashedGrantorUserId)
+	if err != nil {
+		return fiber.NewError(fiber.StatusBadRequest, "Invalid grantor user ID")
+	}
+
+	sql := `SELECT * FROM email_access
+	WHERE receiving_user_id=@userId
+	AND grantor_user_id=@grantorUserId
+	LIMIT 1`
+
+	rows, err := app.pool.Query(c.Context(), sql, pgx.NamedArgs{
+		"userId":        userId,
+		"grantorUserId": grantorUserId,
+	})
+	if err != nil {
+		return err
+	}
+
+	emailAccess, err := pgx.CollectOneRow(rows, pgx.RowToStructByName[EmailAccessResponse])
+	if err != nil {
+		if err == pgx.ErrNoRows {
+			return c.JSON(fiber.Map{
+				"data": nil,
+			})
+		}
+		return err
+	}
+
+	return c.JSON(fiber.Map{
+		"data": emailAccess,
+	})
+}

--- a/api/v1_users_emails_key_test.go
+++ b/api/v1_users_emails_key_test.go
@@ -1,0 +1,54 @@
+package api
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"api.audius.co/database"
+	"api.audius.co/trashid"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestV1UsersEmailsKey(t *testing.T) {
+	app := emptyTestApp(t)
+
+	fixtures := database.FixtureMap{
+		"email_access": []map[string]any{
+			{
+				"id":                  1,
+				"email_owner_user_id": 1,
+				"receiving_user_id":   2,
+				"grantor_user_id":     1,
+				"encrypted_key":       "test",
+				"is_initial":          true,
+				"created_at":          time.Now(),
+				"updated_at":          time.Now(),
+			},
+		},
+	}
+	database.Seed(app.writePool, fixtures)
+
+	// happy path
+	{
+		status, body := testGet(t, app, fmt.Sprintf("/v1/users/%s/emails/%s/key", trashid.MustEncodeHashID(2), trashid.MustEncodeHashID(1)))
+		assert.Equal(t, 200, status)
+		jsonAssert(t, body, map[string]any{
+			"data.id":                  1,
+			"data.email_owner_user_id": 1,
+			"data.receiving_user_id":   2,
+			"data.grantor_user_id":     1,
+			"data.encrypted_key":       "test",
+			"data.is_initial":          true,
+		})
+	}
+
+	// Nonexistent values return null
+	{
+		status, body := testGet(t, app, fmt.Sprintf("/v1/users/%s/emails/%s/key", trashid.MustEncodeHashID(1), trashid.MustEncodeHashID(3)))
+		assert.Equal(t, 200, status)
+		jsonAssert(t, body, map[string]any{
+			"data": nil,
+		})
+	}
+}

--- a/database/seed.go
+++ b/database/seed.go
@@ -552,6 +552,16 @@ var (
 			"blockhash":   "block_abc123",
 			"blocknumber": 101,
 		},
+		"email_access": {
+			"id":                  nil,
+			"email_owner_user_id": nil,
+			"receiving_user_id":   nil,
+			"grantor_user_id":     nil,
+			"encrypted_key":       "test",
+			"is_initial":          false,
+			"created_at":          time.Now(),
+			"updated_at":          time.Now(),
+		},
 	}
 )
 


### PR DESCRIPTION
Original is here: https://github.com/AudiusProject/audius-protocol/blob/111beb0b5a6f63caa0684243c24ebfacfc680e04/packages/discovery-provider/src/api/v1/users.py#L3167

Of note: Since these are encrypted at rest, we do not do any auth/validation of `:userId`. Also preserving the slightly unconventional behavior of returning `null` for missing entries instead of 404ing. Don't want to break client if it relies on that.