### PR TITLE
[PE-6663] Calculate coin holder balance at time of blast

### DIFF
--- a/api/comms/chat.go
+++ b/api/comms/chat.go
@@ -397,10 +397,12 @@ func getNewBlasts(tx dbv1.DBTX, ctx context.Context, arg getNewBlastsParams) ([]
 			WHERE blast.audience = 'coin_holder_audience'
 				AND ac.user_id = blast.from_user_id
 				AND ac.user_id != @user_id
-				AND sub.user_id = @user_id
-				AND sub.balance >= POWER(10, ac.decimals) -- must hold at least 1 coin
-				-- TODO: PE-6663 This isn't entirely correct yet, need to check "time of most recent membership"
-				AND sub.created_at < blast.created_at
+				-- Hold at least one full coin at the time the blast was created
+				AND user_mint_balance_at(
+					@user_id,
+					ac.mint,
+					blast.created_at
+				) >= power(10::bigint, ac.decimals)
 		)
 	)
 	SELECT * FROM all_new

--- a/api/comms/validator.go
+++ b/api/comms/validator.go
@@ -639,12 +639,14 @@ func hasNewBlastFromUser(pool *dbv1.DBPools, ctx context.Context, userID int32, 
 			(blast.audience = 'coin_holder_audience' and exists (
 				SELECT 1
 				FROM artist_coins ac
-				JOIN sol_user_balances sub ON sub.mint = ac.mint
 				WHERE ac.user_id = blast.from_user_id
-					AND sub.user_id = $1
-					AND sub.balance > 0
-					-- TODO: PE-6663 This isn't entirely correct yet, need to check "time of most recent membership"
-					AND sub.created_at < blast.created_at
+					AND ac.user_id != $1
+					-- Hold at least one full coin at the time the blast was created
+					AND user_mint_balance_at(
+						$1,
+						ac.mint,
+						blast.created_at
+					) >= power(10::bigint, ac.decimals)
 			))
 		)
 	)`

--- a/api/comms_blasts.go
+++ b/api/comms_blasts.go
@@ -90,16 +90,18 @@ func (app *ApiServer) getNewBlasts(c *fiber.Ctx) error {
 				AND p.created_at < blast.created_at
 		)
 		OR from_user_id IN (
-			-- coin_holder_audience via sol_user_balances
+			-- coin_holder_audience
 			SELECT ac.user_id
 			FROM artist_coins ac
-			JOIN sol_user_balances sub ON sub.mint = ac.mint
 			WHERE blast.audience = 'coin_holder_audience'
 				AND ac.user_id = blast.from_user_id
-				AND sub.user_id = @user_id
-				AND sub.balance > 0
-				-- TODO: PE-6663 This isn't entirely correct yet, need to check "time of most recent membership"
-				AND sub.created_at < blast.created_at
+				AND ac.user_id != @user_id
+				-- Hold at least one full coin at the time the blast was created
+				AND user_mint_balance_at(
+					@user_id,
+					ac.mint,
+					blast.created_at
+				) >= power(10::bigint, ac.decimals)
 		)
 	)
 	SELECT * FROM all_new

--- a/ddl/functions/chat_blast_audience.sql
+++ b/ddl/functions/chat_blast_audience.sql
@@ -66,12 +66,14 @@ BEGIN
   FROM chat_blast
   JOIN artist_coins
     ON artist_coins.user_id = chat_blast.from_user_id
-  JOIN sol_user_balances
-    ON sol_user_balances.mint = artist_coins.mint
-    AND sol_user_balances.balance >= POWER(10, artist_coins.decimals) -- must hold at least 1 coin
   WHERE chat_blast.blast_id = blast_id_param
     AND chat_blast.audience = 'coin_holder_audience'
-    AND sol_user_balances.user_id != chat_blast.from_user_id;
+    -- Hold at least one full coin at the time the blast was created
+    AND user_mint_balance_at(
+      sol_user_balances.user_id,
+      artist_coins.mint,
+      chat_blast.created_at
+    ) >= POWER(10, artist_coins.decimals);
 
 END;
 $$ LANGUAGE plpgsql;

--- a/ddl/functions/user_mint_balance_at.sql
+++ b/ddl/functions/user_mint_balance_at.sql
@@ -1,0 +1,47 @@
+-- Gets the aggregate balance for a user/mint combo at a given timestamp using sol_token_account_balance_changes
+-- It combines changes for accounts owned by any associated_wallets and sol_claimable_accounts addresses
+-- that map to the user.
+CREATE OR REPLACE FUNCTION user_mint_balance_at(
+  p_user_id  integer,
+  p_mint     text,
+  p_cutoff   timestamptz
+) RETURNS bigint
+LANGUAGE sql
+STABLE PARALLEL SAFE
+AS $$
+WITH owners AS (
+  SELECT aw.wallet AS owner_address
+  FROM associated_wallets aw
+  WHERE aw.user_id = p_user_id
+    AND aw.chain = 'sol'
+    AND aw.is_delete = FALSE
+),
+accounts AS (
+  SELECT sca.account
+  FROM users u
+  JOIN sol_claimable_accounts sca
+    ON sca.ethereum_address = u.wallet
+  WHERE u.user_id = p_user_id
+),
+latest AS (
+  SELECT DISTINCT ON (s.mint, s.account) s.balance
+  FROM (
+    SELECT stabc.*
+    FROM sol_token_account_balance_changes stabc
+    WHERE stabc.mint = p_mint
+      AND stabc.block_timestamp <= p_cutoff
+      AND stabc.account IN (SELECT account FROM accounts)
+
+    UNION ALL
+
+    SELECT stabc.*
+    FROM sol_token_account_balance_changes stabc
+    WHERE stabc.mint = p_mint
+      AND stabc.block_timestamp <= p_cutoff
+      AND stabc.owner IN (SELECT owner_address FROM owners)
+  ) AS s
+  ORDER BY s.mint, s.account, s.block_timestamp DESC, s.slot DESC
+)
+SELECT COALESCE(SUM(balance), 0)::bigint
+FROM latest;
+$$;

--- a/sql/01_schema.sql
+++ b/sql/01_schema.sql
@@ -1168,12 +1168,14 @@ BEGIN
   FROM chat_blast
   JOIN artist_coins
     ON artist_coins.user_id = chat_blast.from_user_id
-  JOIN sol_user_balances
-    ON sol_user_balances.mint = artist_coins.mint
-    AND sol_user_balances.balance >= POWER(10, artist_coins.decimals) -- must hold at least 1 coin
   WHERE chat_blast.blast_id = blast_id_param
     AND chat_blast.audience = 'coin_holder_audience'
-    AND sol_user_balances.user_id != chat_blast.from_user_id;
+    -- Hold at least one full coin at the time the blast was created
+    AND user_mint_balance_at(
+      sol_user_balances.user_id,
+      artist_coins.mint,
+      chat_blast.created_at
+    ) >= POWER(10, artist_coins.decimals);
 
 END;
 $$;
@@ -10836,4 +10838,5 @@ ALTER TABLE ONLY public.users
 --
 -- PostgreSQL database dump complete
 --
+
 

--- a/sql/01_schema.sql
+++ b/sql/01_schema.sql
@@ -3,7 +3,7 @@
 --
 
 -- Dumped from database version 17.5 (Debian 17.5-1.pgdg120+1)
--- Dumped by pg_dump version 17.5 (Debian 17.5-1.pgdg120+1)
+-- Dumped by pg_dump version 17.6 (Debian 17.6-1.pgdg13+1)
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;
@@ -2011,14 +2011,14 @@ begin
   select * into reward_manager_tx from reward_manager_txs where reward_manager_txs.signature = new.signature limit 1;
 
   if reward_manager_tx is not null then
-		select id into existing_notification 
+		select id into existing_notification
 		from notification
 		where
 		type = 'challenge_reward' and
 		new.user_id = any(user_ids) and
 		timestamp >= (new.created_at - interval '1 hour')
 		limit 1;
-		
+
 		if existing_notification is null then
 			-- create a notification for the challenge disbursement
 			insert into notification
@@ -2137,14 +2137,14 @@ CREATE FUNCTION public.handle_comment() RETURNS trigger
     AS $$
 begin
   if new.entity_type = 'Track' then
-    insert into aggregate_track (track_id) 
-    values (new.entity_id) 
+    insert into aggregate_track (track_id)
+    values (new.entity_id)
     on conflict do nothing;
   end if;
 
   -- update agg track
   if new.entity_type = 'Track' then
-    update aggregate_track 
+    update aggregate_track
     set comment_count = (
       select count(*)
       from comments c
@@ -2204,9 +2204,9 @@ begin
   -- Only proceed if this is a remix contest event
   if new.event_type = 'remix_contest' and new.is_deleted = false then
     -- Get the owner of the track and check if it's public
-    select owner_id, not is_unlisted into owner_user_id, track_is_public 
-    from tracks 
-    where is_current and track_id = new.entity_id 
+    select owner_id, not is_unlisted into owner_user_id, track_is_public
+    from tracks
+    where is_current and track_id = new.entity_id
     limit 1;
 
     -- Only create notifications if the track is public
@@ -2286,11 +2286,11 @@ begin
     delta := 1;
   end if;
 
-  update aggregate_user 
-  set following_count = following_count + delta 
+  update aggregate_user
+  set following_count = following_count + delta
   where user_id = new.follower_user_id;
 
-  update aggregate_user 
+  update aggregate_user
   set follower_count = follower_count + delta
   where user_id = new.followee_user_id
   returning follower_count into new_follower_count;
@@ -2299,7 +2299,7 @@ begin
   select new_follower_count into milestone where new_follower_count in (10, 25, 50, 100, 250, 500, 1000, 5000, 10000, 20000, 50000, 100000, 1000000);
   select score < 0 into is_shadowbanned from aggregate_user where user_id = new.follower_user_id;
   if milestone is not null and new.is_delete is false and is_shadowbanned = false then
-      insert into milestones 
+      insert into milestones
         (id, name, threshold, blocknumber, slot, timestamp)
       values
         (new.followee_user_id, 'FOLLOWER_COUNT', milestone, new.blocknumber, new.slot, new.created_at)
@@ -2348,7 +2348,7 @@ exception
     raise warning 'An error occurred in %: %', tg_name, sqlerrm;
     raise;
 
-end; 
+end;
 $$;
 
 
@@ -2404,7 +2404,7 @@ begin
                 'challenge_reward',
                 'challenge_reward:' || new.user_id || ':challenge:' || new.challenge_id || ':specifier:' || new.specifier,
                 new.user_id,
-                case 
+                case
                     when new.challenge_id = 'e' then
                         json_build_object(
                             'specifier', new.specifier,
@@ -2422,9 +2422,9 @@ begin
             )
             on conflict do nothing;
         else
-            -- transactional notifications cover this 
+            -- transactional notifications cover this
             if (new.challenge_id != 'b' and new.challenge_id != 's') then
-                select id into existing_notification 
+                select id into existing_notification
                 from notification
                 where
                 type = 'reward_in_cooldown' and
@@ -2474,7 +2474,7 @@ begin
     insert into aggregate_plays (play_item_id, count) values (new.play_item_id, 0) on conflict do nothing;
 
     update aggregate_plays
-        set count = count + 1 
+        set count = count + 1
         where play_item_id = new.play_item_id
         returning count into new_listen_count;
 
@@ -2489,8 +2489,8 @@ begin
         and timestamp = date_trunc('month', new.created_at)
         and country = coalesce(new.country, '');
 
-    select new_listen_count 
-        into milestone 
+    select new_listen_count
+        into milestone
         where new_listen_count in (10,25,50,100,250,500,1000,2500,5000,10000,25000,50000,100000,250000,500000,1000000);
 
     if milestone is not null then
@@ -2690,7 +2690,7 @@ begin
           json_build_object('track_id', new.track_id, 'playlist_id', new.playlist_id, 'playlist_owner_id', playlist_record.playlist_owner_id)
         from album_purchasers as album_purchaser;
   end if;
-  
+
   return null;
 
 exception
@@ -2717,16 +2717,16 @@ declare
 begin
 
   raise NOTICE 'start';
-  
+
   if new.reaction_type = 'tip' then
 
     raise NOTICE 'is tip';
 
-    SELECT amount, sender_user_id, receiver_user_id 
-    INTO tip_amount, tip_sender_user_id, tip_receiver_user_id 
-    FROM user_tips ut 
+    SELECT amount, sender_user_id, receiver_user_id
+    INTO tip_amount, tip_sender_user_id, tip_receiver_user_id
+    FROM user_tips ut
     WHERE ut.signature = new.reacted_to;
-    
+
     raise NOTICE 'did select % %', tip_sender_user_id, tip_receiver_user_id;
     raise NOTICE 'did select %', new.reacted_to;
 
@@ -2821,7 +2821,7 @@ begin
   end if;
 
   -- update agg user
-  update aggregate_user 
+  update aggregate_user
   set repost_count = (
     select count(*)
     from reposts r
@@ -2834,7 +2834,7 @@ begin
   -- update agg track or playlist
   if new.repost_type = 'track' then
     milestone_name := 'TRACK_REPOST_COUNT';
-    update aggregate_track 
+    update aggregate_track
     set repost_count = (
       select count(*)
       from reposts r
@@ -2860,7 +2860,7 @@ begin
           and r.is_delete is false
           and r.repost_type = new.repost_type
           and r.repost_item_id = new.repost_item_id
-    )    
+    )
     where playlist_id = new.repost_item_id
     returning repost_count into new_val;
 
@@ -2874,7 +2874,7 @@ begin
   select score < 0 into is_shadowbanned from aggregate_user where user_id = new.user_id;
 
   if new.is_delete = false and milestone is not null and owner_user_id is not null and is_shadowbanned = false then
-    insert into milestones 
+    insert into milestones
       (id, name, threshold, blocknumber, slot, timestamp)
     values
       (new.repost_item_id, milestone_name, milestone, new.blocknumber, new.slot, new.created_at)
@@ -2975,7 +2975,7 @@ begin
 				'user_id',
 				new.user_id,
 				'type',
-        case 
+        case
           when is_album then 'album'
           else new.repost_type
         end
@@ -3079,7 +3079,7 @@ begin
     where p.playlist_id = new.save_item_id
     and p.is_current
     on conflict do nothing;
-    
+
     select ap.is_album into is_album
     from aggregate_playlist ap
     where ap.playlist_id = new.save_item_id;
@@ -3104,7 +3104,7 @@ begin
   if new.save_type = 'track' then
     milestone_name := 'TRACK_SAVE_COUNT';
 
-    update aggregate_track 
+    update aggregate_track
     set save_count = (
       select count(*)
       from saves r
@@ -3118,7 +3118,7 @@ begin
     returning save_count into new_val;
 
     -- update agg user
-    update aggregate_user 
+    update aggregate_user
     set track_save_count = (
       select count(*)
       from saves r
@@ -3128,7 +3128,7 @@ begin
         and r.save_type = new.save_type
     )
     where user_id = new.user_id;
-    
+
   	if new.is_delete IS FALSE then
 		  select tracks.owner_id, tracks.remix_of into owner_user_id, track_remix_of from tracks where is_current and track_id = new.save_item_id;
 	  end if;
@@ -3159,7 +3159,7 @@ begin
   select score < 0 into is_shadowbanned from aggregate_user where user_id = new.user_id;
 
   if new.is_delete = false and milestone is not null and is_shadowbanned = false then
-    insert into milestones 
+    insert into milestones
       (id, name, threshold, blocknumber, slot, timestamp)
     values
       (new.save_item_id, milestone_name, milestone, new.blocknumber, new.slot, new.created_at)
@@ -3203,10 +3203,10 @@ begin
       insert into notification
         (blocknumber, user_ids, timestamp, type, specifier, group_id, data)
         values
-        ( 
+        (
           new.blocknumber,
-          ARRAY [owner_user_id], 
-          new.created_at, 
+          ARRAY [owner_user_id],
+          new.created_at,
           'save',
           new.user_id,
           'save:' || new.save_item_id || ':type:'|| new.save_type,
@@ -3265,7 +3265,7 @@ begin
           'user_id',
           new.user_id,
           'type',
-          case 
+          case
             when is_album then 'album'
             else new.save_type
           end
@@ -3279,16 +3279,16 @@ begin
     if new.is_delete is false and new.save_type = 'track' and track_remix_of is not null and is_shadowbanned = false then
       select
         case when tracks.owner_id = new.user_id then TRUE else FALSE end as boolean into is_remix_cosign
-        from tracks 
+        from tracks
         where is_current and track_id = (track_remix_of->'tracks'->0->>'parent_track_id')::int;
       if is_remix_cosign then
         insert into notification
           (blocknumber, user_ids, timestamp, type, specifier, group_id, data)
           values
-          ( 
+          (
             new.blocknumber,
-            ARRAY [owner_user_id], 
-            new.created_at, 
+            ARRAY [owner_user_id],
+            new.created_at,
             'cosign',
             new.user_id,
             'cosign:parent_track' || (track_remix_of->'tracks'->0->>'parent_track_id')::int || ':original_track:'|| new.save_item_id,
@@ -3310,7 +3310,7 @@ exception
       raise warning 'An error occurred in %: %', tg_name, sqlerrm;
       raise;
 
-end; 
+end;
 $$;
 
 
@@ -3425,7 +3425,7 @@ BEGIN
         slot = EXCLUDED.slot,
         updated_at = NOW()
         WHERE sol_token_account_balances.slot < EXCLUDED.slot;
-    
+
     FOR v_user_id IN
         SELECT user_id
         FROM associated_wallets
@@ -3737,7 +3737,7 @@ begin
     when others then
         raise warning 'An error occurred in %: %', tg_name, sqlerrm;
         return null;
-end; 
+end;
 $$;
 
 
@@ -3836,7 +3836,7 @@ begin
   ) as tier (label, val)
   WHERE
     substr(new.current_balance, 1, GREATEST(1, length(new.current_balance) - 18))::bigint >= tier.val
-  ORDER BY 
+  ORDER BY
     tier.val DESC
   limit 1;
 
@@ -3846,7 +3846,7 @@ begin
   ) as tier (label, val)
   WHERE
     substr(new.previous_balance, 1, GREATEST(1, length(new.previous_balance) - 18))::bigint >= tier.val
-  ORDER BY 
+  ORDER BY
     tier.val DESC
   limit 1;
 
@@ -3855,10 +3855,10 @@ begin
     insert into notification
       (blocknumber, user_ids, timestamp, type, specifier, group_id, data)
     values
-      ( 
+      (
         new.blocknumber,
-        ARRAY [new.user_id], 
-        new.updated_at, 
+        ARRAY [new.user_id],
+        new.updated_at,
         'tier_change',
         new.user_id,
         'tier_change:user_id:' || new.user_id ||  ':tier:' || new_tier || ':blocknumber:' || new.blocknumber,
@@ -3894,10 +3894,10 @@ begin
   insert into notification
     (slot, user_ids, timestamp, type, specifier, group_id, data)
   values
-    ( 
+    (
       new.slot,
-      ARRAY [new.receiver_user_id], 
-      new.created_at, 
+      ARRAY [new.receiver_user_id],
+      new.created_at,
       'tip_receive',
       new.receiver_user_id,
       'tip_receive:user_id:' || new.receiver_user_id || ':signature:' || new.signature,
@@ -3908,10 +3908,10 @@ begin
         'tx_signature', new.signature
       )
     ),
-    ( 
+    (
       new.slot,
-      ARRAY [new.sender_user_id], 
-      new.created_at, 
+      ARRAY [new.sender_user_id],
+      new.created_at,
       'tip_send',
       new.sender_user_id,
       'tip_send:user_id:' || new.sender_user_id || ':signature:' || new.signature,
@@ -4449,7 +4449,7 @@ declare
 begin
     -- fetch the user_id where wallet matches grantee_address
     select user_id into matched_user_id from users where lower(wallet) = lower(NEW.grantee_address);
-    
+
     if matched_user_id is not null then
         -- if the grant is newly created (i.e. the grant is not deleted, is not approved yet, and was just created indicated by created timestamp = last updated timestamp) OR grant went from deleted (revoked) to not deleted and is not approved yet...
         if (TG_OP = 'INSERT' and NEW.is_revoked = FALSE and NEW.is_approved is null and NEW.created_at = NEW.updated_at or
@@ -4503,7 +4503,7 @@ exception
   when others then
       raise warning 'An error occurred in %: %', tg_name, sqlerrm;
       return null;
-end; 
+end;
 $$;
 
 
@@ -5010,10 +5010,10 @@ BEGIN
         NOW(),
         NOW()
     FROM (
-        SELECT 
-            p_user_id AS user_id, 
+        SELECT
+            p_user_id AS user_id,
             COALESCE(balance, 0) AS balance
-        FROM associated_wallets 
+        FROM associated_wallets
         JOIN sol_token_account_balances AS associated_wallet_balances
             ON associated_wallet_balances.owner = associated_wallets.wallet
             AND associated_wallet_balances.mint = p_mint
@@ -5023,8 +5023,8 @@ BEGIN
 
         UNION ALL
 
-        SELECT 
-            p_user_id AS user_id, 
+        SELECT
+            p_user_id AS user_id,
             COALESCE(balance, 0) AS balance
         FROM users
         JOIN sol_claimable_accounts
@@ -5040,6 +5040,51 @@ BEGIN
         balance = EXCLUDED.balance,
         updated_at = NOW();
 END;
+$$;
+
+
+--
+-- Name: user_mint_balance_at(integer, text, timestamp with time zone); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.user_mint_balance_at(p_user_id integer, p_mint text, p_cutoff timestamp with time zone) RETURNS bigint
+    LANGUAGE sql STABLE PARALLEL SAFE
+    AS $$
+WITH owners AS (
+  SELECT aw.wallet AS owner_address
+  FROM associated_wallets aw
+  WHERE aw.user_id = p_user_id
+    AND aw.chain = 'sol'
+    AND aw.is_delete = FALSE
+),
+accounts AS (
+  SELECT sca.account
+  FROM users u
+  JOIN sol_claimable_accounts sca
+    ON sca.ethereum_address = u.wallet
+  WHERE u.user_id = p_user_id
+),
+latest AS (
+  SELECT DISTINCT ON (s.mint, s.account) s.balance
+  FROM (
+    SELECT stabc.*
+    FROM sol_token_account_balance_changes stabc
+    WHERE stabc.mint = p_mint
+      AND stabc.block_timestamp <= p_cutoff
+      AND stabc.account IN (SELECT account FROM accounts)
+
+    UNION ALL
+
+    SELECT stabc.*
+    FROM sol_token_account_balance_changes stabc
+    WHERE stabc.mint = p_mint
+      AND stabc.block_timestamp <= p_cutoff
+      AND stabc.owner IN (SELECT owner_address FROM owners)
+  ) AS s
+  ORDER BY s.mint, s.account, s.block_timestamp DESC, s.slot DESC
+)
+SELECT COALESCE(SUM(balance), 0)::bigint
+FROM latest;
 $$;
 
 


### PR DESCRIPTION
This adds a new sql function to get the aggregate balance for a user at a given time by summing the raw balance changes, and updates our queries to use that instead of just checking created_at and balance > 0.

TODO:
Update tests