### PR TITLE
Add refresh_expires_in to OAuth token responses

### DIFF
--- a/api/v1_oauth.go
+++ b/api/v1_oauth.go
@@ -365,11 +365,12 @@ func (app *ApiServer) oauthTokenAuthorizationCode(c *fiber.Ctx, body *oauthToken
 	}
 
 	return c.JSON(fiber.Map{
-		"access_token":  accessToken,
-		"token_type":    "Bearer",
-		"expires_in":    3600,
-		"refresh_token": refreshToken,
-		"scope":         storedScope,
+		"access_token":       accessToken,
+		"token_type":         "Bearer",
+		"expires_in":         3600,
+		"refresh_token":      refreshToken,
+		"refresh_expires_in": int(30 * 24 * time.Hour / time.Second),
+		"scope":              storedScope,
 	})
 }
 
@@ -487,11 +488,12 @@ func (app *ApiServer) oauthTokenRefreshToken(c *fiber.Ctx, body *oauthTokenBody)
 	}
 
 	return c.JSON(fiber.Map{
-		"access_token":  accessToken,
-		"token_type":    "Bearer",
-		"expires_in":    3600,
-		"refresh_token": refreshToken,
-		"scope":         storedScope,
+		"access_token":       accessToken,
+		"token_type":         "Bearer",
+		"expires_in":         3600,
+		"refresh_token":      refreshToken,
+		"refresh_expires_in": int(30 * 24 * time.Hour / time.Second),
+		"scope":              storedScope,
 	})
 }
 


### PR DESCRIPTION
## Summary
- Adds `refresh_expires_in` field (30 days in seconds) to both the authorization code exchange and refresh token grant responses
- Companion to AudiusProject/apps#14078 which adds client-side token expiry tracking to the SDK

## Test plan
- [ ] `POST /v1/oauth/token` (authorization_code grant) response includes `refresh_expires_in: 2592000`
- [ ] `POST /v1/oauth/token` (refresh_token grant) response includes `refresh_expires_in: 2592000`
- [ ] Existing `expires_in` field unchanged (still 3600)

🤖 Generated with [Claude Code](https://claude.com/claude-code)