### PR TITLE
Update dbc pools without needing RPC

### DIFF
--- a/jobs/coin_dbc.go
+++ b/jobs/coin_dbc.go
@@ -174,25 +174,7 @@ func (j *CoinDBCJob) UpdatePool(ctx context.Context, poolPubkey solana.PublicKey
 		return fmt.Errorf("error getting pool config: %w", err)
 	}
 
-	price, err := j.meteoraClient.GetQuotePrice(ctx, poolPubkey, int(poolConfig.TokenDecimal), AUDIO_DECIMALS)
-	if err != nil {
-		return fmt.Errorf("error getting quote price: %w", err)
-	}
-
-	progress, err := j.meteoraClient.GetPoolCurveProgress(ctx, poolPubkey)
-	if err != nil {
-		return fmt.Errorf("error getting pool curve progress: %w", err)
-	}
-
-	// Fetch USD price for quote mint from database; default to 0 if not found
-	var quoteUSD float64
-	if err := j.pool.QueryRow(ctx, "SELECT price FROM artist_coin_stats WHERE mint = $1", poolConfig.QuoteMint.String()).Scan(&quoteUSD); err != nil {
-		j.logger.Error("error querying quote price; defaulting to 0", zap.String("quote_mint", poolConfig.QuoteMint.String()), zap.Error(err))
-		quoteUSD = 0
-	}
-	priceUSD := quoteUSD * price
-
-	err = j.insertPool(ctx, poolPubkey, *pool, *poolConfig, price, priceUSD, progress)
+	err = j.UpsertPool(ctx, poolPubkey, *pool, *poolConfig)
 	if err != nil {
 		j.logger.Error("error inserting pool", zap.Error(err))
 		return fmt.Errorf("error inserting pool: %w", err)
@@ -200,15 +182,15 @@ func (j *CoinDBCJob) UpdatePool(ctx context.Context, poolPubkey solana.PublicKey
 	return nil
 }
 
-func (j *CoinDBCJob) insertPool(
+func (j *CoinDBCJob) UpsertPool(
 	ctx context.Context,
 	poolAddress solana.PublicKey,
 	pool meteora_dbc.Pool,
 	poolConfig meteora_dbc.PoolConfig,
-	price float64,
-	priceUSD float64,
-	curveProgress float64,
 ) error {
+	price := pool.GetQuotePrice(int(poolConfig.TokenDecimal), AUDIO_DECIMALS)
+	progress := pool.GetMigrationProgress(poolConfig.MigrationQuoteThreshold)
+
 	_, err := j.pool.Exec(ctx, `
         INSERT INTO artist_coin_pools (
             address,
@@ -245,7 +227,7 @@ func (j *CoinDBCJob) insertPool(
             @creator_quote_fee,
             @total_trading_quote_fee,
             @price,
-			@price_usd,
+			@price * (SELECT price FROM artist_coin_stats WHERE mint = @quote_mint),
             @curve_progress,
             @is_migrated,
             NOW(),
@@ -285,8 +267,7 @@ func (j *CoinDBCJob) insertPool(
 		"creator_quote_fee":         pool.CreatorQuoteFee,
 		"total_trading_quote_fee":   pool.Metrics.TotalTradingQuoteFee,
 		"price":                     price,
-		"price_usd":                 priceUSD,
-		"curve_progress":            curveProgress,
+		"curve_progress":            progress,
 		"is_migrated":               pool.IsMigrated != 0,
 		"creator_wallet_address":    pool.Creator.String(),
 	})

--- a/solana/indexer/fake_rpc_client/fake_rpc_client.go
+++ b/solana/indexer/fake_rpc_client/fake_rpc_client.go
@@ -15,6 +15,7 @@ type FakeRpcClient struct {
 	GetSlotFunc                         func(ctx context.Context, commitment rpc.CommitmentType) (uint64, error)
 	GetSignaturesForAddressWithOptsFunc func(ctx context.Context, address solana.PublicKey, opts *rpc.GetSignaturesForAddressOpts) ([]*rpc.TransactionSignature, error)
 	GetTransactionFunc                  func(ctx context.Context, sig solana.Signature, opts *rpc.GetTransactionOpts) (*rpc.GetTransactionResult, error)
+	GetAccountDataBorshIntoFunc         func(ctx context.Context, account solana.PublicKey, out interface{}) error
 }
 
 func (m *FakeRpcClient) GetBlockWithOpts(ctx context.Context, slot uint64, opts *rpc.GetBlockOpts) (*rpc.GetBlockResult, error) {
@@ -43,6 +44,13 @@ func (m *FakeRpcClient) GetTransaction(ctx context.Context, sig solana.Signature
 		return m.GetTransactionFunc(ctx, sig, opts)
 	}
 	return nil, nil
+}
+
+func (m *FakeRpcClient) GetAccountDataBorshInto(ctx context.Context, account solana.PublicKey, out interface{}) error {
+	if m.GetAccountDataBorshIntoFunc != nil {
+		return m.GetAccountDataBorshIntoFunc(ctx, account, out)
+	}
+	return errors.New("GetAccountDataBorshIntoFunc not implemented")
 }
 
 func ZipTransactionResultsAndTransactions(

--- a/solana/indexer/solana_indexer.go
+++ b/solana/indexer/solana_indexer.go
@@ -21,6 +21,7 @@ type RpcClient interface {
 	GetSlot(context.Context, rpc.CommitmentType) (uint64, error)
 	GetSignaturesForAddressWithOpts(context.Context, solana.PublicKey, *rpc.GetSignaturesForAddressOpts) ([]*rpc.TransactionSignature, error)
 	GetTransaction(context.Context, solana.Signature, *rpc.GetTransactionOpts) (*rpc.GetTransactionResult, error)
+	GetAccountDataBorshInto(ctx context.Context, account solana.PublicKey, out interface{}) error
 }
 
 type GrpcClient interface {

--- a/solana/indexer/subscription.go
+++ b/solana/indexer/subscription.go
@@ -10,6 +10,7 @@ import (
 	"api.audius.co/jobs"
 	"api.audius.co/logging"
 	"api.audius.co/solana/spl/programs/meteora_dbc"
+	bin "github.com/gagliardetto/binary"
 	"github.com/gagliardetto/solana-go"
 	pb "github.com/rpcpool/yellowstone-grpc/examples/golang/proto"
 	"go.uber.org/zap"
@@ -18,6 +19,9 @@ import (
 // LaserStream from Helius only keeps the last 3000 slots.
 // Subtract 10 slots to be sure that the subscription doesn't fail.
 var MAX_SLOT_GAP = uint64(2990)
+
+// Used to find graduation progress of DBC pools
+const AUDIO_DECIMALS = 8
 
 type artistCoinsChangedNotification struct {
 	Operation string `json:"operation"`
@@ -275,8 +279,18 @@ func (s *SolanaIndexer) handleMessage(ctx context.Context, msg *pb.SubscribeUpda
 			for _, config := range s.config.SolanaConfig.DbcPoolConfigs {
 				if filterName == config.String() {
 					account := solana.PublicKeyFromBytes([]byte(accUpdate.Account.Pubkey))
-					logger.Debug("Updating DBC pool", zap.String("pool", account.String()), zap.String("config", config.String()))
-					err := jobs.NewCoinDBCJob(s.config, s.pool).UpdatePool(ctx, account)
+					logger.Info("Updating DBC pool", zap.String("pool", account.String()), zap.String("config", config.String()))
+					var pool meteora_dbc.Pool
+					err := bin.NewBinDecoder(accUpdate.Account.Data).Decode(&pool)
+
+					dbcClient := meteora_dbc.NewClient(s.rpcClient, logger)
+					poolConfig, err := dbcClient.GetPoolConfig(ctx, pool.Config)
+					if err != nil || poolConfig == nil {
+						logger.Error("failed to get DBC pool config", zap.String("pool", account.String()), zap.String("config", config.String()), zap.Error(err))
+						continue
+					}
+					jobs.NewCoinDBCJob(s.config, s.pool).UpsertPool(ctx, account, pool, *poolConfig)
+
 					if err != nil {
 						logger.Error("failed to update DBC pool", zap.String("pool", account.String()), zap.Error(err))
 					}

--- a/solana/indexer/subscription_test.go
+++ b/solana/indexer/subscription_test.go
@@ -58,6 +58,11 @@ func (m *mockRpcClient) GetTransaction(ctx context.Context, signature solana.Sig
 	return args.Get(0).(*rpc.GetTransactionResult), args.Error(1)
 }
 
+func (m *mockRpcClient) GetAccountDataBorshInto(ctx context.Context, account solana.PublicKey, out interface{}) error {
+	args := m.Called(ctx, account, out)
+	return args.Error(0)
+}
+
 // Tests that the subscription is made for the artist coins in the database
 // and is updated as new artist coins are added and removed.
 func TestSubscription(t *testing.T) {

--- a/solana/spl/programs/meteora_dbc/client.go
+++ b/solana/spl/programs/meteora_dbc/client.go
@@ -2,22 +2,24 @@ package meteora_dbc
 
 import (
 	"context"
-	"math/big"
 
 	"github.com/gagliardetto/solana-go"
-	"github.com/gagliardetto/solana-go/rpc"
 	"go.uber.org/zap"
 )
 
 var DbcProgramID = solana.MustPublicKeyFromBase58("dbcij3LWUppWqq96dh6gJWwBifmcGfLSB5D4DuSMaqN")
 
+type RpcClient interface {
+	GetAccountDataBorshInto(ctx context.Context, account solana.PublicKey, out interface{}) error
+}
+
 type Client struct {
-	client *rpc.Client
+	client RpcClient
 	logger *zap.Logger
 }
 
 func NewClient(
-	client *rpc.Client,
+	client RpcClient,
 	logger *zap.Logger,
 ) *Client {
 	return &Client{
@@ -55,12 +57,7 @@ func (c *Client) GetPoolCurveProgress(ctx context.Context, poolAccount solana.Pu
 		return 0, err
 	}
 
-	quoteReserve := new(big.Int).SetUint64(pool.QuoteReserve)
-	migrationQuoteThreshold := new(big.Int).SetUint64(config.MigrationQuoteThreshold)
-	quotient := new(big.Rat).SetFrac(quoteReserve, migrationQuoteThreshold)
-	progress, _ := quotient.Float64()
-
-	return progress, nil
+	return pool.GetMigrationProgress(config.MigrationQuoteThreshold), nil
 }
 
 func (c *Client) GetQuotePrice(ctx context.Context, poolAccount solana.PublicKey, tokenBaseDecimals int, tokenQuoteDecimals int) (float64, error) {
@@ -69,15 +66,5 @@ func (c *Client) GetQuotePrice(ctx context.Context, poolAccount solana.PublicKey
 		return 0, err
 	}
 
-	sqrtPrice := pool.SqrtPrice.BigInt()
-	sqrtPriceSquared := new(big.Int).Mul(sqrtPrice, sqrtPrice)
-	decimalsFactor := new(big.Int).Exp(big.NewInt(10), big.NewInt(int64(tokenBaseDecimals-tokenQuoteDecimals)), nil)
-
-	numerator := new(big.Int).Mul(sqrtPriceSquared, decimalsFactor)
-	divisor := new(big.Int).Exp(big.NewInt(2), big.NewInt(128), nil)
-	quotient := new(big.Rat).SetFrac(numerator, divisor)
-
-	price, _ := quotient.Float64()
-
-	return price, nil
+	return pool.GetQuotePrice(tokenBaseDecimals, tokenQuoteDecimals), nil
 }

--- a/solana/spl/programs/meteora_dbc/pool.go
+++ b/solana/spl/programs/meteora_dbc/pool.go
@@ -1,0 +1,63 @@
+package meteora_dbc
+
+import (
+	"math/big"
+
+	bin "github.com/gagliardetto/binary"
+	"github.com/gagliardetto/solana-go"
+)
+
+type Pool struct {
+	Discriminator              [8]uint8
+	VolatilityTracker          VolatilityTracker
+	Config                     solana.PublicKey
+	Creator                    solana.PublicKey
+	BaseMint                   solana.PublicKey
+	BaseVault                  solana.PublicKey
+	QuoteVault                 solana.PublicKey
+	BaseReserve                uint64
+	QuoteReserve               uint64
+	ProtocolBaseFee            uint64
+	ProtocolQuoteFee           uint64
+	PartnerBaseFee             uint64
+	PartnerQuoteFee            uint64
+	SqrtPrice                  bin.Uint128
+	ActivationPoint            uint64
+	PoolType                   uint8
+	IsMigrated                 uint8
+	IsPartnerWithdrawSurplus   uint8
+	IsProtocolWithdrawSurplus  uint8
+	MigrationProgress          uint8
+	IsWithdrawLeftover         uint8
+	IsCreatorWithdrawSurplus   uint8
+	MigrationFeeWithdrawStatus uint8
+	Metrics                    PoolMetrics
+	FinishCurveTimestamp       uint64
+	CreatorBaseFee             uint64
+	CreatorQuoteFee            uint64
+	Padding1                   [7]uint64
+}
+
+func (p Pool) GetMigrationProgress(migrationQuoteThreshold uint64) float64 {
+
+	quoteReserve := new(big.Int).SetUint64(p.QuoteReserve)
+	migrationQuoteThresholdBig := new(big.Int).SetUint64(migrationQuoteThreshold)
+	quotient := new(big.Rat).SetFrac(quoteReserve, migrationQuoteThresholdBig)
+	progress, _ := quotient.Float64()
+
+	return progress
+}
+
+func (p Pool) GetQuotePrice(tokenBaseDecimals int, tokenQuoteDecimals int) float64 {
+	sqrtPrice := p.SqrtPrice.BigInt()
+	sqrtPriceSquared := new(big.Int).Mul(sqrtPrice, sqrtPrice)
+	decimalsFactor := new(big.Int).Exp(big.NewInt(10), big.NewInt(int64(tokenBaseDecimals-tokenQuoteDecimals)), nil)
+
+	numerator := new(big.Int).Mul(sqrtPriceSquared, decimalsFactor)
+	divisor := new(big.Int).Exp(big.NewInt(2), big.NewInt(128), nil)
+	quotient := new(big.Rat).SetFrac(numerator, divisor)
+
+	price, _ := quotient.Float64()
+
+	return price
+}

--- a/solana/spl/programs/meteora_dbc/state.go
+++ b/solana/spl/programs/meteora_dbc/state.go
@@ -104,34 +104,3 @@ type PoolMetrics struct {
 	TotalTradingBaseFee   uint64
 	TotalTradingQuoteFee  uint64
 }
-
-type Pool struct {
-	Discriminator              [8]uint8
-	VolatilityTracker          VolatilityTracker
-	Config                     solana.PublicKey
-	Creator                    solana.PublicKey
-	BaseMint                   solana.PublicKey
-	BaseVault                  solana.PublicKey
-	QuoteVault                 solana.PublicKey
-	BaseReserve                uint64
-	QuoteReserve               uint64
-	ProtocolBaseFee            uint64
-	ProtocolQuoteFee           uint64
-	PartnerBaseFee             uint64
-	PartnerQuoteFee            uint64
-	SqrtPrice                  bin.Uint128
-	ActivationPoint            uint64
-	PoolType                   uint8
-	IsMigrated                 uint8
-	IsPartnerWithdrawSurplus   uint8
-	IsProtocolWithdrawSurplus  uint8
-	MigrationProgress          uint8
-	IsWithdrawLeftover         uint8
-	IsCreatorWithdrawSurplus   uint8
-	MigrationFeeWithdrawStatus uint8
-	Metrics                    PoolMetrics
-	FinishCurveTimestamp       uint64
-	CreatorBaseFee             uint64
-	CreatorQuoteFee            uint64
-	Padding1                   [7]uint64
-}


### PR DESCRIPTION
The RPC doesn't always have the state change by the time the subscription notifies the indexer, causing the DBC to not be found.

The subscription actually gives us the updated state, so use that instead.

Still need to fetch the config, but that's going to be stable and around much longer and won't change as frequently.