### PR TITLE
[API-355] Add health check metrics for new core indexer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,4 +47,5 @@ test-schema::
 	fi; \
 	adjustedUrl=$$(echo "$$writeDbUrl" | sed 's/localhost/host.docker.internal/g'); \
 	docker compose exec db bash -c "pg_dump '$$adjustedUrl' --schema-only --no-owner --no-acl > ./sql/01_schema.sql"; \
+	sed '/^\\restrict /d;/^\\unrestrict /d' ./sql/01_schema.sql > ./sql/01_schema.sql.tmp && mv ./sql/01_schema.sql.tmp ./sql/01_schema.sql; \
 	echo "schema dumped to ./sql/01_schema.sql"

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ docker compose up -d
 make test
 ```
 
-#### To run tests with custom migrations
+#### To update schema after migration changes and run tests
 ```
 docker compose up -d
 
@@ -80,21 +80,6 @@ http://localhost:1323/apidiff.html
 Tool for interacting with the postgres server
 
 http://localhost:21301/?pgsql=db&username=postgres
-
-## Schema dump
-
-```
-docker compose exec db bash
-export discoveryDbUrl='a_db_url'
-pg_dump $discoveryDbUrl --schema-only --no-comments --no-owner --no-acl > ./sql/01_schema.sql
-```
-
-If you re-dump schema, reset dev postgres state:
-
-```
-docker compose down --volumes
-docker compose up -d
-```
 
 ## ElasticSearch
 

