### PR TITLE
Add audience for outgoing chat blasts

### DIFF
--- a/api/comms_chats_messages.go
+++ b/api/comms_chats_messages.go
@@ -72,7 +72,7 @@ func (app *ApiServer) getChatMessages(c *fiber.Ctx) error {
 		@chat_id as chat_id,
 		b.from_user_id as user_id,
 		b.created_at,
-		'' as audience,
+		b.audience,
 		b.plaintext as ciphertext,
 		true as is_plaintext,
 		'[]'::json AS reactions

--- a/api/comms_chats_messages_test.go
+++ b/api/comms_chats_messages_test.go
@@ -141,6 +141,7 @@ func TestGetChatMessages(t *testing.T) {
 			"data.0.message_id":     "blast1",
 			"data.0.sender_user_id": trashid.MustEncodeHashID(1),
 			"data.0.message":        "Hello followers!",
+			"data.0.audience":       "follower_audience",
 			"data.0.is_plaintext":   true,
 			"health.is_healthy":     true,
 		})
@@ -157,6 +158,7 @@ func TestGetChatMessages(t *testing.T) {
 			"data.0.message_id":     "blast2",
 			"data.0.sender_user_id": trashid.MustEncodeHashID(1),
 			"data.0.message":        "Thanks for buying my track!",
+			"data.0.audience":       "customer_audience",
 			"data.0.is_plaintext":   true,
 			"health.is_healthy":     true,
 		})


### PR DESCRIPTION
Need this to show artist coin headers in artist's own outgoing blast threads.