### PR TITLE
Fix coin blasts sending to all chats

### DIFF
--- a/ddl/functions/chat_blast_audience.sql
+++ b/ddl/functions/chat_blast_audience.sql
@@ -69,7 +69,8 @@ BEGIN
     ON sol_user_balances.mint = artist_coins.mint
     AND sol_user_balances.balance > 0
   WHERE chat_blast.blast_id = blast_id_param
-    AND chat_blast.audience = 'coin_holder_audience';
+    AND chat_blast.audience = 'coin_holder_audience'
+    AND sol_user_balances.user_id != chat_blast.from_user_id;
 
 END;
 $$ LANGUAGE plpgsql;


### PR DESCRIPTION
Fixes a bug where:

- Artist owns their own artist coin
- Artist has many existing chats
- Artist sends blast to coin holders
- Results in that message getting sent to all existing chats

Root cause was:
In audience calculation, since the artist themselves were a coin holder, they were getting included in the audience.
This led to some sql wonkiness in `chat_blast.go` blast fan-out logic where there would be many dup rows with that user_id and all their existing chats, eg:

```
"blast_id"|"from_user_id"|"to_user_id"|"chat_id"|"handle"
"01K5CGZYEDJY92E7WEETFHPYDW"|63846489|128006|"PX52wR:lzl4w"|"dharit"
"01K5CGZYEDJY92E7WEETFHPYDW"|63846489|63846489|"PX52wR:ZOpkv5E"|"fariddiraf"
"01K5CGZYEDJY92E7WEETFHPYDW"|63846489|63846489|"PX52wR:Wem1e"|"fariddiraf"
"01K5CGZYEDJY92E7WEETFHPYDW"|63846489|63846489|"PX52wR:g493y2p"|"fariddiraf"
"01K5CGZYEDJY92E7WEETFHPYDW"|63846489|63846489|"PX52wR:lzl4w"|"fariddiraf"
"01K5CGZYEDJY92E7WEETFHPYDW"|63846489|63846489|"E2AMEVN:PX52wR"|"fariddiraf"
"01K5CGZYEDJY92E7WEETFHPYDW"|63846489|63846489|"PX52wR:eJ57D"|"fariddiraf"
"01K5CGZYEDJY92E7WEETFHPYDW"|63846489|63846489|"PX52wR:PX52wR"|"fariddiraf"
"01K5CGZYEDJY92E7WEETFHPYDW"|63846489|63846489|"PX52wR:Pdxw5"|"fariddiraf"
"01K5CGZYEDJY92E7WEETFHPYDW"|63846489|63846489|"0MMZ6:PX52wR"|"fariddiraf"
"01K5CGZYEDJY92E7WEETFHPYDW"|63846489|63846489|"7eP5n:PX52wR"|"fariddiraf"
"01K5CGZYEDJY92E7WEETFHPYDW"|63846489|63846489|"J5ZOp:PX52wR"|"fariddiraf"
"01K5CGZYEDJY92E7WEETFHPYDW"|63846489|63846489|"PWY7x2X:PX52wR"|"fariddiraf"
```