### PR TITLE
Fix hash ID decoding in playlist contents and grant request bodies

### DIFF
--- a/api/v1_grants.go
+++ b/api/v1_grants.go
@@ -20,11 +20,11 @@ type createGrantBody struct {
 }
 
 type addManagerBody struct {
-	ManagerUserId trashid.HashId `json:"manager_user_id"`
+	ManagerUserId trashid.HashId `json:"manager_user_id" validate:"required,min=1"`
 }
 
 type approveGrantBody struct {
-	GrantorUserId trashid.HashId `json:"grantor_user_id"`
+	GrantorUserId trashid.HashId `json:"grantor_user_id" validate:"required,min=1"`
 }
 
 // postV1UsersGrant creates a grant from the user to an app (user authorizes app to act on their behalf)
@@ -161,6 +161,9 @@ func (app *ApiServer) postV1UsersManager(c *fiber.Ctx) error {
 		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
 			"error": "Invalid request body",
 		})
+	}
+	if err := app.requestValidator.Validate(&body); err != nil {
+		return err
 	}
 	// Get manager's wallet (grantee_address)
 	users, err := app.queries.Users(c.Context(), dbv1.GetUsersParams{
@@ -308,6 +311,9 @@ func (app *ApiServer) postV1UsersApproveGrant(c *fiber.Ctx) error {
 		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
 			"error": "Invalid request body",
 		})
+	}
+	if err := app.requestValidator.Validate(&body); err != nil {
+		return err
 	}
 	signer, err := app.getApiSigner(c)
 	if err != nil {

--- a/api/v1_grants.go
+++ b/api/v1_grants.go
@@ -20,11 +20,11 @@ type createGrantBody struct {
 }
 
 type addManagerBody struct {
-	ManagerUserId string `json:"manager_user_id"`
+	ManagerUserId trashid.HashId `json:"manager_user_id"`
 }
 
 type approveGrantBody struct {
-	GrantorUserId string `json:"grantor_user_id"`
+	GrantorUserId trashid.HashId `json:"grantor_user_id"`
 }
 
 // postV1UsersGrant creates a grant from the user to an app (user authorizes app to act on their behalf)
@@ -162,17 +162,10 @@ func (app *ApiServer) postV1UsersManager(c *fiber.Ctx) error {
 			"error": "Invalid request body",
 		})
 	}
-	managerUserID, err := trashid.DecodeHashId(body.ManagerUserId)
-	if err != nil {
-		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
-			"error": "Invalid manager_user_id",
-		})
-	}
-
 	// Get manager's wallet (grantee_address)
 	users, err := app.queries.Users(c.Context(), dbv1.GetUsersParams{
 		MyID: 0,
-		Ids:  []int32{int32(managerUserID)},
+		Ids:  []int32{int32(body.ManagerUserId)},
 	})
 	if err != nil || len(users) == 0 {
 		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
@@ -316,20 +309,13 @@ func (app *ApiServer) postV1UsersApproveGrant(c *fiber.Ctx) error {
 			"error": "Invalid request body",
 		})
 	}
-	grantorUserID, err := trashid.DecodeHashId(body.GrantorUserId)
-	if err != nil {
-		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
-			"error": "Invalid grantor_user_id",
-		})
-	}
-
 	signer, err := app.getApiSigner(c)
 	if err != nil {
 		return err
 	}
 
 	nonce := time.Now().UnixNano()
