### PR TITLE
Fix missing coin balance after creation

### DIFF
--- a/api/v1_coin.go
+++ b/api/v1_coin.go
@@ -181,7 +181,7 @@ func (app *ApiServer) v1CoinByTicker(c *fiber.Ctx) error {
 		LEFT JOIN artist_coin_stats
 			ON artist_coin_stats.mint = artist_coins.mint
 		LEFT JOIN artist_coin_pools
-			ON artist_coin_pools.base_mint = artist_coin_stats.mint
+			ON artist_coin_pools.base_mint = artist_coins.mint
 		WHERE artist_coins.ticker = @ticker
 		LIMIT 1
 	`

--- a/api/v1_users_coin.go
+++ b/api/v1_users_coin.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/gagliardetto/solana-go"
@@ -94,7 +95,7 @@ func (app *ApiServer) v1UsersCoin(c *fiber.Ctx) error {
 				'[]'::json
 			) AS accounts
 		FROM artist_coins
-		JOIN artist_coin_stats stats ON artist_coins.mint = stats.mint
+		LEFT JOIN artist_coin_stats stats ON artist_coins.mint = stats.mint
 		LEFT JOIN balances_by_mint ON artist_coins.mint = balances_by_mint.mint
 		LEFT JOIN (
 			SELECT *
@@ -121,6 +122,11 @@ func (app *ApiServer) v1UsersCoin(c *fiber.Ctx) error {
 
 	userCoin, err := pgx.CollectExactlyOneRow(rows, pgx.RowToStructByName[UserCoinAccounts])
 	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return c.JSON(fiber.Map{
+				"data": nil,
+			})
+		}
 		return err
 	}
 

--- a/api/v1_users_coin.go
+++ b/api/v1_users_coin.go
@@ -110,7 +110,8 @@ func (app *ApiServer) v1UsersCoin(c *fiber.Ctx) error {
 			artist_coins.decimals,
 			artist_coins.user_id,
 			balances_by_mint.balance,
-			stats.price
+			stats.price,
+			pools.price_usd
 	;`
 
 	rows, err := app.pool.Query(c.Context(), sql, pgx.NamedArgs{

--- a/api/v1_users_coin.go
+++ b/api/v1_users_coin.go
@@ -81,14 +81,14 @@ func (app *ApiServer) v1UsersCoin(c *fiber.Ctx) error {
 			artist_coins.has_discord,
 			artist_coins.user_id AS owner_id,
 			COALESCE(balances_by_mint.balance, 0) AS balance,
-			COALESCE((balances_by_mint.balance * stats.price) / POWER(10, artist_coins.decimals), 0) AS balance_usd,
+			COALESCE((balances_by_mint.balance * COALESCE(stats.price, pools.price_usd)) / POWER(10, artist_coins.decimals), 0) AS balance_usd,
 			COALESCE(
 				JSON_AGG(
 					JSON_BUILD_OBJECT(
 						'account', balances.account,
 						'owner', balances.owner,
 						'balance', balances.balance,
-						'balance_usd', (balances.balance * stats.price) / POWER(10, artist_coins.decimals),
+						'balance_usd', (balances.balance * COALESCE(stats.price, pools.price_usd)) / POWER(10, artist_coins.decimals),
 						'is_in_app_wallet', balances.is_in_app_wallet
 					)
 				) FILTER (WHERE balances.account IS NOT NULL),
@@ -96,6 +96,7 @@ func (app *ApiServer) v1UsersCoin(c *fiber.Ctx) error {
 			) AS accounts
 		FROM artist_coins
 		LEFT JOIN artist_coin_stats stats ON artist_coins.mint = stats.mint
+		LEFT JOIN artist_coin_pools pools ON artist_coins.mint = pools.base_mint
 		LEFT JOIN balances_by_mint ON artist_coins.mint = balances_by_mint.mint
 		LEFT JOIN (
 			SELECT *

--- a/api/v1_users_coins.go
+++ b/api/v1_users_coins.go
@@ -69,10 +69,11 @@ func (app *ApiServer) v1UsersCoins(c *fiber.Ctx) error {
 			artist_coins.has_discord,
 			artist_coins.user_id AS owner_id,
 			COALESCE(balances_by_mint.balance, 0) AS balance,
-			(COALESCE(balances_by_mint.balance, 0) * stats.price) / POWER(10, artist_coins.decimals) AS balance_usd
+			(COALESCE(balances_by_mint.balance, 0) * COALESCE(stats.price, pools.price_usd)) / POWER(10, artist_coins.decimals) AS balance_usd
 		FROM artist_coins
 		LEFT JOIN balances_by_mint ON balances_by_mint.mint = artist_coins.mint
 		LEFT JOIN artist_coin_stats stats ON stats.mint = artist_coins.mint
+		LEFT JOIN artist_coin_pools pools ON pools.base_mint = artist_coins.mint
 		WHERE artist_coins.user_id = @user_id  -- Show owned coins
 		   OR balance > 0  -- Show coins with positive balance
 		ORDER BY

--- a/api/v1_users_coins.go
+++ b/api/v1_users_coins.go
@@ -72,7 +72,7 @@ func (app *ApiServer) v1UsersCoins(c *fiber.Ctx) error {
 			(COALESCE(balances_by_mint.balance, 0) * stats.price) / POWER(10, artist_coins.decimals) AS balance_usd
 		FROM artist_coins
 		LEFT JOIN balances_by_mint ON balances_by_mint.mint = artist_coins.mint
-		JOIN artist_coin_stats stats ON stats.mint = artist_coins.mint
+		LEFT JOIN artist_coin_stats stats ON stats.mint = artist_coins.mint
 		WHERE artist_coins.user_id = @user_id  -- Show owned coins
 		   OR balance > 0  -- Show coins with positive balance
 		ORDER BY


### PR DESCRIPTION
Because the artist coin is missing stats after creation until the stats job runs (on a 5min interval right now) we should use a left join so that it still shows up when insights are missing. The insights are used in the query for getting price, as is the pool, so we'll have to do some extra work here I think to prevent the price from looking like 0?

Testing this locally was a bit of a beast... I think we just get this out and test against prod launch of a coin to see if this solves the optimism problem since none of this is live yet anyway.