--- a/api/health_check.go
+++ b/api/health_check.go
@@ -1,7 +1,14 @@
 package api
 
 import (
+	"context"
+	"math"
+
+	core_indexer "api.audius.co/indexer"
+	"connectrpc.com/connect"
+	corev1 "github.com/AudiusProject/audiusd/pkg/api/core/v1"
 	"github.com/gofiber/fiber/v2"
+	"go.uber.org/zap"
 )
 
 type contentNode struct {
@@ -15,7 +22,35 @@ type networkInfo struct {
 }
 
 type healthCheckResponse struct {
-	Network networkInfo `json:"network"`
+	CoreIndexer *coreIndexerHealth `json:"core_indexer"`
+	Network     networkInfo        `json:"network"`
+}
+
+type coreIndexerHealth struct {
+	LastIndexedBlock int64 `json:"last_indexed_block"`
+	BlockDiff        int64 `json:"block_diff"`
+}
+
+func (app *ApiServer) getCoreIndexerHealth(ctx context.Context) (*coreIndexerHealth, error) {
+	nodeInfo, err := app.auds.Core.GetNodeInfo(ctx, connect.NewRequest(&corev1.GetNodeInfoRequest{}))
+	if err != nil {
+		return nil, fiber.NewError(fiber.StatusInternalServerError, "Failed to get core node info")
+	}
+	chainHeight := nodeInfo.Msg.CurrentHeight
+
+	var indexerLastBlockHeight int64
+	err = app.pool.QueryRow(ctx, "SELECT COALESCE(last_checkpoint, 0) FROM indexing_checkpoints WHERE tablename = $1", core_indexer.CoreIndexerCheckpointName).Scan(&indexerLastBlockHeight)
+	if err != nil {
+		return nil, fiber.NewError(fiber.StatusInternalServerError, "Failed to get core indexer last block height")
+	}
+
+	// Indexer can actually be ahead of the block our RPC returns!
+	blockDiff := int64(math.Max(0, float64(chainHeight-indexerLastBlockHeight)))
+
+	return &coreIndexerHealth{
+		LastIndexedBlock: indexerLastBlockHeight,
+		BlockDiff:        blockDiff,
+	}, nil
 }
 
 func (app *ApiServer) healthCheck(c *fiber.Ctx) error {
@@ -29,7 +64,13 @@ func (app *ApiServer) healthCheck(c *fiber.Ctx) error {
 		}
 	}
 
+	coreIndexerHealth, err := app.getCoreIndexerHealth(c.Context())
+	if err != nil {
+		app.logger.Error("Failed to get core indexer health", zap.Error(err))
+	}
+
 	health := healthCheckResponse{
+		CoreIndexer: coreIndexerHealth,
 		Network: networkInfo{
 			ContentNodes: contentNodes,
 		},

--- a/api/health_check.go
+++ b/api/health_check.go
@@ -53,7 +53,17 @@ func (app *ApiServer) getCoreIndexerHealth(ctx context.Context) (*coreIndexerHea
 	}, nil
 }
 
+type HealthCheckQueryParams struct {
+	MaxCoreIndexerBlockDiff *int64 `query:"max_core_indexer_block_diff" validate:"omitempty,min=0"`
+}
+
 func (app *ApiServer) healthCheck(c *fiber.Ctx) error {
+	var params HealthCheckQueryParams
+	err := app.ParseAndValidateQueryParams(c, &params)
+	if err != nil {
+		return err
+	}
+
 	healthyNodes := app.contentNodeMonitor.GetContentNodes()
 	// Convert config.Node to contentNode
 	contentNodes := make([]contentNode, len(healthyNodes))
@@ -67,6 +77,12 @@ func (app *ApiServer) healthCheck(c *fiber.Ctx) error {
 	coreIndexerHealth, err := app.getCoreIndexerHealth(c.Context())
 	if err != nil {
 		app.logger.Error("Failed to get core indexer health", zap.Error(err))
+	}
+
+	if params.MaxCoreIndexerBlockDiff != nil {
+		if coreIndexerHealth.BlockDiff > *params.MaxCoreIndexerBlockDiff {
+			c.Status(fiber.StatusInternalServerError)
+		}
 	}
 
 	health := healthCheckResponse{

--- a/api/health_check.go
+++ b/api/health_check.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"context"
-	"math"
 
 	core_indexer "api.audius.co/indexer"
 	"connectrpc.com/connect"
@@ -44,8 +43,7 @@ func (app *ApiServer) getCoreIndexerHealth(ctx context.Context) (*coreIndexerHea
 		return nil, fiber.NewError(fiber.StatusInternalServerError, "Failed to get core indexer last block height")
 	}
 
-	// Indexer can actually be ahead of the block our RPC returns!
-	blockDiff := int64(math.Max(0, float64(chainHeight-indexerLastBlockHeight)))
+	blockDiff := chainHeight - indexerLastBlockHeight
 
 	return &coreIndexerHealth{
 		LastIndexedBlock: indexerLastBlockHeight,

--- a/api/health_check.go
+++ b/api/health_check.go
@@ -80,7 +80,9 @@ func (app *ApiServer) healthCheck(c *fiber.Ctx) error {
 	}
 
 	if params.MaxCoreIndexerBlockDiff != nil {
-		if coreIndexerHealth.BlockDiff > *params.MaxCoreIndexerBlockDiff {
+		// If max diff was requested but we failed to calculate it,
+		// return 500 just to be safe.
+		if coreIndexerHealth == nil || coreIndexerHealth.BlockDiff > *params.MaxCoreIndexerBlockDiff {
 			c.Status(fiber.StatusInternalServerError)
 		}
 	}

--- a/indexer/indexer.go
+++ b/indexer/indexer.go
@@ -25,7 +25,7 @@ type CoreIndexer struct {
 }
 
 const (
-	coreIndexerCheckpointName = "api_core_indexer_last_height"
+	CoreIndexerCheckpointName = "api_core_indexer_last_height"
 )
 
 func NewIndexer(config config.Config) *CoreIndexer {
@@ -54,7 +54,7 @@ func (ci *CoreIndexer) Start(ctx context.Context) error {
 	sdk := sdk.NewAudiusdSDK(ci.Config.AudiusdURL)
 
 	var height int64
-	err := ci.pool.QueryRow(context.Background(), `select last_checkpoint from indexing_checkpoints where tablename = $1`, coreIndexerCheckpointName).Scan(&height)
+	err := ci.pool.QueryRow(context.Background(), `select last_checkpoint from indexing_checkpoints where tablename = $1`, CoreIndexerCheckpointName).Scan(&height)
 	if err != nil {
 		if err == pgx.ErrNoRows {
 			nodeInfo, err := sdk.Core.GetNodeInfo(context.Background(), connect.NewRequest(&corev1.GetNodeInfoRequest{}))
@@ -128,7 +128,7 @@ func (ci *CoreIndexer) handleBlock(block *corev1.Block) error {
 	_, err = dbTx.Exec(context.Background(), `
 	insert into indexing_checkpoints values ($1, $2)
 	on conflict (tablename) do update set last_checkpoint = excluded.last_checkpoint
-	`, coreIndexerCheckpointName, block.Height)
+	`, CoreIndexerCheckpointName, block.Height)
 
 	if err != nil {
 		return err

--- a/sql/01_schema.sql
+++ b/sql/01_schema.sql
@@ -2,10 +2,9 @@
 -- PostgreSQL database dump
 --
 
-\restrict qNSeJSiwqv3O2HB9UoUDJoM3QufXge5QMQYu9BaYLHKGZxri689g8MaAhCBLi5s
 
--- Dumped from database version 15.13
--- Dumped by pg_dump version 17.6 (Debian 17.6-2.pgdg13+1)
+-- Dumped from database version 17.6 (Debian 17.6-1.pgdg13+1)
+-- Dumped by pg_dump version 17.6 (Debian 17.6-1.pgdg13+1)
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;
@@ -24,13 +23,6 @@ SET row_security = off;
 --
 
 CREATE SCHEMA hashids;
-
-
---
--- Name: public; Type: SCHEMA; Schema: -; Owner: -
---
-
--- *not* creating schema, since initdb creates it
 
 
 --
@@ -181,17 +173,6 @@ CREATE TYPE public.profile_type_enum AS ENUM (
 
 
 --
--- Name: proof_status; Type: TYPE; Schema: public; Owner: -
---
-
-CREATE TYPE public.proof_status AS ENUM (
-    'unresolved',
-    'pass',
-    'fail'
-);
-
-
---
 -- Name: reposttype; Type: TYPE; Schema: public; Owner: -
 --
 
@@ -251,16 +232,6 @@ CREATE TYPE public.usdc_purchase_content_type AS ENUM (
     'track',
     'playlist',
     'album'
-);
-
-
---
--- Name: validator_event; Type: TYPE; Schema: public; Owner: -
---
-
-CREATE TYPE public.validator_event AS ENUM (
-    'registered',
-    'deregistered'
 );
 
 
@@ -998,8 +969,8 @@ BEGIN
       -- Logging the action
       RAISE NOTICE 'Adding foreign key constraint to table %', _table_name;
 
-      EXECUTE format('ALTER TABLE %s ADD CONSTRAINT %s FOREIGN KEY (blocknumber) REFERENCES blocks (number) ON DELETE CASCADE', 
-                     quote_ident(_table_name), 
+      EXECUTE format('ALTER TABLE %s ADD CONSTRAINT %s FOREIGN KEY (blocknumber) REFERENCES blocks (number) ON DELETE CASCADE',
+                     quote_ident(_table_name),
                      quote_ident(_table_name || '_blocknumber_fkey'));
 
    END LOOP;
@@ -1643,9 +1614,9 @@ BEGIN
       -- Logging the deletion
       RAISE NOTICE 'Deleting rows from table % where is_current is false', _table_name;
 
-      EXECUTE format('DELETE FROM %s WHERE is_current = false', 
+      EXECUTE format('DELETE FROM %s WHERE is_current = false',
                      quote_ident(_table_name));
-                     
+
    END LOOP;
 END
 $$;
@@ -1665,7 +1636,7 @@ BEGIN
    LOOP
       RAISE NOTICE 'Deleting rows from table % where is_current is false', _table_name;
 
-      EXECUTE format('DELETE FROM %s WHERE is_current = false', 
+      EXECUTE format('DELETE FROM %s WHERE is_current = false',
                      quote_ident(_table_name));
 
    END LOOP;
@@ -1686,11 +1657,11 @@ BEGIN
    FOREACH _table_name IN ARRAY _table_names
    LOOP
       RAISE NOTICE 'Dropping foreign key constraint to table %', _table_name;
-      EXECUTE format('LOCK TABLE %s IN ACCESS EXCLUSIVE MODE', 
+      EXECUTE format('LOCK TABLE %s IN ACCESS EXCLUSIVE MODE',
                      quote_ident(_table_name));
 
-      EXECUTE format('ALTER TABLE %s DROP CONSTRAINT IF EXISTS %s', 
-                     quote_ident(_table_name), 
+      EXECUTE format('ALTER TABLE %s DROP CONSTRAINT IF EXISTS %s',
+                     quote_ident(_table_name),
                      quote_ident(_table_name || '_blocknumber_fkey'));
 
    END LOOP;
@@ -1732,227 +1703,6 @@ BEGIN
 
     return next;
 END;
-$$;
-
-
---
--- Name: get_computed_scores(integer[]); Type: FUNCTION; Schema: public; Owner: -
---
-
-CREATE FUNCTION public.get_computed_scores(target_user_ids integer[] DEFAULT NULL::integer[]) RETURNS TABLE(user_id integer, handle_lc text, play_count integer, follower_count integer, challenge_count integer, following_count integer, score integer)
-    LANGUAGE sql
-    AS $$
-    with play_activity as (
-        select plays.user_id,
-            count(distinct date_trunc('minute', plays.created_at)) as play_count
-        from plays
-        join users on plays.user_id = users.user_id
-        where target_user_ids is null or plays.user_id = any(target_user_ids)
-        group by plays.user_id
-    ),
-    fast_challenge_completion as (
-        select users.user_id,
-            handle_lc,
-            users.created_at,
-            count(*) as challenge_count,
-            array_agg(user_challenges.challenge_id) as challenge_ids
-        from users
-        left join user_challenges on users.user_id = user_challenges.user_id
-        where user_challenges.is_complete
-            and user_challenges.completed_at - users.created_at <= interval '3 minutes'
-            and user_challenges.challenge_id not in ('m', 'b')
-            and (target_user_ids is null or users.user_id = any(target_user_ids))
-        group by users.user_id, users.handle_lc, users.created_at
-    ),
-    chat_blocks as (
-        select chat_blocked_users.blockee_user_id as user_id,
-            count(*) as block_count
-        from chat_blocked_users
-        join users on chat_blocked_users.blockee_user_id = users.user_id
-        where target_user_ids is null or chat_blocked_users.blockee_user_id = any(target_user_ids)
-        group by chat_blocked_users.blockee_user_id
-    ),
-    aggregate_scores as (
-        select users.user_id,
-            users.handle_lc,
-            users.created_at,
-            coalesce(play_activity.play_count, 0) as play_count,
-            coalesce(fast_challenge_completion.challenge_count, 0) as challenge_count,
-            coalesce(aggregate_user.following_count, 0) as following_count,
-            coalesce(aggregate_user.follower_count, 0) as follower_count,
-            coalesce(chat_blocks.block_count, 0) as block_count
-        from users
-        left join play_activity on users.user_id = play_activity.user_id
-        left join fast_challenge_completion on users.user_id = fast_challenge_completion.user_id
-        left join chat_blocks on users.user_id = chat_blocks.user_id
-        left join aggregate_user on aggregate_user.user_id = users.user_id
-        where users.handle_lc is not null
-            and (target_user_ids is null or users.user_id = any(target_user_ids))
-    )
-    select a.user_id,
-        a.handle_lc,
-        a.play_count,
-        a.follower_count,
-        a.challenge_count,
-        a.following_count,
-        (
-            a.play_count + a.follower_count - a.challenge_count - (a.block_count * 10) +
-            case when a.following_count < 5 then -1 else 0 end
-        ) as score
-    from aggregate_scores a
-$$;
-
-
---
--- Name: get_computed_scores(integer); Type: FUNCTION; Schema: public; Owner: -
---
-
-CREATE FUNCTION public.get_computed_scores(target_user_id integer DEFAULT NULL::integer) RETURNS TABLE(user_id integer, handle_lc text, play_count integer, follower_count integer, challenge_count integer, following_count integer, score integer)
-    LANGUAGE sql
-    AS $$
-    with play_activity as (
-        select plays.user_id,
-            count(distinct date_trunc('minute', plays.created_at)) as play_count
-        from plays
-        join users on plays.user_id = users.user_id
-        where target_user_id is null or plays.user_id = target_user_id
-        group by plays.user_id
-    ),
-    fast_challenge_completion as (
-        select users.user_id,
-            handle_lc,
-            users.created_at,
-            count(*) as challenge_count,
-            array_agg(user_challenges.challenge_id) as challenge_ids
-        from users
-        left join user_challenges on users.user_id = user_challenges.user_id
-        where user_challenges.is_complete
-            and user_challenges.completed_at - users.created_at <= interval '3 minutes'
-            and user_challenges.challenge_id not in ('m', 'b')
-            and (target_user_id is null or users.user_id = target_user_id)
-        group by users.user_id, users.handle_lc, users.created_at
-    ),
-    chat_blocks as (
-        select chat_blocked_users.blockee_user_id as user_id,
-            count(*) as block_count
-        from chat_blocked_users
-        join users on chat_blocked_users.blockee_user_id = users.user_id
-        where target_user_id is null or chat_blocked_users.blockee_user_id = target_user_id
-        group by chat_blocked_users.blockee_user_id
-    ),
-    aggregate_scores as (
-        select users.user_id,
-            users.handle_lc,
-            users.created_at,
-            coalesce(play_activity.play_count, 0) as play_count,
-            coalesce(fast_challenge_completion.challenge_count, 0) as challenge_count,
-            coalesce(aggregate_user.following_count, 0) as following_count,
-            coalesce(aggregate_user.follower_count, 0) as follower_count,
-            coalesce(chat_blocks.block_count, 0) as block_count
-        from users
-        left join play_activity on users.user_id = play_activity.user_id
-        left join fast_challenge_completion on users.user_id = fast_challenge_completion.user_id
-        left join chat_blocks on users.user_id = chat_blocks.user_id
-        left join aggregate_user on aggregate_user.user_id = users.user_id
-        where users.handle_lc is not null
-            and (target_user_id is null or users.user_id = target_user_id)
-    )
-    select
-        a.user_id,
-        a.handle_lc,
-        a.play_count,
-        a.follower_count,
-        a.challenge_count,
-        a.following_count,
-        (
-            a.play_count + a.follower_count - a.challenge_count - (a.block_count * 10) +
-            case when a.following_count < 5 then -1 else 0 end
-        ) as score
-    from aggregate_scores a
-$$;
-
-
---
--- Name: get_shadowbanned_users(integer[]); Type: FUNCTION; Schema: public; Owner: -
---
-
-CREATE FUNCTION public.get_shadowbanned_users(user_ids integer[]) RETURNS TABLE(user_id integer)
-    LANGUAGE plpgsql
-    AS $$ begin return query with scoped_users as (
-        select users.user_id
-        from users
-        where users.user_id = any (user_ids)
-    ),
-    play_activity as (
-        select plays.user_id,
-            count(distinct date_trunc('minute', plays.created_at)) as play_count
-        from plays
-        where plays.user_id is not null
-            and plays.user_id in (
-                select scoped_users.user_id
-                from scoped_users
-            )
-        group by plays.user_id
-    ),
-    fast_challenge_completion as (
-        select users.user_id,
-            handle_lc,
-            users.created_at,
-            count(*) as challenge_count,
-            array_agg(user_challenges.challenge_id) as challenge_ids
-        from users
-            left join user_challenges on users.user_id = user_challenges.user_id
-        where user_challenges.is_complete
-            and user_challenges.completed_at - users.created_at <= interval '3 minutes'
-            and user_challenges.challenge_id not in ('m', 'b')
-            and users.user_id in (
-                select scoped_users.user_id
-                from scoped_users
-            )
-        group by users.user_id,
-            users.handle_lc,
-            users.created_at
-        order by users.created_at desc
-    ),
-    aggregate_scores as (
-        select users.user_id,
-            users.handle_lc,
-            users.created_at,
-            coalesce(play_activity.play_count, 0) as play_count,
-            coalesce(fast_challenge_completion.challenge_count, 0) as challenge_count,
-            coalesce(aggregate_user.following_count, 0) as following_count,
-            coalesce(aggregate_user.follower_count, 0) as follower_count
-        from users
-            left join play_activity on users.user_id = play_activity.user_id
-            left join fast_challenge_completion on users.user_id = fast_challenge_completion.user_id
-            left join aggregate_user on aggregate_user.user_id = users.user_id
-        where users.handle_lc is not null
-            and users.user_id in (
-                select scoped_users.user_id
-                from scoped_users
-            )
-        order by users.created_at desc
-    ),
-    computed_scores as (
-        select a.user_id,
-            a.handle_lc,
-            a.play_count,
-            a.follower_count,
-            a.challenge_count,
-            a.following_count,
-            (
-                a.play_count + a.follower_count - a.challenge_count + case
-                    when a.following_count < 5 then -1
-                    else 0
-                end
-            ) as overall_score
-        from aggregate_scores a
-    )
-select computed_scores.user_id
-from computed_scores
-where overall_score < 0;
--- filter based on threshold
-end;
 $$;
 
 
@@ -2267,14 +2017,14 @@ begin
   select * into reward_manager_tx from reward_manager_txs where reward_manager_txs.signature = new.signature limit 1;
 
   if reward_manager_tx is not null then
-		select id into existing_notification 
+		select id into existing_notification
 		from notification
 		where
 		type = 'challenge_reward' and
 		new.user_id = any(user_ids) and
 		timestamp >= (new.created_at - interval '1 hour')
 		limit 1;
-		
+
 		if existing_notification is null then
 			-- create a notification for the challenge disbursement
 			insert into notification
@@ -2393,14 +2143,14 @@ CREATE FUNCTION public.handle_comment() RETURNS trigger
     AS $$
 begin
   if new.entity_type = 'Track' then
-    insert into aggregate_track (track_id) 
-    values (new.entity_id) 
+    insert into aggregate_track (track_id)
+    values (new.entity_id)
     on conflict do nothing;
   end if;
 
   -- update agg track
   if new.entity_type = 'Track' then
-    update aggregate_track 
+    update aggregate_track
     set comment_count = (
       select count(*)
       from comments c
@@ -2412,136 +2162,6 @@ begin
     )
     where track_id = new.entity_id;
   end if;
-
-  return null;
-
-exception
-    when others then
-      raise warning 'An error occurred in %: %', tg_name, sqlerrm;
-      return null;
-end;
-$$;
-
-
---
--- Name: handle_comment_mention(); Type: FUNCTION; Schema: public; Owner: -
---
-
-CREATE FUNCTION public.handle_comment_mention() RETURNS trigger
-    LANGUAGE plpgsql
-    AS $$
-declare
-  comment_user_id int;
-  entity_user_id int;
-  entity_id int;
-  entity_type text;
-begin
-  select comments.user_id, comments.entity_id, comments.entity_type
-  into comment_user_id , entity_id, entity_type
-  from comments 
-  where comment_id = new.comment_id;
-
-  select tracks.owner_id 
-  into entity_user_id 
-  from tracks 
-  where track_id = entity_id;
-
-  begin
-    if new.user_id != entity_user_id then
-      insert into notification
-        (blocknumber, user_ids, timestamp, type, specifier, group_id, data)
-        values
-        ( 
-          new.blocknumber,
-          ARRAY [new.user_id], 
-          new.created_at, 
-          'comment_mention',
-          comment_user_id,
-          'comment_mention:' || entity_id || ':type:' || entity_type,
-          json_build_object
-          (
-            'type', entity_type,
-            'entity_id', entity_id,
-            'entity_user_id', entity_user_id,
-            'comment_user_id', comment_user_id
-          )
-        )
-      on conflict do nothing;
-    end if;
-  end;
-
-  return null;
-
-exception
-    when others then
-      raise warning 'An error occurred in %: %', tg_name, sqlerrm;
-      return null;
-end;
-$$;
-
-
---
--- Name: handle_comment_thread(); Type: FUNCTION; Schema: public; Owner: -
---
-
-CREATE FUNCTION public.handle_comment_thread() RETURNS trigger
-    LANGUAGE plpgsql
-    AS $$
-declare
-  parent_comment_user_id int;
-  comment_user_id int;
-  entity_user_id int;
-  entity_id int;
-  entity_type text;
-  blocknumber int;
-  created_at timestamp without time zone;
-  notification_muted boolean;
-begin
-  select comments.user_id, comments.entity_id, comments.entity_type 
-  into parent_comment_user_id, entity_id, entity_type 
-  from comments 
-  where comment_id = new.parent_comment_id;
-
-  select comments.user_id, comments.blocknumber, comments.created_at
-  into comment_user_id, blocknumber, created_at
-  from comments 
-  where comment_id = new.comment_id;
-
-  select tracks.owner_id 
-  into entity_user_id 
-  from tracks 
-  where track_id = entity_id;
-
-  select comment_notification_settings.is_muted
-  into notification_muted
-  from comment_notification_settings
-  where user_id = parent_comment_user_id 
-  and comment_notification_settings.entity_id = new.parent_comment_id
-  and comment_notification_settings.entity_type = 'Comment';
-
-  begin
-    if notification_muted is not true and comment_user_id != parent_comment_user_id then
-      insert into notification
-        (blocknumber, user_ids, timestamp, type, specifier, group_id, data)
-        values
-        ( 
-          blocknumber,
-          ARRAY [parent_comment_user_id],
-          created_at, 
-          'comment_thread',
-          comment_user_id,
-          'comment_thread:' || new.parent_comment_id,
-          json_build_object
-          (
-            'type', entity_type,
-            'entity_id', entity_id,
-            'entity_user_id', entity_user_id,
-            'comment_user_id', comment_user_id
-          )
-        )
-      on conflict do nothing;
-    end if;
-  end;
 
   return null;
 
@@ -2590,9 +2210,9 @@ begin
   -- Only proceed if this is a remix contest event
   if new.event_type = 'remix_contest' and new.is_deleted = false then
     -- Get the owner of the track and check if it's public
-    select owner_id, not is_unlisted into owner_user_id, track_is_public 
-    from tracks 
-    where is_current and track_id = new.entity_id 
+    select owner_id, not is_unlisted into owner_user_id, track_is_public
+    from tracks
+    where is_current and track_id = new.entity_id
     limit 1;
 
     -- Only create notifications if the track is public
@@ -2672,11 +2292,11 @@ begin
     delta := 1;
   end if;
 
-  update aggregate_user 
-  set following_count = following_count + delta 
+  update aggregate_user
+  set following_count = following_count + delta
   where user_id = new.follower_user_id;
 
-  update aggregate_user 
+  update aggregate_user
   set follower_count = follower_count + delta
   where user_id = new.followee_user_id
   returning follower_count into new_follower_count;
@@ -2685,7 +2305,7 @@ begin
   select new_follower_count into milestone where new_follower_count in (10, 25, 50, 100, 250, 500, 1000, 5000, 10000, 20000, 50000, 100000, 1000000);
   select score < 0 into is_shadowbanned from aggregate_user where user_id = new.follower_user_id;
   if milestone is not null and new.is_delete is false and is_shadowbanned = false then
-      insert into milestones 
+      insert into milestones
         (id, name, threshold, blocknumber, slot, timestamp)
       values
         (new.followee_user_id, 'FOLLOWER_COUNT', milestone, new.blocknumber, new.slot, new.created_at)
@@ -2734,7 +2354,7 @@ exception
     raise warning 'An error occurred in %: %', tg_name, sqlerrm;
     raise;
 
-end; 
+end;
 $$;
 
 
@@ -2790,7 +2410,7 @@ begin
                 'challenge_reward',
                 'challenge_reward:' || new.user_id || ':challenge:' || new.challenge_id || ':specifier:' || new.specifier,
                 new.user_id,
-                case 
+                case
                     when new.challenge_id = 'e' then
                         json_build_object(
                             'specifier', new.specifier,
@@ -2808,16 +2428,15 @@ begin
             )
             on conflict do nothing;
         else
-            -- transactional notifications cover this 
+            -- transactional notifications cover this
             if (new.challenge_id != 'b' and new.challenge_id != 's') then
-                select id into existing_notification 
+                select id into existing_notification
                 from notification
                 where
                 type = 'reward_in_cooldown' and
                 new.user_id = any(user_ids) and
                 timestamp >= (new.completed_at - interval '1 hour')
                 limit 1;
-                RAISE NOTICE 'Checking for existing reward_in_cooldown notification for existing_notification: %', existing_notification;
 
                 if existing_notification is null then
                     insert into notification
@@ -2861,7 +2480,7 @@ begin
     insert into aggregate_plays (play_item_id, count) values (new.play_item_id, 0) on conflict do nothing;
 
     update aggregate_plays
-        set count = count + 1 
+        set count = count + 1
         where play_item_id = new.play_item_id
         returning count into new_listen_count;
 
@@ -2876,8 +2495,8 @@ begin
         and timestamp = date_trunc('month', new.created_at)
         and country = coalesce(new.country, '');
 
-    select new_listen_count 
-        into milestone 
+    select new_listen_count
+        into milestone
         where new_listen_count in (10,25,50,100,250,500,1000,2500,5000,10000,25000,50000,100000,250000,500000,1000000);
 
     if milestone is not null then
@@ -3077,7 +2696,7 @@ begin
           json_build_object('track_id', new.track_id, 'playlist_id', new.playlist_id, 'playlist_owner_id', playlist_record.playlist_owner_id)
         from album_purchasers as album_purchaser;
   end if;
-  
+
   return null;
 
 exception
@@ -3104,16 +2723,16 @@ declare
 begin
 
   raise NOTICE 'start';
-  
+
   if new.reaction_type = 'tip' then
 
     raise NOTICE 'is tip';
 
-    SELECT amount, sender_user_id, receiver_user_id 
-    INTO tip_amount, tip_sender_user_id, tip_receiver_user_id 
-    FROM user_tips ut 
+    SELECT amount, sender_user_id, receiver_user_id
+    INTO tip_amount, tip_sender_user_id, tip_receiver_user_id
+    FROM user_tips ut
     WHERE ut.signature = new.reacted_to;
-    
+
     raise NOTICE 'did select % %', tip_sender_user_id, tip_receiver_user_id;
     raise NOTICE 'did select %', new.reacted_to;
 
@@ -3208,7 +2827,7 @@ begin
   end if;
 
   -- update agg user
-  update aggregate_user 
+  update aggregate_user
   set repost_count = (
     select count(*)
     from reposts r
@@ -3221,7 +2840,7 @@ begin
   -- update agg track or playlist
   if new.repost_type = 'track' then
     milestone_name := 'TRACK_REPOST_COUNT';
-    update aggregate_track 
+    update aggregate_track
     set repost_count = (
       select count(*)
       from reposts r
@@ -3247,7 +2866,7 @@ begin
           and r.is_delete is false
           and r.repost_type = new.repost_type
           and r.repost_item_id = new.repost_item_id
-    )    
+    )
     where playlist_id = new.repost_item_id
     returning repost_count into new_val;
 
@@ -3261,7 +2880,7 @@ begin
   select score < 0 into is_shadowbanned from aggregate_user where user_id = new.user_id;
 
   if new.is_delete = false and milestone is not null and owner_user_id is not null and is_shadowbanned = false then
-    insert into milestones 
+    insert into milestones
       (id, name, threshold, blocknumber, slot, timestamp)
     values
       (new.repost_item_id, milestone_name, milestone, new.blocknumber, new.slot, new.created_at)
@@ -3362,7 +2981,7 @@ begin
 				'user_id',
 				new.user_id,
 				'type',
-        case 
+        case
           when is_album then 'album'
           else new.repost_type
         end
@@ -3466,7 +3085,7 @@ begin
     where p.playlist_id = new.save_item_id
     and p.is_current
     on conflict do nothing;
-    
+
     select ap.is_album into is_album
     from aggregate_playlist ap
     where ap.playlist_id = new.save_item_id;
@@ -3491,7 +3110,7 @@ begin
   if new.save_type = 'track' then
     milestone_name := 'TRACK_SAVE_COUNT';
 
-    update aggregate_track 
+    update aggregate_track
     set save_count = (
       select count(*)
       from saves r
@@ -3505,7 +3124,7 @@ begin
     returning save_count into new_val;
 
     -- update agg user
-    update aggregate_user 
+    update aggregate_user
     set track_save_count = (
       select count(*)
       from saves r
@@ -3515,7 +3134,7 @@ begin
         and r.save_type = new.save_type
     )
     where user_id = new.user_id;
-    
+
   	if new.is_delete IS FALSE then
 		  select tracks.owner_id, tracks.remix_of into owner_user_id, track_remix_of from tracks where is_current and track_id = new.save_item_id;
 	  end if;
@@ -3546,7 +3165,7 @@ begin
   select score < 0 into is_shadowbanned from aggregate_user where user_id = new.user_id;
 
   if new.is_delete = false and milestone is not null and is_shadowbanned = false then
-    insert into milestones 
+    insert into milestones
       (id, name, threshold, blocknumber, slot, timestamp)
     values
       (new.save_item_id, milestone_name, milestone, new.blocknumber, new.slot, new.created_at)
@@ -3590,10 +3209,10 @@ begin
       insert into notification
         (blocknumber, user_ids, timestamp, type, specifier, group_id, data)
         values
-        ( 
+        (
           new.blocknumber,
-          ARRAY [owner_user_id], 
-          new.created_at, 
+          ARRAY [owner_user_id],
+          new.created_at,
           'save',
           new.user_id,
           'save:' || new.save_item_id || ':type:'|| new.save_type,
@@ -3652,7 +3271,7 @@ begin
           'user_id',
           new.user_id,
           'type',
-          case 
+          case
             when is_album then 'album'
             else new.save_type
           end
@@ -3666,16 +3285,16 @@ begin
     if new.is_delete is false and new.save_type = 'track' and track_remix_of is not null and is_shadowbanned = false then
       select
         case when tracks.owner_id = new.user_id then TRUE else FALSE end as boolean into is_remix_cosign
-        from tracks 
+        from tracks
         where is_current and track_id = (track_remix_of->'tracks'->0->>'parent_track_id')::int;
       if is_remix_cosign then
         insert into notification
           (blocknumber, user_ids, timestamp, type, specifier, group_id, data)
           values
-          ( 
+          (
             new.blocknumber,
-            ARRAY [owner_user_id], 
-            new.created_at, 
+            ARRAY [owner_user_id],
+            new.created_at,
             'cosign',
             new.user_id,
             'cosign:parent_track' || (track_remix_of->'tracks'->0->>'parent_track_id')::int || ':original_track:'|| new.save_item_id,
@@ -3697,7 +3316,7 @@ exception
       raise warning 'An error occurred in %: %', tg_name, sqlerrm;
       raise;
 
-end; 
+end;
 $$;
 
 
@@ -3812,7 +3431,7 @@ BEGIN
         slot = EXCLUDED.slot,
         updated_at = NOW()
         WHERE sol_token_account_balances.slot < EXCLUDED.slot;
-    
+
     FOR v_user_id IN
         SELECT user_id
         FROM associated_wallets
@@ -4124,7 +3743,7 @@ begin
     when others then
         raise warning 'An error occurred in %: %', tg_name, sqlerrm;
         return null;
-end; 
+end;
 $$;
 
 
@@ -4223,7 +3842,7 @@ begin
   ) as tier (label, val)
   WHERE
     substr(new.current_balance, 1, GREATEST(1, length(new.current_balance) - 18))::bigint >= tier.val
-  ORDER BY 
+  ORDER BY
     tier.val DESC
   limit 1;
 
@@ -4233,7 +3852,7 @@ begin
   ) as tier (label, val)
   WHERE
     substr(new.previous_balance, 1, GREATEST(1, length(new.previous_balance) - 18))::bigint >= tier.val
-  ORDER BY 
+  ORDER BY
     tier.val DESC
   limit 1;
 
@@ -4242,10 +3861,10 @@ begin
     insert into notification
       (blocknumber, user_ids, timestamp, type, specifier, group_id, data)
     values
-      ( 
+      (
         new.blocknumber,
-        ARRAY [new.user_id], 
-        new.updated_at, 
+        ARRAY [new.user_id],
+        new.updated_at,
         'tier_change',
         new.user_id,
         'tier_change:user_id:' || new.user_id ||  ':tier:' || new_tier || ':blocknumber:' || new.blocknumber,
@@ -4281,10 +3900,10 @@ begin
   insert into notification
     (slot, user_ids, timestamp, type, specifier, group_id, data)
   values
-    ( 
+    (
       new.slot,
-      ARRAY [new.receiver_user_id], 
-      new.created_at, 
+      ARRAY [new.receiver_user_id],
+      new.created_at,
       'tip_receive',
       new.receiver_user_id,
       'tip_receive:user_id:' || new.receiver_user_id || ':signature:' || new.signature,
@@ -4295,10 +3914,10 @@ begin
         'tx_signature', new.signature
       )
     ),
-    ( 
+    (
       new.slot,
-      ARRAY [new.sender_user_id], 
-      new.created_at, 
+      ARRAY [new.sender_user_id],
+      new.created_at,
       'tip_send',
       new.sender_user_id,
       'tip_send:user_id:' || new.sender_user_id || ':signature:' || new.signature,
@@ -4802,34 +4421,6 @@ $$;
 
 
 --
--- Name: on_new_notification_row(); Type: FUNCTION; Schema: public; Owner: -
---
-
-CREATE FUNCTION public.on_new_notification_row() RETURNS trigger
-    LANGUAGE plpgsql
-    AS $$
-begin
-  PERFORM pg_notify(TG_TABLE_NAME, json_build_object('notification_id', new.id)::text);
-  return null;
-end; 
-$$;
-
-
---
--- Name: on_new_notification_seen_row(); Type: FUNCTION; Schema: public; Owner: -
---
-
-CREATE FUNCTION public.on_new_notification_seen_row() RETURNS trigger
-    LANGUAGE plpgsql
-    AS $$
-begin
-  PERFORM pg_notify(TG_TABLE_NAME, json_build_object('user_id', new.user_id)::text);
-  return null;
-end; 
-$$;
-
-
---
 -- Name: on_new_row(); Type: FUNCTION; Schema: public; Owner: -
 --
 
@@ -4864,7 +4455,7 @@ declare
 begin
     -- fetch the user_id where wallet matches grantee_address
     select user_id into matched_user_id from users where lower(wallet) = lower(NEW.grantee_address);
-    
+
     if matched_user_id is not null then
         -- if the grant is newly created (i.e. the grant is not deleted, is not approved yet, and was just created indicated by created timestamp = last updated timestamp) OR grant went from deleted (revoked) to not deleted and is not approved yet...
         if (TG_OP = 'INSERT' and NEW.is_revoked = FALSE and NEW.is_approved is null and NEW.created_at = NEW.updated_at or
@@ -4918,7 +4509,7 @@ exception
   when others then
       raise warning 'An error occurred in %: %', tg_name, sqlerrm;
       return null;
-end; 
+end;
 $$;
 
 
@@ -5263,19 +4854,19 @@ begin
     if codes is null then
         return true;
     end if;
-    
+
     -- array must have at least one element
     if array_length(codes, 1) is null then
         return false;
     end if;
-    
+
     -- check each element to make sure it's a 2 letter ISO code
     for i in 1..array_length(codes, 1) loop
         if codes[i] !~ '^[A-Z]{2}$' then
             return false;
         end if;
     end loop;
-    
+
     return true;
 end;
 $_$;
@@ -5320,6 +4911,7 @@ CREATE TABLE public.tracks (
     txhash character varying DEFAULT ''::character varying NOT NULL,
     slot integer,
     is_available boolean DEFAULT true NOT NULL,
+    is_stream_gated boolean DEFAULT false NOT NULL,
     stream_conditions jsonb,
     track_cid character varying,
     is_playlist_upload boolean DEFAULT false NOT NULL,
@@ -5332,11 +4924,11 @@ CREATE TABLE public.tracks (
     track_segments jsonb DEFAULT '[]'::jsonb NOT NULL,
     is_scheduled_release boolean DEFAULT false NOT NULL,
     is_downloadable boolean DEFAULT false NOT NULL,
+    is_download_gated boolean DEFAULT false NOT NULL,
     download_conditions jsonb,
     is_original_available boolean DEFAULT false NOT NULL,
     orig_file_cid character varying,
     orig_filename character varying,
-    collections_containing_track integer[],
     playlists_containing_track integer[] DEFAULT '{}'::integer[] NOT NULL,
     placement_hosts text,
     ddex_app character varying,
@@ -5360,8 +4952,6 @@ CREATE TABLE public.tracks (
     cover_original_song_title character varying,
     cover_original_artist character varying,
     is_owned_by_user boolean DEFAULT false NOT NULL,
-    is_stream_gated boolean DEFAULT false,
-    is_download_gated boolean DEFAULT false,
     no_ai_use boolean DEFAULT false,
     parental_warning public.parental_warning_type,
     territory_codes text[],
@@ -5426,10 +5016,10 @@ BEGIN
         NOW(),
         NOW()
     FROM (
-        SELECT 
-            p_user_id AS user_id, 
+        SELECT
+            p_user_id AS user_id,
             COALESCE(balance, 0) AS balance
-        FROM associated_wallets 
+        FROM associated_wallets
         JOIN sol_token_account_balances AS associated_wallet_balances
             ON associated_wallet_balances.owner = associated_wallets.wallet
             AND associated_wallet_balances.mint = p_mint
@@ -5439,8 +5029,8 @@ BEGIN
 
         UNION ALL
 
-        SELECT 
-            p_user_id AS user_id, 
+        SELECT
+            p_user_id AS user_id,
             COALESCE(balance, 0) AS balance
         FROM users
         JOIN sol_claimable_accounts
@@ -5584,37 +5174,6 @@ ALTER TEXT SEARCH CONFIGURATION public.audius_ts_config
 CREATE TABLE public."SequelizeMeta" (
     name character varying(255) NOT NULL
 );
-
-
---
--- Name: access_keys; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.access_keys (
-    id integer NOT NULL,
-    track_id text NOT NULL,
-    pub_key text NOT NULL
-);
-
-
---
--- Name: access_keys_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.access_keys_id_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: access_keys_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public.access_keys_id_seq OWNED BY public.access_keys.id;
 
 
 --
@@ -5964,27 +5523,6 @@ CREATE TABLE public.album_price_history (
 
 
 --
--- Name: alembic_version; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.alembic_version (
-    version_num character varying(32) NOT NULL
-);
-
-
---
--- Name: anti_abuse_blocked_users; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.anti_abuse_blocked_users (
-    handle_lc character varying(255) NOT NULL,
-    is_blocked boolean DEFAULT false NOT NULL,
-    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP,
-    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP
-);
-
-
---
 -- Name: api_metrics_apps; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -6046,10 +5584,10 @@ CREATE TABLE public.app_name_metrics (
 --
 
 CREATE MATERIALIZED VIEW public.app_name_metrics_all_time AS
- SELECT app_name_metrics.application_name AS name,
-    sum(app_name_metrics.count) AS count
+ SELECT application_name AS name,
+    sum(count) AS count
    FROM public.app_name_metrics
-  GROUP BY app_name_metrics.application_name
+  GROUP BY application_name
   WITH NO DATA;
 
 
@@ -6072,11 +5610,11 @@ ALTER TABLE public.app_name_metrics ALTER COLUMN id ADD GENERATED ALWAYS AS IDEN
 --
 
 CREATE MATERIALIZED VIEW public.app_name_metrics_trailing_month AS
- SELECT app_name_metrics.application_name AS name,
-    sum(app_name_metrics.count) AS count
+ SELECT application_name AS name,
+    sum(count) AS count
    FROM public.app_name_metrics
-  WHERE (app_name_metrics."timestamp" > (now() - '1 mon'::interval))
-  GROUP BY app_name_metrics.application_name
+  WHERE ("timestamp" > (now() - '1 mon'::interval))
+  GROUP BY application_name
   WITH NO DATA;
 
 
@@ -6085,11 +5623,11 @@ CREATE MATERIALIZED VIEW public.app_name_metrics_trailing_month AS
 --
 
 CREATE MATERIALIZED VIEW public.app_name_metrics_trailing_week AS
- SELECT app_name_metrics.application_name AS name,
-    sum(app_name_metrics.count) AS count
+ SELECT application_name AS name,
+    sum(count) AS count
    FROM public.app_name_metrics
-  WHERE (app_name_metrics."timestamp" > (now() - '7 days'::interval))
-  GROUP BY app_name_metrics.application_name
+  WHERE ("timestamp" > (now() - '7 days'::interval))
+  GROUP BY application_name
   WITH NO DATA;
 
 
@@ -6115,8 +5653,7 @@ CREATE TABLE public.artist_coin_pools (
     curve_progress double precision,
     is_migrated boolean,
     created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
-    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
-    total_trading_quote_fee numeric
+    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL
 );
 
 
@@ -6185,6 +5722,9 @@ CREATE TABLE public.artist_coins (
     name text DEFAULT ''::text NOT NULL,
     has_discord boolean DEFAULT false NOT NULL,
     updated_at timestamp without time zone DEFAULT now(),
+    twitter text,
+    instagram text,
+    tiktok text,
     link_1 text,
     link_2 text,
     link_3 text,
@@ -6635,100 +6175,6 @@ CREATE TABLE public.comments (
 
 
 --
--- Name: core_app_state; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.core_app_state (
-    block_height bigint NOT NULL,
-    app_hash bytea NOT NULL,
-    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP
-);
-
-
---
--- Name: core_blocks; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.core_blocks (
-    rowid bigint NOT NULL,
-    height bigint NOT NULL,
-    chain_id text NOT NULL,
-    hash text NOT NULL,
-    proposer text NOT NULL,
-    created_at timestamp without time zone NOT NULL
-);
-
-
---
--- Name: core_blocks_rowid_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.core_blocks_rowid_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: core_blocks_rowid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public.core_blocks_rowid_seq OWNED BY public.core_blocks.rowid;
-
-
---
--- Name: core_db_migrations; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.core_db_migrations (
-    id text NOT NULL,
-    applied_at timestamp with time zone
-);
-
-
---
--- Name: core_ern; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.core_ern (
-    id bigint NOT NULL,
-    address text NOT NULL,
-    index bigint NOT NULL,
-    tx_hash text NOT NULL,
-    sender text NOT NULL,
-    message_control_type smallint NOT NULL,
-    party_addresses text[] DEFAULT '{}'::text[],
-    resource_addresses text[] DEFAULT '{}'::text[],
-    release_addresses text[] DEFAULT '{}'::text[],
-    deal_addresses text[] DEFAULT '{}'::text[],
-    raw_message bytea NOT NULL,
-    raw_acknowledgment bytea NOT NULL,
-    block_height bigint NOT NULL
-);
-
-
---
--- Name: core_ern_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.core_ern_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: core_ern_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public.core_ern_id_seq OWNED BY public.core_ern.id;
-
-
---
 -- Name: core_indexed_blocks; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -6740,182 +6186,6 @@ CREATE TABLE public.core_indexed_blocks (
     plays_slot integer DEFAULT 0,
     em_block integer
 );
-
-
---
--- Name: core_mead; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.core_mead (
-    id bigint NOT NULL,
-    address text NOT NULL,
-    tx_hash text NOT NULL,
-    index bigint NOT NULL,
-    sender text NOT NULL,
-    resource_addresses text[] DEFAULT '{}'::text[],
-    release_addresses text[] DEFAULT '{}'::text[],
-    raw_message bytea NOT NULL,
-    raw_acknowledgment bytea NOT NULL,
-    block_height bigint NOT NULL
-);
-
-
---
--- Name: core_mead_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.core_mead_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: core_mead_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public.core_mead_id_seq OWNED BY public.core_mead.id;
-
-
---
--- Name: core_pie; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.core_pie (
-    id bigint NOT NULL,
-    address text NOT NULL,
-    tx_hash text NOT NULL,
-    index bigint NOT NULL,
-    sender text NOT NULL,
-    party_addresses text[] DEFAULT '{}'::text[],
-    raw_message bytea NOT NULL,
-    raw_acknowledgment bytea NOT NULL,
-    block_height bigint NOT NULL
-);
-
-
---
--- Name: core_pie_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.core_pie_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: core_pie_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public.core_pie_id_seq OWNED BY public.core_pie.id;
-
-
---
--- Name: core_transactions; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.core_transactions (
-    rowid bigint NOT NULL,
-    block_id bigint NOT NULL,
-    index integer NOT NULL,
-    tx_hash text NOT NULL,
-    transaction bytea NOT NULL,
-    created_at timestamp without time zone NOT NULL
-);
-
-
---
--- Name: core_transactions_rowid_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.core_transactions_rowid_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: core_transactions_rowid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public.core_transactions_rowid_seq OWNED BY public.core_transactions.rowid;
-
-
---
--- Name: core_tx_stats; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.core_tx_stats (
-    id integer NOT NULL,
-    tx_type text NOT NULL,
-    tx_hash text NOT NULL,
-    block_height bigint NOT NULL,
-    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP
-);
-
-
---
--- Name: core_tx_stats_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.core_tx_stats_id_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: core_tx_stats_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public.core_tx_stats_id_seq OWNED BY public.core_tx_stats.id;
-
-
---
--- Name: core_validators; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.core_validators (
-    rowid integer NOT NULL,
-    pub_key text NOT NULL,
-    endpoint text NOT NULL,
-    eth_address text NOT NULL,
-    comet_address text NOT NULL,
-    eth_block text NOT NULL,
-    node_type text NOT NULL,
-    sp_id text NOT NULL,
-    comet_pub_key text NOT NULL
-);
-
-
---
--- Name: core_validators_rowid_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.core_validators_rowid_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: core_validators_rowid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public.core_validators_rowid_seq OWNED BY public.core_validators.rowid;
 
 
 --
@@ -7106,22 +6376,6 @@ ALTER SEQUENCE public.encrypted_emails_id_seq OWNED BY public.encrypted_emails.i
 
 
 --
--- Name: eth_active_proposals; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.eth_active_proposals (
-    id bigint NOT NULL,
-    proposer text NOT NULL,
-    submission_block_number bigint NOT NULL,
-    target_contract_registry_key text NOT NULL,
-    target_contract_address text NOT NULL,
-    call_value bigint NOT NULL,
-    function_signature text NOT NULL,
-    call_data text NOT NULL
-);
-
-
---
 -- Name: eth_blocks; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -7150,67 +6404,6 @@ CREATE SEQUENCE public.eth_blocks_last_scanned_block_seq
 --
 
 ALTER SEQUENCE public.eth_blocks_last_scanned_block_seq OWNED BY public.eth_blocks.last_scanned_block;
-
-
---
--- Name: eth_db_migrations; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.eth_db_migrations (
-    version bigint NOT NULL,
-    dirty boolean NOT NULL
-);
-
-
---
--- Name: eth_funding_rounds; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.eth_funding_rounds (
-    round_num integer NOT NULL,
-    blocknumber bigint NOT NULL,
-    creation_time timestamp without time zone NOT NULL
-);
-
-
---
--- Name: eth_registered_endpoints; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.eth_registered_endpoints (
-    id integer NOT NULL,
-    service_type text NOT NULL,
-    owner text NOT NULL,
-    delegate_wallet text NOT NULL,
-    endpoint text NOT NULL,
-    blocknumber bigint NOT NULL,
-    registered_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL
-);
-
-
---
--- Name: eth_service_providers; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.eth_service_providers (
-    address text NOT NULL,
-    deployer_stake bigint NOT NULL,
-    deployer_cut bigint NOT NULL,
-    valid_bounds boolean NOT NULL,
-    number_of_endpoints integer NOT NULL,
-    min_account_stake bigint NOT NULL,
-    max_account_stake bigint NOT NULL
-);
-
-
---
--- Name: eth_staked; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.eth_staked (
-    address text NOT NULL,
-    total_staked bigint NOT NULL
-);
 
 
 --
@@ -7291,37 +6484,6 @@ CREATE TABLE public.indexing_checkpoints (
 
 
 --
--- Name: management_keys; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.management_keys (
-    id integer NOT NULL,
-    track_id text NOT NULL,
-    address text NOT NULL
-);
-
-
---
--- Name: management_keys_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.management_keys_id_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: management_keys_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public.management_keys_id_seq OWNED BY public.management_keys.id;
-
-
---
 -- Name: milestones; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -7348,56 +6510,6 @@ CREATE TABLE public.muted_users (
     txhash text NOT NULL,
     blockhash text NOT NULL,
     blocknumber integer
-);
-
-
---
--- Name: new_tracks; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.new_tracks (
-    blockhash character varying,
-    track_id integer,
-    is_current boolean,
-    is_delete boolean,
-    owner_id integer,
-    title text,
-    cover_art character varying,
-    tags character varying,
-    genre character varying,
-    mood character varying,
-    credits_splits character varying,
-    create_date character varying,
-    file_type character varying,
-    metadata_multihash character varying,
-    blocknumber integer,
-    created_at timestamp without time zone,
-    description character varying,
-    isrc character varying,
-    iswc character varying,
-    license character varying,
-    updated_at timestamp without time zone,
-    cover_art_sizes character varying,
-    download jsonb,
-    is_unlisted boolean,
-    field_visibility jsonb,
-    route_id character varying,
-    stem_of jsonb,
-    remix_of jsonb,
-    txhash character varying,
-    slot integer,
-    is_available boolean,
-    is_premium boolean,
-    premium_conditions jsonb,
-    track_cid character varying,
-    is_playlist_upload boolean,
-    duration integer,
-    ai_attribution_user_id integer,
-    preview_cid character varying,
-    audio_upload_id character varying,
-    preview_start_seconds double precision,
-    release_date timestamp without time zone,
-    track_segments jsonb
 );
 
 
@@ -7548,6 +6660,7 @@ CREATE TABLE public.playlists (
     slot integer,
     metadata_multihash character varying,
     is_image_autogenerated boolean DEFAULT false NOT NULL,
+    is_stream_gated boolean DEFAULT false NOT NULL,
     stream_conditions jsonb,
     ddex_app character varying,
     ddex_release_ids jsonb,
@@ -7556,8 +6669,7 @@ CREATE TABLE public.playlists (
     producer_copyright_line jsonb,
     parental_warning_type character varying,
     is_scheduled_release boolean DEFAULT false NOT NULL,
-    release_date timestamp without time zone,
-    is_stream_gated boolean DEFAULT false
+    release_date timestamp without time zone
 );
 
 
@@ -7725,8 +6837,8 @@ CREATE TABLE public.route_metrics (
 --
 
 CREATE MATERIALIZED VIEW public.route_metrics_all_time AS
- SELECT count(DISTINCT route_metrics.ip) AS unique_count,
-    sum(route_metrics.count) AS count
+ SELECT count(DISTINCT ip) AS unique_count,
+    sum(count) AS count
    FROM public.route_metrics
   WITH NO DATA;
 
@@ -7736,11 +6848,11 @@ CREATE MATERIALIZED VIEW public.route_metrics_all_time AS
 --
 
 CREATE MATERIALIZED VIEW public.route_metrics_day_bucket AS
- SELECT count(DISTINCT route_metrics.ip) AS unique_count,
-    sum(route_metrics.count) AS count,
-    date_trunc('day'::text, route_metrics."timestamp") AS "time"
+ SELECT count(DISTINCT ip) AS unique_count,
+    sum(count) AS count,
+    date_trunc('day'::text, "timestamp") AS "time"
    FROM public.route_metrics
-  GROUP BY (date_trunc('day'::text, route_metrics."timestamp"))
+  GROUP BY (date_trunc('day'::text, "timestamp"))
   WITH NO DATA;
 
 
@@ -7763,11 +6875,11 @@ ALTER TABLE public.route_metrics ALTER COLUMN id ADD GENERATED ALWAYS AS IDENTIT
 --
 
 CREATE MATERIALIZED VIEW public.route_metrics_month_bucket AS
- SELECT count(DISTINCT route_metrics.ip) AS unique_count,
-    sum(route_metrics.count) AS count,
-    date_trunc('month'::text, route_metrics."timestamp") AS "time"
+ SELECT count(DISTINCT ip) AS unique_count,
+    sum(count) AS count,
+    date_trunc('month'::text, "timestamp") AS "time"
    FROM public.route_metrics
-  GROUP BY (date_trunc('month'::text, route_metrics."timestamp"))
+  GROUP BY (date_trunc('month'::text, "timestamp"))
   WITH NO DATA;
 
 
@@ -7776,10 +6888,10 @@ CREATE MATERIALIZED VIEW public.route_metrics_month_bucket AS
 --
 
 CREATE MATERIALIZED VIEW public.route_metrics_trailing_month AS
- SELECT count(DISTINCT route_metrics.ip) AS unique_count,
-    sum(route_metrics.count) AS count
+ SELECT count(DISTINCT ip) AS unique_count,
+    sum(count) AS count
    FROM public.route_metrics
-  WHERE (route_metrics."timestamp" > (now() - '1 mon'::interval))
+  WHERE ("timestamp" > (now() - '1 mon'::interval))
   WITH NO DATA;
 
 
@@ -7788,10 +6900,10 @@ CREATE MATERIALIZED VIEW public.route_metrics_trailing_month AS
 --
 
 CREATE MATERIALIZED VIEW public.route_metrics_trailing_week AS
- SELECT count(DISTINCT route_metrics.ip) AS unique_count,
-    sum(route_metrics.count) AS count
+ SELECT count(DISTINCT ip) AS unique_count,
+    sum(count) AS count
    FROM public.route_metrics
-  WHERE (route_metrics."timestamp" > (now() - '7 days'::interval))
+  WHERE ("timestamp" > (now() - '7 days'::interval))
   WITH NO DATA;
 
 
@@ -7933,71 +7045,6 @@ CREATE SEQUENCE public.skipped_transactions_id_seq
 --
 
 ALTER SEQUENCE public.skipped_transactions_id_seq OWNED BY public.skipped_transactions.id;
-
-
---
--- Name: sla_node_reports; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.sla_node_reports (
-    id integer NOT NULL,
-    address character varying NOT NULL,
-    blocks_proposed integer NOT NULL,
-    sla_rollup_id integer
-);
-
-
---
--- Name: sla_node_reports_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.sla_node_reports_id_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: sla_node_reports_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public.sla_node_reports_id_seq OWNED BY public.sla_node_reports.id;
-
-
---
--- Name: sla_rollups; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.sla_rollups (
-    id integer NOT NULL,
-    tx_hash text NOT NULL,
-    block_start bigint NOT NULL,
-    block_end bigint NOT NULL,
-    "time" timestamp without time zone NOT NULL
-);
-
-
---
--- Name: sla_rollups_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.sla_rollups_id_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: sla_rollups_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public.sla_rollups_id_seq OWNED BY public.sla_rollups.id;
 
 
 --
@@ -8277,39 +7324,6 @@ COMMENT ON TABLE public.sol_user_balances IS 'Stores the balances of Solana toke
 
 
 --
--- Name: sound_recordings; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.sound_recordings (
-    id integer NOT NULL,
-    sound_recording_id text NOT NULL,
-    track_id text NOT NULL,
-    cid text NOT NULL,
-    encoding_details text
-);
-
-
---
--- Name: sound_recordings_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.sound_recordings_id_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: sound_recordings_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public.sound_recordings_id_seq OWNED BY public.sound_recordings.id;
-
-
---
 -- Name: spl_token_tx; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -8329,73 +7343,6 @@ CREATE TABLE public.stems (
     parent_track_id integer NOT NULL,
     child_track_id integer NOT NULL
 );
-
-
---
--- Name: storage_proof_peers; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.storage_proof_peers (
-    id integer NOT NULL,
-    block_height bigint NOT NULL,
-    prover_addresses text[] NOT NULL
-);
-
-
---
--- Name: storage_proof_peers_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.storage_proof_peers_id_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: storage_proof_peers_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public.storage_proof_peers_id_seq OWNED BY public.storage_proof_peers.id;
-
-
---
--- Name: storage_proofs; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.storage_proofs (
-    id integer NOT NULL,
-    block_height bigint NOT NULL,
-    address text NOT NULL,
-    cid text,
-    proof_signature text,
-    proof text,
-    prover_addresses text[] DEFAULT '{}'::text[] NOT NULL,
-    status public.proof_status DEFAULT 'unresolved'::public.proof_status NOT NULL
-);
-
-
---
--- Name: storage_proofs_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.storage_proofs_id_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: storage_proofs_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public.storage_proofs_id_seq OWNED BY public.storage_proofs.id;
 
 
 --
@@ -8431,16 +7378,16 @@ CREATE TABLE public.supporter_rank_ups (
 --
 
 CREATE MATERIALIZED VIEW public.tag_track_user AS
- SELECT unnest(t.tags) AS tag,
-    t.track_id,
-    t.owner_id
+ SELECT unnest(tags) AS tag,
+    track_id,
+    owner_id
    FROM ( SELECT string_to_array(lower((tracks.tags)::text), ','::text) AS tags,
             tracks.track_id,
             tracks.owner_id
            FROM public.tracks
           WHERE (((tracks.tags)::text <> ''::text) AND (tracks.tags IS NOT NULL) AND (tracks.is_current IS TRUE) AND (tracks.is_unlisted IS FALSE) AND (tracks.stem_of IS NULL))
           ORDER BY tracks.updated_at DESC) t
-  GROUP BY (unnest(t.tags)), t.track_id, t.owner_id
+  GROUP BY (unnest(tags)), track_id, owner_id
   WITH NO DATA;
 
 
@@ -8488,36 +7435,6 @@ CREATE TABLE public.track_price_history (
     created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
     access public.usdc_purchase_access_type DEFAULT 'stream'::public.usdc_purchase_access_type NOT NULL
 );
-
-
---
--- Name: track_releases; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.track_releases (
-    id integer NOT NULL,
-    track_id text NOT NULL
-);
-
-
---
--- Name: track_releases_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.track_releases_id_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: track_releases_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public.track_releases_id_seq OWNED BY public.track_releases.id;
 
 
 --
@@ -8980,50 +7897,6 @@ CREATE TABLE public.user_tips (
 
 
 --
--- Name: validator_history; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.validator_history (
-    rowid integer NOT NULL,
-    endpoint text NOT NULL,
-    eth_address text NOT NULL,
-    comet_address text NOT NULL,
-    sp_id bigint NOT NULL,
-    service_type text NOT NULL,
-    event_type public.validator_event NOT NULL,
-    event_time timestamp without time zone NOT NULL,
-    event_block bigint NOT NULL
-);
-
-
---
--- Name: validator_history_rowid_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.validator_history_rowid_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: validator_history_rowid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public.validator_history_rowid_seq OWNED BY public.validator_history.rowid;
-
-
---
--- Name: access_keys id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.access_keys ALTER COLUMN id SET DEFAULT nextval('public.access_keys_id_seq'::regclass);
-
-
---
 -- Name: aggregate_daily_app_name_metrics id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -9087,55 +7960,6 @@ ALTER TABLE ONLY public.challenge_profile_completion ALTER COLUMN user_id SET DE
 
 
 --
--- Name: core_blocks rowid; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.core_blocks ALTER COLUMN rowid SET DEFAULT nextval('public.core_blocks_rowid_seq'::regclass);
-
-
---
--- Name: core_ern id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.core_ern ALTER COLUMN id SET DEFAULT nextval('public.core_ern_id_seq'::regclass);
-
-
---
--- Name: core_mead id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.core_mead ALTER COLUMN id SET DEFAULT nextval('public.core_mead_id_seq'::regclass);
-
-
---
--- Name: core_pie id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.core_pie ALTER COLUMN id SET DEFAULT nextval('public.core_pie_id_seq'::regclass);
-
-
---
--- Name: core_transactions rowid; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.core_transactions ALTER COLUMN rowid SET DEFAULT nextval('public.core_transactions_rowid_seq'::regclass);
-
-
---
--- Name: core_tx_stats id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.core_tx_stats ALTER COLUMN id SET DEFAULT nextval('public.core_tx_stats_id_seq'::regclass);
-
-
---
--- Name: core_validators rowid; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.core_validators ALTER COLUMN rowid SET DEFAULT nextval('public.core_validators_rowid_seq'::regclass);
-
-
---
 -- Name: email_access id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -9154,13 +7978,6 @@ ALTER TABLE ONLY public.encrypted_emails ALTER COLUMN id SET DEFAULT nextval('pu
 --
 
 ALTER TABLE ONLY public.eth_blocks ALTER COLUMN last_scanned_block SET DEFAULT nextval('public.eth_blocks_last_scanned_block_seq'::regclass);
-
-
---
--- Name: management_keys id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.management_keys ALTER COLUMN id SET DEFAULT nextval('public.management_keys_id_seq'::regclass);
 
 
 --
@@ -9192,48 +8009,6 @@ ALTER TABLE ONLY public.skipped_transactions ALTER COLUMN id SET DEFAULT nextval
 
 
 --
--- Name: sla_node_reports id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.sla_node_reports ALTER COLUMN id SET DEFAULT nextval('public.sla_node_reports_id_seq'::regclass);
-
-
---
--- Name: sla_rollups id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.sla_rollups ALTER COLUMN id SET DEFAULT nextval('public.sla_rollups_id_seq'::regclass);
-
-
---
--- Name: sound_recordings id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.sound_recordings ALTER COLUMN id SET DEFAULT nextval('public.sound_recordings_id_seq'::regclass);
-
-
---
--- Name: storage_proof_peers id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.storage_proof_peers ALTER COLUMN id SET DEFAULT nextval('public.storage_proof_peers_id_seq'::regclass);
-
-
---
--- Name: storage_proofs id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.storage_proofs ALTER COLUMN id SET DEFAULT nextval('public.storage_proofs_id_seq'::regclass);
-
-
---
--- Name: track_releases id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.track_releases ALTER COLUMN id SET DEFAULT nextval('public.track_releases_id_seq'::regclass);
-
-
---
 -- Name: user_balance_changes user_id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -9262,26 +8037,11 @@ ALTER TABLE ONLY public.user_listening_history ALTER COLUMN user_id SET DEFAULT 
 
 
 --
--- Name: validator_history rowid; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.validator_history ALTER COLUMN rowid SET DEFAULT nextval('public.validator_history_rowid_seq'::regclass);
-
-
---
 -- Name: SequelizeMeta SequelizeMeta_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public."SequelizeMeta"
     ADD CONSTRAINT "SequelizeMeta_pkey" PRIMARY KEY (name);
-
-
---
--- Name: access_keys access_keys_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.access_keys
-    ADD CONSTRAINT access_keys_pkey PRIMARY KEY (id);
 
 
 --
@@ -9378,22 +8138,6 @@ ALTER TABLE ONLY public.aggregate_user_tips
 
 ALTER TABLE ONLY public.album_price_history
     ADD CONSTRAINT album_price_history_pkey PRIMARY KEY (playlist_id, block_timestamp);
-
-
---
--- Name: alembic_version alembic_version_pkc; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.alembic_version
-    ADD CONSTRAINT alembic_version_pkc PRIMARY KEY (version_num);
-
-
---
--- Name: anti_abuse_blocked_users anti_abuse_blocked_users_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.anti_abuse_blocked_users
-    ADD CONSTRAINT anti_abuse_blocked_users_pkey PRIMARY KEY (handle_lc);
 
 
 --
@@ -9653,102 +8397,6 @@ ALTER TABLE ONLY public.comments
 
 
 --
--- Name: core_app_state core_app_state_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.core_app_state
-    ADD CONSTRAINT core_app_state_pkey PRIMARY KEY (block_height, app_hash);
-
-
---
--- Name: core_blocks core_blocks_height_chain_id_key; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.core_blocks
-    ADD CONSTRAINT core_blocks_height_chain_id_key UNIQUE (height, chain_id);
-
-
---
--- Name: core_blocks core_blocks_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.core_blocks
-    ADD CONSTRAINT core_blocks_pkey PRIMARY KEY (rowid);
-
-
---
--- Name: core_db_migrations core_db_migrations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.core_db_migrations
-    ADD CONSTRAINT core_db_migrations_pkey PRIMARY KEY (id);
-
-
---
--- Name: core_ern core_ern_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.core_ern
-    ADD CONSTRAINT core_ern_pkey PRIMARY KEY (id);
-
-
---
--- Name: core_mead core_mead_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.core_mead
-    ADD CONSTRAINT core_mead_pkey PRIMARY KEY (id);
-
-
---
--- Name: core_pie core_pie_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.core_pie
-    ADD CONSTRAINT core_pie_pkey PRIMARY KEY (id);
-
-
---
--- Name: core_transactions core_transactions_block_id_index_key; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.core_transactions
-    ADD CONSTRAINT core_transactions_block_id_index_key UNIQUE (block_id, index);
-
-
---
--- Name: core_transactions core_transactions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.core_transactions
-    ADD CONSTRAINT core_transactions_pkey PRIMARY KEY (rowid);
-
-
---
--- Name: core_tx_stats core_tx_stats_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.core_tx_stats
-    ADD CONSTRAINT core_tx_stats_pkey PRIMARY KEY (id);
-
-
---
--- Name: core_tx_stats core_tx_stats_tx_hash_key; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.core_tx_stats
-    ADD CONSTRAINT core_tx_stats_tx_hash_key UNIQUE (tx_hash);
-
-
---
--- Name: core_validators core_validators_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.core_validators
-    ADD CONSTRAINT core_validators_pkey PRIMARY KEY (rowid);
-
-
---
 -- Name: countries countries_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -9761,7 +8409,7 @@ ALTER TABLE ONLY public.countries
 --
 
 ALTER TABLE ONLY public.dashboard_wallet_users
-    ADD CONSTRAINT dashboard_wallet_users_pkey PRIMARY KEY (user_id, wallet);
+    ADD CONSTRAINT dashboard_wallet_users_pkey PRIMARY KEY (wallet);
 
 
 --
@@ -9777,7 +8425,7 @@ ALTER TABLE ONLY public.delist_status_cursor
 --
 
 ALTER TABLE ONLY public.developer_apps
-    ADD CONSTRAINT developer_apps_pkey PRIMARY KEY (address, txhash);
+    ADD CONSTRAINT developer_apps_pkey PRIMARY KEY (txhash, address);
 
 
 --
@@ -9813,59 +8461,11 @@ ALTER TABLE ONLY public.encrypted_emails
 
 
 --
--- Name: eth_active_proposals eth_active_proposals_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.eth_active_proposals
-    ADD CONSTRAINT eth_active_proposals_pkey PRIMARY KEY (id);
-
-
---
 -- Name: eth_blocks eth_blocks_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.eth_blocks
     ADD CONSTRAINT eth_blocks_pkey PRIMARY KEY (last_scanned_block);
-
-
---
--- Name: eth_db_migrations eth_db_migrations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.eth_db_migrations
-    ADD CONSTRAINT eth_db_migrations_pkey PRIMARY KEY (version);
-
-
---
--- Name: eth_funding_rounds eth_funding_rounds_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.eth_funding_rounds
-    ADD CONSTRAINT eth_funding_rounds_pkey PRIMARY KEY (round_num);
-
-
---
--- Name: eth_registered_endpoints eth_registered_endpoints_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.eth_registered_endpoints
-    ADD CONSTRAINT eth_registered_endpoints_pkey PRIMARY KEY (id, service_type);
-
-
---
--- Name: eth_service_providers eth_service_providers_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.eth_service_providers
-    ADD CONSTRAINT eth_service_providers_pkey PRIMARY KEY (address);
-
-
---
--- Name: eth_staked eth_staked_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.eth_staked
-    ADD CONSTRAINT eth_staked_pkey PRIMARY KEY (address);
 
 
 --
@@ -9881,7 +8481,7 @@ ALTER TABLE ONLY public.events
 --
 
 ALTER TABLE ONLY public.follows
-    ADD CONSTRAINT follows_pkey PRIMARY KEY (follower_user_id, followee_user_id, txhash);
+    ADD CONSTRAINT follows_pkey PRIMARY KEY (followee_user_id, txhash, follower_user_id);
 
 
 --
@@ -9889,7 +8489,7 @@ ALTER TABLE ONLY public.follows
 --
 
 ALTER TABLE ONLY public.grants
-    ADD CONSTRAINT grants_pkey PRIMARY KEY (grantee_address, user_id, txhash);
+    ADD CONSTRAINT grants_pkey PRIMARY KEY (user_id, txhash, grantee_address);
 
 
 --
@@ -9906,14 +8506,6 @@ ALTER TABLE ONLY public.hourly_play_counts
 
 ALTER TABLE ONLY public.indexing_checkpoints
     ADD CONSTRAINT indexing_checkpoints_pkey PRIMARY KEY (tablename);
-
-
---
--- Name: management_keys management_keys_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.management_keys
-    ADD CONSTRAINT management_keys_pkey PRIMARY KEY (id);
 
 
 --
@@ -9985,7 +8577,7 @@ ALTER TABLE ONLY public.playlist_routes
 --
 
 ALTER TABLE ONLY public.playlist_seen
-    ADD CONSTRAINT playlist_seen_pkey PRIMARY KEY (user_id, playlist_id, seen_at);
+    ADD CONSTRAINT playlist_seen_pkey PRIMARY KEY (playlist_id, seen_at, user_id);
 
 
 --
@@ -10009,7 +8601,7 @@ ALTER TABLE ONLY public.playlist_trending_scores
 --
 
 ALTER TABLE ONLY public.playlists
-    ADD CONSTRAINT playlists_pkey PRIMARY KEY (playlist_id, txhash);
+    ADD CONSTRAINT playlists_pkey PRIMARY KEY (txhash, playlist_id);
 
 
 --
@@ -10065,7 +8657,7 @@ ALTER TABLE ONLY public.reported_comments
 --
 
 ALTER TABLE ONLY public.reposts
-    ADD CONSTRAINT reposts_pkey PRIMARY KEY (user_id, repost_item_id, repost_type, txhash);
+    ADD CONSTRAINT reposts_pkey PRIMARY KEY (txhash, user_id, repost_item_id, repost_type);
 
 
 --
@@ -10129,7 +8721,7 @@ ALTER TABLE ONLY public.rpclog
 --
 
 ALTER TABLE ONLY public.saves
-    ADD CONSTRAINT saves_pkey PRIMARY KEY (user_id, save_item_id, save_type, txhash);
+    ADD CONSTRAINT saves_pkey PRIMARY KEY (save_item_id, user_id, txhash, save_type);
 
 
 --
@@ -10162,30 +8754,6 @@ ALTER TABLE ONLY public.shares
 
 ALTER TABLE ONLY public.skipped_transactions
     ADD CONSTRAINT skipped_transactions_pkey PRIMARY KEY (id);
-
-
---
--- Name: sla_node_reports sla_node_reports_address_sla_rollup_id_key; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.sla_node_reports
-    ADD CONSTRAINT sla_node_reports_address_sla_rollup_id_key UNIQUE (address, sla_rollup_id);
-
-
---
--- Name: sla_node_reports sla_node_reports_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.sla_node_reports
-    ADD CONSTRAINT sla_node_reports_pkey PRIMARY KEY (id);
-
-
---
--- Name: sla_rollups sla_rollups_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.sla_rollups
-    ADD CONSTRAINT sla_rollups_pkey PRIMARY KEY (id);
 
 
 --
@@ -10285,14 +8853,6 @@ ALTER TABLE ONLY public.sol_user_balances
 
 
 --
--- Name: sound_recordings sound_recordings_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.sound_recordings
-    ADD CONSTRAINT sound_recordings_pkey PRIMARY KEY (id);
-
-
---
 -- Name: spl_token_tx spl_token_tx_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -10309,43 +8869,11 @@ ALTER TABLE ONLY public.stems
 
 
 --
--- Name: storage_proof_peers storage_proof_peers_block_height_key; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.storage_proof_peers
-    ADD CONSTRAINT storage_proof_peers_block_height_key UNIQUE (block_height);
-
-
---
--- Name: storage_proof_peers storage_proof_peers_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.storage_proof_peers
-    ADD CONSTRAINT storage_proof_peers_pkey PRIMARY KEY (id);
-
-
---
--- Name: storage_proofs storage_proofs_address_block_height_key; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.storage_proofs
-    ADD CONSTRAINT storage_proofs_address_block_height_key UNIQUE (address, block_height);
-
-
---
--- Name: storage_proofs storage_proofs_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.storage_proofs
-    ADD CONSTRAINT storage_proofs_pkey PRIMARY KEY (id);
-
-
---
 -- Name: subscriptions subscriptions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.subscriptions
-    ADD CONSTRAINT subscriptions_pkey PRIMARY KEY (subscriber_id, user_id, txhash);
+    ADD CONSTRAINT subscriptions_pkey PRIMARY KEY (txhash, user_id, subscriber_id);
 
 
 --
@@ -10381,22 +8909,6 @@ ALTER TABLE ONLY public.track_price_history
 
 
 --
--- Name: track_releases track_releases_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.track_releases
-    ADD CONSTRAINT track_releases_pkey PRIMARY KEY (id);
-
-
---
--- Name: track_releases track_releases_track_id_key; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.track_releases
-    ADD CONSTRAINT track_releases_track_id_key UNIQUE (track_id);
-
-
---
 -- Name: track_routes track_routes_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -10417,7 +8929,7 @@ ALTER TABLE ONLY public.track_trending_scores
 --
 
 ALTER TABLE ONLY public.tracks
-    ADD CONSTRAINT tracks_pkey PRIMARY KEY (track_id, txhash);
+    ADD CONSTRAINT tracks_pkey PRIMARY KEY (txhash, track_id);
 
 
 --
@@ -10569,15 +9081,7 @@ ALTER TABLE ONLY public.user_tips
 --
 
 ALTER TABLE ONLY public.users
-    ADD CONSTRAINT users_pkey PRIMARY KEY (user_id, txhash);
-
-
---
--- Name: validator_history validator_history_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.validator_history
-    ADD CONSTRAINT validator_history_pkey PRIMARY KEY (rowid);
+    ADD CONSTRAINT users_pkey PRIMARY KEY (txhash, user_id);
 
 
 --
@@ -10644,13 +9148,6 @@ CREATE INDEX chat_member_user_idx ON public.chat_member USING btree (user_id);
 
 
 --
--- Name: eth_registered_endpoints_wallet_idx; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX eth_registered_endpoints_wallet_idx ON public.eth_registered_endpoints USING btree (delegate_wallet);
-
-
---
 -- Name: fix_tracks_top_genre_users_idx; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -10669,13 +9166,6 @@ CREATE INDEX follows_blocknumber_idx ON public.follows USING btree (blocknumber)
 --
 
 CREATE INDEX follows_inbound_idx ON public.follows USING btree (followee_user_id, follower_user_id, is_delete);
-
-
---
--- Name: idx_access_keys_track_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_access_keys_track_id ON public.access_keys USING btree (track_id);
 
 
 --
@@ -10784,188 +9274,6 @@ CREATE INDEX idx_chat_message_user_id ON public.chat_message USING btree (user_i
 
 
 --
--- Name: idx_core_blocks_chain_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_core_blocks_chain_id ON public.core_blocks USING btree (chain_id);
-
-
---
--- Name: idx_core_blocks_created_at; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_core_blocks_created_at ON public.core_blocks USING btree (created_at);
-
-
---
--- Name: idx_core_blocks_hash; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_core_blocks_hash ON public.core_blocks USING btree (hash);
-
-
---
--- Name: idx_core_blocks_height; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_core_blocks_height ON public.core_blocks USING btree (height);
-
-
---
--- Name: idx_core_blocks_proposer; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_core_blocks_proposer ON public.core_blocks USING btree (proposer);
-
-
---
--- Name: idx_core_ern_address; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_core_ern_address ON public.core_ern USING btree (address);
-
-
---
--- Name: idx_core_ern_block_height; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_core_ern_block_height ON public.core_ern USING btree (block_height);
-
-
---
--- Name: idx_core_ern_message_control_type; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_core_ern_message_control_type ON public.core_ern USING btree (message_control_type);
-
-
---
--- Name: idx_core_ern_sender; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_core_ern_sender ON public.core_ern USING btree (sender);
-
-
---
--- Name: idx_core_mead_address; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_core_mead_address ON public.core_mead USING btree (address);
-
-
---
--- Name: idx_core_mead_block_height; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_core_mead_block_height ON public.core_mead USING btree (block_height);
-
-
---
--- Name: idx_core_mead_sender; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_core_mead_sender ON public.core_mead USING btree (sender);
-
-
---
--- Name: idx_core_pie_address; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_core_pie_address ON public.core_pie USING btree (address);
-
-
---
--- Name: idx_core_pie_block_height; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_core_pie_block_height ON public.core_pie USING btree (block_height);
-
-
---
--- Name: idx_core_pie_sender; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_core_pie_sender ON public.core_pie USING btree (sender);
-
-
---
--- Name: idx_core_stats_tx_type; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_core_stats_tx_type ON public.core_tx_stats USING btree (tx_type);
-
-
---
--- Name: idx_core_transactions_block_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_core_transactions_block_id ON public.core_transactions USING btree (block_id);
-
-
---
--- Name: idx_core_transactions_created_at; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_core_transactions_created_at ON public.core_transactions USING btree (created_at);
-
-
---
--- Name: idx_core_transactions_tx_hash; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_core_transactions_tx_hash ON public.core_transactions USING btree (tx_hash);
-
-
---
--- Name: idx_core_transactions_tx_hash_lower; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_core_transactions_tx_hash_lower ON public.core_transactions USING btree (lower(tx_hash));
-
-
---
--- Name: idx_core_tx_hash; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_core_tx_hash ON public.core_tx_stats USING btree (tx_hash);
-
-
---
--- Name: idx_core_tx_stats_created_at; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_core_tx_stats_created_at ON public.core_tx_stats USING btree (created_at);
-
-
---
--- Name: idx_core_tx_stats_time_type; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_core_tx_stats_time_type ON public.core_tx_stats USING btree (created_at, tx_type);
-
-
---
--- Name: idx_core_validators_comet_address; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_core_validators_comet_address ON public.core_validators USING btree (comet_address);
-
-
---
--- Name: idx_core_validators_endpoint; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_core_validators_endpoint ON public.core_validators USING btree (endpoint);
-
-
---
--- Name: idx_core_validators_eth_address; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_core_validators_eth_address ON public.core_validators USING btree (eth_address);
-
-
---
 -- Name: idx_ddex_release_ids; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -11057,13 +9365,6 @@ CREATE INDEX idx_lower_wallet ON public.users USING btree (lower((wallet)::text)
 
 
 --
--- Name: idx_management_keys_track_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_management_keys_track_id ON public.management_keys USING btree (track_id);
-
-
---
 -- Name: idx_payment_router_txs_slot; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -11096,55 +9397,6 @@ CREATE INDEX idx_reward_manager_txs_slot ON public.reward_manager_txs USING btre
 --
 
 CREATE INDEX idx_rpc_relayed_by ON public.rpc_log USING btree (relayed_by, relayed_at);
-
-
---
--- Name: idx_sla_node_reports_rollup_address; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_sla_node_reports_rollup_address ON public.sla_node_reports USING btree (sla_rollup_id, address);
-
-
---
--- Name: idx_sla_rollups_block_end; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_sla_rollups_block_end ON public.sla_rollups USING btree (block_end DESC);
-
-
---
--- Name: idx_sound_recordings_track_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_sound_recordings_track_id ON public.sound_recordings USING btree (track_id);
-
-
---
--- Name: idx_storage_proof_peers_block_height; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_storage_proof_peers_block_height ON public.storage_proof_peers USING btree (block_height DESC);
-
-
---
--- Name: idx_storage_proofs_block_height; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_storage_proofs_block_height ON public.storage_proofs USING btree (block_height DESC);
-
-
---
--- Name: idx_time; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_time ON public.sla_rollups USING btree ("time" DESC);
-
-
---
--- Name: idx_track_releases_track_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_track_releases_track_id ON public.track_releases USING btree (track_id);
 
 
 --
@@ -11222,13 +9474,6 @@ CREATE INDEX idx_user_bank_txs_slot ON public.user_bank_txs USING btree (slot);
 --
 
 CREATE INDEX idx_user_status ON public.users USING btree (user_id, is_deactivated, is_available, is_current);
-
-
---
--- Name: idx_validator_history_event_time; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_validator_history_event_time ON public.validator_history USING btree (event_time);
 
 
 --
@@ -11446,13 +9691,6 @@ CREATE INDEX ix_user_tips_sender_user_id ON public.user_tips USING btree (sender
 --
 
 CREATE INDEX ix_user_tips_slot ON public.user_tips USING btree (slot);
-
-
---
--- Name: ix_users_active_count; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX ix_users_active_count ON public.users USING btree (is_deactivated, is_current, handle_lc, is_available) WHERE ((is_deactivated = false) AND (is_current = true) AND (handle_lc IS NOT NULL) AND (is_available = true));
 
 
 --
@@ -11953,6 +10191,13 @@ CREATE INDEX track_delist_statuses_track_cid_created_at ON public.track_delist_s
 
 
 --
+-- Name: track_is_premium_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX track_is_premium_idx ON public.tracks USING btree (is_stream_gated, is_delete);
+
+
+--
 -- Name: track_owner_id_idx; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -12282,20 +10527,6 @@ CREATE TRIGGER trg_follows AFTER INSERT OR UPDATE ON public.follows FOR EACH ROW
 
 
 --
--- Name: notification trg_notification; Type: TRIGGER; Schema: public; Owner: -
---
-
-CREATE TRIGGER trg_notification AFTER INSERT ON public.notification FOR EACH ROW EXECUTE FUNCTION public.on_new_notification_row();
-
-
---
--- Name: notification_seen trg_notification_seen; Type: TRIGGER; Schema: public; Owner: -
---
-
-CREATE TRIGGER trg_notification_seen AFTER INSERT ON public.notification_seen FOR EACH ROW EXECUTE FUNCTION public.on_new_notification_seen_row();
-
-
---
 -- Name: playlists trg_playlists; Type: TRIGGER; Schema: public; Owner: -
 --
 
@@ -12552,22 +10783,6 @@ ALTER TABLE ONLY public.saves
 
 
 --
--- Name: shares shares_blocknumber_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.shares
-    ADD CONSTRAINT shares_blocknumber_fkey FOREIGN KEY (blocknumber) REFERENCES public.blocks(number) ON DELETE CASCADE;
-
-
---
--- Name: sla_node_reports sla_node_reports_sla_rollup_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.sla_node_reports
-    ADD CONSTRAINT sla_node_reports_sla_rollup_id_fkey FOREIGN KEY (sla_rollup_id) REFERENCES public.sla_rollups(id);
-
-
---
 -- Name: subscriptions subscriptions_blocknumber_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -12635,5 +10850,4 @@ ALTER TABLE ONLY public.users
 -- PostgreSQL database dump complete
 --
 
-\unrestrict qNSeJSiwqv3O2HB9UoUDJoM3QufXge5QMQYu9BaYLHKGZxri689g8MaAhCBLi5s
 


### PR DESCRIPTION
This mimics the health check strategy we used for block diffs before: Pass a query param to indicate max allowed and we return a 500 if it is exceeded. Also will return 500 if we failed to compute the block diff and a max was provided.
Otherwise, this is intended to not interrupt the health check since that's also used by various consumers to get the list of content nodes.

I'm open to making this thing cache the block diff and only compute it once every few seconds if we think the RPS to this endpoint will add too much load. It does make a RPC call to core and a database request, so it's not exactly the lightest weight thing.