-	metadata := map[string]interface{}{"grantor_user_id": int64(grantorUserID)}
+	metadata := map[string]interface{}{"grantor_user_id": int64(body.GrantorUserId)}
 	metadataBytes, _ := json.Marshal(metadata)
 
 	manageEntityTx := &corev1.ManageEntityLegacy{

--- a/api/v1_playlist.go
+++ b/api/v1_playlist.go
@@ -16,9 +16,9 @@ import (
 )
 
 type PlaylistTrackInfo struct {
-	TrackId           string `json:"track_id" validate:"required"`
-	Timestamp         int64  `json:"timestamp" validate:"required,min=0"`
-	MetadataTimestamp *int64 `json:"metadata_timestamp,omitempty" validate:"omitempty,min=0"`
+	TrackId           trashid.IntId `json:"track_id" validate:"required"`
+	Timestamp         int64         `json:"timestamp" validate:"required,min=0"`
+	MetadataTimestamp *int64        `json:"metadata_timestamp,omitempty" validate:"omitempty,min=0"`
 }
 
 type CreatePlaylistRequest struct {

--- a/api/v1_playlist.go
+++ b/api/v1_playlist.go
@@ -16,7 +16,7 @@ import (
 )
 
 type PlaylistTrackInfo struct {
-	TrackId           trashid.IntId `json:"track_id" validate:"required"`
+	TrackId           trashid.IntId `json:"track_id" validate:"required,min=1"`
 	Timestamp         int64         `json:"timestamp" validate:"required,min=0"`
 	MetadataTimestamp *int64        `json:"metadata_timestamp,omitempty" validate:"omitempty,min=0"`
 }

--- a/trashid/hashid.go
+++ b/trashid/hashid.go
@@ -60,6 +60,30 @@ func MustDecodeHashID(id string) int {
 	return val
 }
 
+// IntId accepts a hash ID or raw int on input (JSON unmarshal) but
+// always marshals back as a plain integer. Use this for fields that are
+// part of chain metadata where the indexer expects numeric IDs.
+type IntId int
+
+func (num IntId) MarshalJSON() ([]byte, error) {
+	return []byte(strconv.Itoa(int(num))), nil
+}
+
+func (num *IntId) UnmarshalJSON(data []byte) error {
+	if data[0] == '"' {
+		idStr := strings.Trim(string(data), `"`)
+		id, err := DecodeHashId(idStr)
+		if err != nil {
+			return err
+		}
+		*num = IntId(id)
+		return nil
+	}
+	val, err := strconv.Atoi(string(data))
+	*num = IntId(val)
+	return err
+}
+
 // type alias for int that will do hashid on the way out the door
 type HashId int
 

--- a/trashid/hashid_test.go
+++ b/trashid/hashid_test.go
@@ -46,3 +46,38 @@ func TestHashId(t *testing.T) {
 		assert.Equal(t, 0, int(h))
 	}
 }
+
+func TestIntId(t *testing.T) {
+
+	// when we serialize... it emits a plain number (not a hash string)
+	{
+		i := IntId(44)
+		j, err := json.Marshal(i)
+		assert.NoError(t, err)
+		assert.Equal(t, `44`, string(j))
+	}
+
+	// when we parse a hashid string... it decodes to the numeric value
+	{
+		var i IntId
+		err := json.Unmarshal([]byte(`"eYorL"`), &i)
+		assert.NoError(t, err)
+		assert.Equal(t, 44, int(i))
+	}
+
+	// when we parse a raw number... it works as-is
+	{
+		var i IntId
+		err := json.Unmarshal([]byte("33"), &i)
+		assert.NoError(t, err)
+		assert.Equal(t, 33, int(i))
+	}
+
+	// errors on bad hashid string
+	{
+		var i IntId
+		err := json.Unmarshal([]byte(`"asdjkfalksdjfaklsdjf"`), &i)
+		assert.Error(t, err)
+		assert.Equal(t, 0, int(i))
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `trashid.IntId` type: accepts hash IDs or raw ints on JSON input, always marshals as a plain integer. Designed for chain metadata fields where the indexer expects numeric IDs.
- `PlaylistTrackInfo.TrackId` (`string` → `trashid.IntId`): playlist_contents track IDs are now decoded at the API boundary. Previously hash ID strings were forwarded raw to chain, requiring an indexer workaround.
- `addManagerBody.ManagerUserId` (`string` → `trashid.HashId`): removes redundant manual `DecodeHashId` call, adds struct tag validation
- `approveGrantBody.GrantorUserId` (`string` → `trashid.HashId`): removes redundant manual `DecodeHashId` call, adds struct tag validation

## Test plan
- [ ] POST /v1/playlists with hash ID track IDs in playlist_contents — verify chain metadata contains int IDs
- [ ] POST /v1/playlists with raw int track IDs in playlist_contents — verify still works (backward compat)
- [ ] POST /v1/users/:id/managers with hash ID manager_user_id — verify grant created
- [ ] POST /v1/users/:id/managers with missing/zero manager_user_id — verify 400
- [ ] POST /v1/users/:id/approve-grant with hash ID grantor_user_id — verify grant approved
- [ ] POST /v1/users/:id/approve-grant with missing/zero grantor_user_id — verify 400
- [x] Unit tests for `trashid.IntId` marshal/unmarshal round-trip

🤖 Generated with [Claude Code](https://claude.com/claude-code)