### PR TITLE
Include unlisted tracks in playlist responses

### DIFF
--- a/api/dbv1/parallel.go
+++ b/api/dbv1/parallel.go
@@ -7,11 +7,12 @@ import (
 )
 
 type ParallelParams struct {
-	UserIds      []int32
-	TrackIds     []int32
-	PlaylistIds  []int32
-	MyID         int32
-	AuthedWallet string
+	UserIds         []int32
+	TrackIds        []int32
+	PlaylistIds     []int32
+	MyID            int32
+	AuthedWallet    string
+	IncludeUnlisted bool
 }
 
 type ParallelResult struct {
@@ -43,9 +44,10 @@ func (q *Queries) Parallel(ctx context.Context, arg ParallelParams) (*ParallelRe
 			var err error
 			trackMap, err = q.TracksKeyed(ctx, TracksParams{
 				GetTracksParams: GetTracksParams{
-					Ids:          arg.TrackIds,
-					MyID:         arg.MyID,
-					AuthedWallet: arg.AuthedWallet,
+					Ids:             arg.TrackIds,
+					MyID:            arg.MyID,
+					AuthedWallet:    arg.AuthedWallet,
+					IncludeUnlisted: arg.IncludeUnlisted,
 				},
 			})
 			return err

--- a/api/dbv1/playlists.go
+++ b/api/dbv1/playlists.go
@@ -69,10 +69,11 @@ func (q *Queries) PlaylistsKeyed(ctx context.Context, arg PlaylistsParams) (map[
 
 	// fetch users + tracks in parallel
 	loaded, err := q.Parallel(ctx, ParallelParams{
-		UserIds:      userIds,
-		TrackIds:     trackIds,
-		MyID:         arg.MyID.(int32),
-		AuthedWallet: arg.AuthedWallet,
+		UserIds:         userIds,
+		TrackIds:        trackIds,
+		MyID:            arg.MyID.(int32),
+		AuthedWallet:    arg.AuthedWallet,
+		IncludeUnlisted: true,
 	})
 	if err != nil {
 		return nil, err

--- a/api/v1_playlist_test.go
+++ b/api/v1_playlist_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"api.audius.co/api/dbv1"
+	"api.audius.co/database"
 	"api.audius.co/trashid"
 	"github.com/stretchr/testify/assert"
 )
@@ -97,5 +98,60 @@ func TestGetPlaylistUsdcPurchaseSelfAccess(t *testing.T) {
 	jsonAssert(t, body2, map[string]any{
 		"data.0.playlist_name": "Purchase Gated Stream",
 		"data.0.access":        `{"stream":true,"download":true}`,
+	})
+}
+
+func TestGetPlaylistIncludesUnlistedTracks(t *testing.T) {
+	app := emptyTestApp(t)
+
+	fixtures := database.FixtureMap{
+		"users": []map[string]any{
+			{
+				"user_id": 1,
+				"handle":  "user1",
+				"name":    "User 1",
+			},
+		},
+		"tracks": []map[string]any{
+			{
+				"track_id": 1,
+				"owner_id": 1,
+				"title":    "Listed Track",
+			},
+			{
+				"track_id":    2,
+				"owner_id":    1,
+				"title":       "Unlisted Track",
+				"is_unlisted": true,
+			},
+		},
+		"playlists": []map[string]any{
+			{
+				"playlist_id":       1,
+				"playlist_owner_id": 1,
+				"playlist_contents": map[string]any{
+					"track_ids": []map[string]any{
+						{"track": 1, "time": 1, "metadata_time": 1},
+						{"track": 2, "time": 2, "metadata_time": 2},
+					},
+				},
+			},
+		},
+	}
+	database.Seed(app.pool.Replicas[0], fixtures)
+
+	playlistId := trashid.MustEncodeHashID(1)
+
+	var playlistResponse struct {
+		Data []dbv1.Playlist
+	}
+	status, body := testGet(t, app, "/v1/full/playlists/"+playlistId, &playlistResponse)
+	assert.Equal(t, 200, status)
+
+	// Both listed and unlisted tracks should appear in the hydrated tracks array
+	jsonAssert(t, body, map[string]any{
+		"data.0.tracks.#":    2,
+		"data.0.tracks.0.id": trashid.MustEncodeHashID(1),
+		"data.0.tracks.1.id": trashid.MustEncodeHashID(2),
 	})
 }

--- a/api/v1_playlist_tracks.go
+++ b/api/v1_playlist_tracks.go
@@ -58,9 +58,10 @@ func (app *ApiServer) v1PlaylistTracks(c *fiber.Ctx) error {
 
 	tracks, err := app.queries.Tracks(c.Context(), dbv1.TracksParams{
 		GetTracksParams: dbv1.GetTracksParams{
-			Ids:          trackIds,
-			MyID:         myId,
-			AuthedWallet: app.tryGetAuthedWallet(c),
+			Ids:             trackIds,
+			MyID:            myId,
+			AuthedWallet:    app.tryGetAuthedWallet(c),
+			IncludeUnlisted: true,
 		},
 	})
 

--- a/api/v1_playlist_tracks_test.go
+++ b/api/v1_playlist_tracks_test.go
@@ -88,3 +88,65 @@ func TestV1PlaylistTracks(t *testing.T) {
 		})
 	}
 }
+
+func TestV1PlaylistTracksIncludesUnlisted(t *testing.T) {
+	app := emptyTestApp(t)
+
+	fixtures := database.FixtureMap{
+		"users": []map[string]any{
+			{
+				"user_id": 1,
+				"handle":  "user1",
+				"name":    "User 1",
+			},
+		},
+		"tracks": []map[string]any{
+			{
+				"track_id": 1,
+				"owner_id": 1,
+				"title":    "Listed Track",
+			},
+			{
+				"track_id":    2,
+				"owner_id":    1,
+				"title":       "Unlisted Track",
+				"is_unlisted": true,
+			},
+		},
+		"playlists": []map[string]any{
+			{
+				"playlist_id":       1,
+				"playlist_owner_id": 1,
+				"playlist_contents": map[string]any{
+					"track_ids": []map[string]any{
+						{"track": 1, "time": 1, "metadata_time": 1},
+						{"track": 2, "time": 2, "metadata_time": 2},
+					},
+				},
+			},
+		},
+	}
+	database.Seed(app.pool.Replicas[0], fixtures)
+
+	playlistId := trashid.MustEncodeHashID(1)
+
+	// GET /v1/playlists/:id/tracks should include unlisted tracks
+	{
+		status, body := testGet(t, app, "/v1/playlists/"+playlistId+"/tracks", nil)
+		assert.Equal(t, 200, status)
+		jsonAssert(t, body, map[string]any{
+			"data.#":    2,
+			"data.0.id": trashid.MustEncodeHashID(1),
+			"data.1.id": trashid.MustEncodeHashID(2),
+		})
+	}
+
+	// Also works with exclude_gated=false
+	{
+		status, body := testGet(t, app, "/v1/playlists/"+playlistId+"/tracks?exclude_gated=false", nil)
+		assert.Equal(t, 200, status)
+		jsonAssert(t, body, map[string]any{
+			"data.#": 2,
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Unlisted tracks added to playlists were being filtered out by the `get_tracks` query's `is_unlisted = false` filter
- This caused a mismatch where `playlist_contents` listed the track ID but the hydrated `tracks` array was missing it
- Sets `IncludeUnlisted: true` for both `GET /v1/playlists/:id` (via `ParallelParams`) and `GET /v1/playlists/:id/tracks`

## Test plan
- [ ] Fetch a playlist containing an unlisted track via `GET /v1/playlists/:id` and verify the track appears in the `tracks` array
- [ ] Fetch playlist tracks via `GET /v1/playlists/:id/tracks` and verify unlisted tracks are included
- [ ] Verify non-playlist track endpoints still respect the unlisted filter

🤖 Generated with [Claude Code](https://claude.com/claude-code)