### PR TITLE
Add coin ticker available check

### DIFF
--- a/api/server.go
+++ b/api/server.go
@@ -492,6 +492,7 @@ func NewApiServer(config config.Config) *ApiServer {
 		g.Get("/coins", app.v1Coins)
 		g.Get("/coins/:mint", app.v1Coin)
 		g.Get("/coins/ticker/:ticker", app.v1CoinByTicker)
+		g.Get("/coins/ticker/:ticker/available", app.v1CoinTickerAvailable)
 		g.Get("/coins/:mint/insights", app.v1CoinInsights)
 		g.Get("/coins/:mint/members", app.v1CoinsMembers)
 		g.Post("/coins", app.v1CreateCoin)

--- a/api/swagger/swagger-v1.yaml
+++ b/api/swagger/swagger-v1.yaml
@@ -3619,6 +3619,54 @@ paths:
         '500':
           description: Server error
           content: {}
+  /coins/ticker/{ticker}/available:
+    get:
+      tags:
+        - coins
+      operationId: Check Coin Ticker Availability
+      description: 'Checks if a coin ticker is available for use'
+      parameters:
+      - name: ticker
+        in: path
+        description: The ticker to check for availability
+        required: true
+        schema:
+          type: string
+          example: $NEWCOIN
+      responses:
+        '200':
+          description: Ticker is taken (not available)
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  available:
+                    type: boolean
+                    example: false
+        '404':
+          description: Ticker is available
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  available:
+                    type: boolean
+                    example: true
+        '400':
+          description: Bad request - ticker parameter is required
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    example: "ticker parameter is required"
+        '500':
+          description: Server error
+          content: {}
   /coins/{mint}/insights:
     get:
       tags:

--- a/api/v1_coin.go
+++ b/api/v1_coin.go
@@ -188,3 +188,44 @@ func (app *ApiServer) v1CoinByTicker(c *fiber.Ctx) error {
 		"data": coinRow,
 	})
 }
+
+func (app *ApiServer) v1CoinTickerAvailable(c *fiber.Ctx) error {
+	ticker := c.Params("ticker")
+	if ticker == "" {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"error": "ticker parameter is required",
+		})
+	}
+
+	// Check if ticker exists in the database
+	sql := `
+		SELECT COUNT(*) 
+		FROM artist_coins 
+		WHERE ticker = @ticker
+	`
+
+	rows, err := app.pool.Query(c.Context(), sql, pgx.NamedArgs{
+		"ticker": ticker,
+	})
+	if err != nil {
+		return err
+	}
+
+	var count int
+	err = rows.Scan(&count)
+	if err != nil {
+		return err
+	}
+
+	// If count is 0, ticker is available (return 404 like handle validation)
+	if count == 0 {
+		return c.Status(fiber.StatusNotFound).JSON(fiber.Map{
+			"available": true,
+		})
+	}
+
+	// If count > 0, ticker is taken (return 200 with available: false)
+	return c.JSON(fiber.Map{
+		"available": false,
+	})
+}

--- a/api/v1_coin_test.go
+++ b/api/v1_coin_test.go
@@ -69,3 +69,52 @@ func TestV1Coin(t *testing.T) {
 		assert.Contains(t, string(body), "no rows")
 	}
 }
+
+func TestV1CoinTickerAvailable(t *testing.T) {
+	app := emptyTestApp(t)
+
+	fixtures := database.FixtureMap{
+		"artist_coins": {
+			{
+				"ticker":     "$AUDIO",
+				"decimals":   8,
+				"user_id":    1,
+				"mint":       "9LzCMqDgTKYz9Drzqnpgee3SGa89up3a247ypMj2xrqM",
+				"name":       "Audius",
+				"created_at": time.Now().Add(-time.Second),
+			},
+		},
+	}
+
+	database.Seed(app.pool.Replicas[0], fixtures)
+
+	// Test ticker that exists (should return 200 with available: false)
+	{
+		status, body := testGet(t, app, "/v1/coins/ticker/$AUDIO/available")
+		assert.Equal(t, 200, status)
+
+		jsonAssert(t, body, map[string]any{
+			"available": false,
+		})
+	}
+
+	// Test ticker that doesn't exist (should return 404 with available: true)
+	{
+		status, body := testGet(t, app, "/v1/coins/ticker/$NONEXISTENT/available")
+		assert.Equal(t, 404, status)
+
+		jsonAssert(t, body, map[string]any{
+			"available": true,
+		})
+	}
+
+	// Test with empty ticker parameter (should return 400)
+	{
+		status, body := testGet(t, app, "/v1/coins/ticker//available")
+		assert.Equal(t, 400, status)
+
+		jsonAssert(t, body, map[string]any{
+			"error": "ticker parameter is required",
+		})
+	}
+}


### PR DESCRIPTION
Adds get endpoint to check if coin ticker is available for use, which is needed during the create artist coin flow