### PR TITLE
[API-316] Migrate /challenges/:id/info

### DIFF
--- a/api/server.go
+++ b/api/server.go
@@ -474,6 +474,7 @@ func NewApiServer(config config.Config) *ApiServer {
 		// Challenges
 		g.Get("/challenges/undisbursed", app.v1ChallengesUndisbursed)
 		g.Get("/challenges/undisbursed/:userId", app.v1ChallengesUndisbursed)
+		g.Get("/challenges/:challengeId/info", app.v1ChallengesInfo)
 
 		// Metrics
 		g.Get("/metrics/genres", app.v1MetricsGenres)

--- a/api/v1_challenges_info.go
+++ b/api/v1_challenges_info.go
@@ -1,0 +1,103 @@
+package api
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/jackc/pgx/v5"
+)
+
+type GetChallengesInfoQueryParams struct {
+	WeeklyPoolMinAmount *int `query:"weekly_pool_min_amount" validate:"omitempty,min=0"`
+}
+
+type ChallengeInfo struct {
+	ChallengeID         string `json:"challenge_id" db:"id"`
+	Type                string `json:"type" db:"type"`
+	Amount              string `json:"amount" db:"amount"`
+	Active              bool   `json:"active" db:"active"`
+	StepCount           *int   `json:"step_count" db:"step_count"`
+	StartingBlock       *int   `json:"starting_block" db:"starting_block"`
+	WeeklyPool          *int   `json:"weekly_pool" db:"weekly_pool"`
+	WeeklyPoolRemaining *int   `json:"weekly_pool_remaining" db:"weekly_pool_remaining"`
+	CooldownDays        *int   `json:"cooldown_days" db:"cooldown_days"`
+}
+
+func getWeeklyPoolWindowStart() time.Time {
+	now := time.Now().UTC()
+
+	if now.Weekday() == time.Monday && now.Hour() < 16 {
+		year, month, day := now.AddDate(0, 0, -7).Date()
+		return time.Date(year, month, day, 16, 0, 0, 0, time.UTC)
+	} else {
+		// get monday of this week
+		year, month, day := now.AddDate(0, 0, -int(now.Weekday())+1).Date()
+		return time.Date(year, month, day, 16, 0, 0, 0, time.UTC)
+	}
+}
+
+func (app *ApiServer) v1ChallengesInfo(c *fiber.Ctx) error {
+	params := GetChallengesInfoQueryParams{}
+	if err := app.ParseAndValidateQueryParams(c, &params); err != nil {
+		return err
+	}
+
+	weeklyPoolWindowStart := getWeeklyPoolWindowStart()
+	fmt.Println("weeklyPoolWindowStart", weeklyPoolWindowStart)
+
+	sql := `
+	  SELECT
+	  	c.id,
+		c.type,
+		c.amount,
+		c.active,
+		c.step_count,
+		c.starting_block,
+		c.weekly_pool,
+		c.cooldown_days,
+		CASE
+			WHEN c.weekly_pool IS NULL THEN NULL
+			ELSE c.weekly_pool - COALESCE(
+				(SELECT SUM(cd.amount::bigint) / 100000000
+				 FROM challenge_disbursements cd
+				 WHERE cd.challenge_id = c.id
+				   AND cd.created_at > @weeklyPoolWindowStart),
+				0
+			)::int
+		END as weekly_pool_remaining
+	  FROM challenges c
+	  WHERE c.id = @challengeId
+	`
+
+	challengeInfo := ChallengeInfo{}
+	err := app.pool.QueryRow(c.Context(), sql, pgx.NamedArgs{
+		"challengeId":           c.Params("challengeId"),
+		"weeklyPoolWindowStart": weeklyPoolWindowStart,
+	}).Scan(
+		&challengeInfo.ChallengeID,
+		&challengeInfo.Type,
+		&challengeInfo.Amount,
+		&challengeInfo.Active,
+		&challengeInfo.StepCount,
+		&challengeInfo.StartingBlock,
+		&challengeInfo.WeeklyPool,
+		&challengeInfo.CooldownDays,
+		&challengeInfo.WeeklyPoolRemaining,
+	)
+	if err != nil {
+		return err
+	}
+
+	// Quirk of this endpoint, send a 500 if the caller specified a weekly pool min amount and
+	// it has been exceeded.
+	if params.WeeklyPoolMinAmount != nil &&
+		challengeInfo.WeeklyPoolRemaining != nil &&
+		*challengeInfo.WeeklyPoolRemaining < *params.WeeklyPoolMinAmount {
+		c.Status(500)
+	}
+
+	return c.JSON(fiber.Map{
+		"data": challengeInfo,
+	})
+}


### PR DESCRIPTION
This is mostly a debug/monitoring endpoint (not used in client or exposed in SDK).
Fun thing I learned while migrating this: The implementation in python doesn't do the math right....

I moved the calculations to be purely in the query and return the remaining pool amount as an integer. Since these values are specified in AUDIO and not in WEI, we don't need bigint/numerics for that if we cast the final result before returning it from the query.