### PR TITLE
[API-216] Migrate `/v1/users/:userId/collectibles`

### DIFF
--- a/api/server.go
+++ b/api/server.go
@@ -336,6 +336,7 @@ func NewApiServer(config config.Config) *ApiServer {
 		g.Use("/users/:userId", app.requireUserIdMiddleware)
 		g.Get("/users/:userId", app.v1User)
 		g.Get("/users/:userId/challenges", app.v1UsersChallenges)
+		g.Get("/users/:userId/collectibles", app.v1UsersCollectibles)
 		g.Get("/users/:userId/comments", app.v1UsersComments)
 		g.Get("/users/:userId/emails/:grantorUserId/key", app.v1UsersEmailsKey)
 		g.Get("/users/:userId/followers", app.v1UsersFollowers)

--- a/api/v1_users_collectibles.go
+++ b/api/v1_users_collectibles.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 
 	"github.com/gofiber/fiber/v2"
+	"github.com/jackc/pgx/v5"
 )
 
 type CollectiblesRow struct {
@@ -15,13 +16,15 @@ func (app *ApiServer) v1UsersCollectibles(c *fiber.Ctx) error {
 
 	sql := `
 		SELECT data FROM collectibles
-		WHERE user_id = $1
+		WHERE user_id = @userId
 		LIMIT 1
 	`
 
 	var collectible CollectiblesRow
 
-	err := app.pool.QueryRow(c.Context(), sql, userId).Scan(&collectible.Data)
+	err := app.pool.QueryRow(c.Context(), sql, pgx.NamedArgs{
+		"userId": userId,
+	}).Scan(&collectible.Data)
 	if err != nil {
 		return err
 	}

--- a/api/v1_users_collectibles.go
+++ b/api/v1_users_collectibles.go
@@ -26,10 +26,15 @@ func (app *ApiServer) v1UsersCollectibles(c *fiber.Ctx) error {
 		"userId": userId,
 	}).Scan(&collectible.Data)
 	if err != nil {
+		if err == pgx.ErrNoRows {
+			return c.JSON(fiber.Map{
+				"data": nil,
+			})
+		}
 		return err
 	}
 
 	return c.JSON(fiber.Map{
-		"data": collectible.Data,
+		"data": collectible,
 	})
 }

--- a/api/v1_users_collectibles.go
+++ b/api/v1_users_collectibles.go
@@ -1,0 +1,32 @@
+package api
+
+import (
+	"encoding/json"
+
+	"github.com/gofiber/fiber/v2"
+)
+
+type CollectiblesRow struct {
+	Data json.RawMessage `json:"data"`
+}
+
+func (app *ApiServer) v1UsersCollectibles(c *fiber.Ctx) error {
+	userId := app.getUserId(c)
+
+	sql := `
+		SELECT data FROM collectibles
+		WHERE user_id = $1
+		LIMIT 1
+	`
+
+	var collectible CollectiblesRow
+
+	err := app.pool.QueryRow(c.Context(), sql, userId).Scan(&collectible.Data)
+	if err != nil {
+		return err
+	}
+
+	return c.JSON(fiber.Map{
+		"data": collectible.Data,
+	})
+}

--- a/api/v1_users_collectibles_test.go
+++ b/api/v1_users_collectibles_test.go
@@ -32,12 +32,23 @@ func TestUsersCollectibles(t *testing.T) {
 
 	database.Seed(app.writePool, fixtures)
 
-	status, body := testGet(t, app, "/v1/users/"+trashid.MustEncodeHashID(1)+"/collectibles")
-	assert.Equal(t, 200, status)
+	{
+		status, body := testGet(t, app, "/v1/users/"+trashid.MustEncodeHashID(1)+"/collectibles")
+		assert.Equal(t, 200, status)
 
-	jsonAssert(t, body, map[string]any{
-		"data.1:::0x1234": "{}",
-		"data.order.#":    1,
-		"data.order.0":    "1:::0x1234",
-	})
+		jsonAssert(t, body, map[string]any{
+			"data.data.1:::0x1234": "{}",
+			"data.data.order.#":    1,
+			"data.data.order.0":    "1:::0x1234",
+		})
+	}
+
+	{
+		status, body := testGet(t, app, "/v1/users/"+trashid.MustEncodeHashID(2)+"/collectibles")
+		assert.Equal(t, 200, status)
+
+		jsonAssert(t, body, map[string]any{
+			"data": nil,
+		})
+	}
 }

--- a/api/v1_users_collectibles_test.go
+++ b/api/v1_users_collectibles_test.go
@@ -1,0 +1,43 @@
+package api
+
+import (
+	"testing"
+
+	"api.audius.co/database"
+	"api.audius.co/trashid"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUsersCollectibles(t *testing.T) {
+	app := emptyTestApp(t)
+
+	fixtures := database.FixtureMap{
+		"users": {
+			{
+				"user_id": 1,
+			},
+		},
+		"collectibles": {
+			{
+				"user_id": 1,
+				"data": map[string]any{
+					"1:::0x1234": map[string]any{},
+					"order": []string{
+						"1:::0x1234",
+					},
+				},
+			},
+		},
+	}
+
+	database.Seed(app.writePool, fixtures)
+
+	status, body := testGet(t, app, "/v1/users/"+trashid.MustEncodeHashID(1)+"/collectibles")
+	assert.Equal(t, 200, status)
+
+	jsonAssert(t, body, map[string]any{
+		"data.1:::0x1234": "{}",
+		"data.order.#":    1,
+		"data.order.0":    "1:::0x1234",
+	})
+}

--- a/database/seed.go
+++ b/database/seed.go
@@ -562,6 +562,14 @@ var (
 			"created_at":          time.Now(),
 			"updated_at":          time.Now(),
 		},
+		"collectibles": {
+			"user_id":     nil,
+			"data":        nil,
+			"blockhash":   "block_abc123",
+			"blocknumber": 101,
+			"created_at":  time.Now(),
+			"updated_at":  time.Now(),
+		},
 	}
 )
 


### PR DESCRIPTION
Extremely basic endpoint. We're just fetching the raw data from the row and returning it back. Fun quirks:
* I named the column `data` originally, so it's `data.data` in the response.
* Similar to a few other endpoints, we don't 404 on not found, just return `null`. Can't guarantee client won't error if we break from that behavior.