### PR TITLE
Better `make test-schema`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,10 +41,10 @@ test-schema::
 	@set -a; \
 	. .env; \
     if [ -z "$$writeDbUrl" ]; then \
-		echo "writeDbUrl is not set in .env - using test db"; \
+		echo "writeDbUrl is not set in .env - using test db and running migrations"; \
 		writeDbUrl=postgresql://postgres:example@localhost:21300/postgres; \
+		make migrate; \
 	fi; \
-	make migrate; \
 	adjustedUrl=$$(echo "$$writeDbUrl" | sed 's/localhost/host.docker.internal/g'); \
 	docker compose exec db bash -c "pg_dump '$$adjustedUrl' --schema-only --no-owner --no-acl > ./sql/01_schema.sql"; \
 	echo "schema dumped to ./sql/01_schema.sql"

--- a/Makefile
+++ b/Makefile
@@ -41,8 +41,10 @@ test-schema::
 	@set -a; \
 	. .env; \
     if [ -z "$$writeDbUrl" ]; then \
-		echo "writeDbUrl is not set in .env"; \
-		exit 1; \
+		echo "writeDbUrl is not set in .env - using test db"; \
+		writeDbUrl=postgresql://postgres:example@localhost:21300/postgres; \
 	fi; \
+	make migrate; \
 	adjustedUrl=$$(echo "$$writeDbUrl" | sed 's/localhost/host.docker.internal/g'); \
-	docker compose exec db bash -c "pg_dump '$$adjustedUrl' --schema-only --no-owner --no-acl > ./sql/01_schema.sql"
+	docker compose exec db bash -c "pg_dump '$$adjustedUrl' --schema-only --no-owner --no-acl > ./sql/01_schema.sql"; \
+	echo "schema dumped to ./sql/01_schema.sql"

--- a/ddl/run_migrations.go
+++ b/ddl/run_migrations.go
@@ -8,9 +8,9 @@ import (
 	"api.audius.co/config"
 )
 
-func RunMigrations() error {
+func RunMigrations(forceMigration bool) error {
 	fmt.Println("Running migrations...")
-	if !config.Cfg.RunMigrations {
+	if !config.Cfg.RunMigrations && !forceMigration {
 		fmt.Println("Skipping migrations. Set env runMigrations=true to run.")
 		return nil
 	}

--- a/main.go
+++ b/main.go
@@ -26,7 +26,7 @@ func main() {
 	switch command {
 	case "server":
 		{
-			ddl.RunMigrations()
+			ddl.RunMigrations(false)
 
 			fmt.Println("Running server...")
 			as := api.NewApiServer(config.Cfg)
@@ -34,7 +34,7 @@ func main() {
 		}
 	case "indexer":
 		{
-			ddl.RunMigrations()
+			ddl.RunMigrations(false)
 			fmt.Println("Running indexer...")
 			_, err := indexer.NewIndexer(indexer.CoreIndexerConfig{
 				DbUrl: config.Cfg.WriteDbUrl,
@@ -53,7 +53,7 @@ func main() {
 		}
 	case "solana-indexer":
 		{
-			ddl.RunMigrations()
+			ddl.RunMigrations(false)
 			fmt.Println("Running solana-indexer...")
 			solanaIndexer := solana_indexer.New(config.Cfg)
 			defer solanaIndexer.Close()
@@ -70,7 +70,7 @@ func main() {
 		}
 	case "migrate":
 		{
-			ddl.RunMigrations()
+			ddl.RunMigrations(true)
 			os.Exit(0)
 		}
 	default:


### PR DESCRIPTION
- Default to test db for `make test-schema`
- Run migrations regardless of env file config when running `make migrate`
