### PR TITLE
Allow audiusAppUrl to be overridden via env var

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -348,6 +348,12 @@ func init() {
 		Cfg.AntiAbuseOracles = strings.Split(v, ",")
 	}
 
+	// Override the Audius app base URL when set, so developer apps running against a
+	// non-default frontend (local override, preview deploy) get the right redirect_uri base.
+	if v := os.Getenv("audiusAppUrl"); v != "" {
+		Cfg.AudiusAppUrl = strings.TrimSuffix(v, "/")
+	}
+
 	if v := os.Getenv("featuredAudienceUserId"); v != "" {
 		parsed, err := strconv.ParseInt(v, 10, 32)
 		if err != nil {


### PR DESCRIPTION
## Summary

`Cfg.AudiusAppUrl` was hardcoded inside the per-env `switch` in `config.init()` for `dev`, `stage` and `prod`, so it could not be pointed at a non-default frontend without a code change. Developer apps running against a local override or preview deploy got the wrong `redirect_uri` base.

This applies an `audiusAppUrl` env override **after** the switch, alongside the existing `archiverNodes` and `antiAbuseOracles` overrides that solve the same problem for values the switch also sets per-env:

```go
// Override the Audius app base URL when set, so developer apps running against a
// non-default frontend (local override, preview deploy) get the right redirect_uri base.
if v := os.Getenv("audiusAppUrl"); v != "" {
    Cfg.AudiusAppUrl = strings.TrimSuffix(v, "/")
}
```

Placing it after the switch means it covers every env and cannot be silently missed when a new env case is added — the earlier revision of this PR guarded `dev` and `prod` individually, and a `stage` default added to `main` in the meantime went unguarded.

The trailing slash is trimmed because every consumer builds URLs as `base + "/..."` (`v1_oauth.go`, `v1_sitemaps.go`, `v1_users_sales_download.go`, `v1_users_purchases_download.go`), so a trailing slash would produce `//`.

Rebased onto current `main` — the previous revision was 246 commits behind and conflicting.

## Test plan

`go build`, `go vet` and `gofmt` are clean. A standard unit test can't cover this: `init()` runs at package load, before `t.Setenv` could take effect. Verified instead by running the real package across the env matrix:

| ENV | `audiusAppUrl` | `Cfg.AudiusAppUrl` |
|---|---|---|
| dev | *(unset)* | `http://localhost:3000` |
| dev | `http://custom.example` | `http://custom.example` |
| stage | *(unset)* | `https://staging.audius.co` |
| stage | `http://custom.example` | `http://custom.example` |
| prod | *(unset)* | `https://audius.co` |
| prod | `https://preview.audius.co` | `https://preview.audius.co` |
| prod | `https://trailing.example/` | `https://trailing.example` |

## Note

`Cfg.AudiusdURL` has the same latent bug — read from `os.Getenv("audiusdUrl")` in the `Cfg` initializer, then unconditionally overwritten in all three switch branches. Left alone as out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)