### PR TITLE
Add dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.env*
+.DS_Store
+build
+scratch
+gitleaks-report.json


### PR DESCRIPTION
Just a little safety thing in case somebody decides to build a docker image locally and push it up :-). Copied the contents of `.gitignore` minus the old module name.