### PR TITLE
Use LATERAL joins for followee reposts/favorites queries

### DIFF
--- a/api/dbv1/get_playlists.sql.go
+++ b/api/dbv1/get_playlists.sql.go
@@ -89,19 +89,24 @@ SELECT
     SELECT json_agg(
       json_build_object(
         'user_id', r.user_id::text,
-        'repost_item_id', repost_item_id::text, -- this is redundant
+        'repost_item_id', r.repost_item_id::text, -- this is redundant
         'repost_type', 'RepostType.track', -- some sqlalchemy bs
         'created_at', r.created_at -- this is not actually present in python response?
       )
     )
     FROM (
-      SELECT user_id, repost_item_id, reposts.created_at
-      FROM reposts
-      JOIN my_follows USING (user_id)
-      WHERE repost_item_id = p.playlist_id
-        AND repost_type != 'track'
-        AND reposts.is_delete = false
-      ORDER BY follower_count DESC
+      SELECT mf.user_id, lr.repost_item_id, lr.created_at, mf.follower_count
+      FROM my_follows mf
+      CROSS JOIN LATERAL (
+        SELECT reposts.repost_item_id, reposts.created_at
+        FROM reposts
+        WHERE reposts.user_id = mf.user_id
+          AND reposts.repost_item_id = p.playlist_id
+          AND reposts.repost_type != 'track'
+          AND reposts.is_delete = false
+        LIMIT 1
+      ) lr
+      ORDER BY mf.follower_count DESC
       LIMIT 6
     ) r
   )::jsonb as followee_reposts,
@@ -116,13 +121,18 @@ SELECT
       )
     )
     FROM (
-      SELECT user_id, save_item_id, saves.created_at
-      FROM saves
-      JOIN my_follows USING (user_id)
-      WHERE save_item_id = p.playlist_id
-        AND save_type != 'track'
-        AND saves.is_delete = false
-      ORDER BY follower_count DESC
+      SELECT mf.user_id, ls.save_item_id, ls.created_at, mf.follower_count
+      FROM my_follows mf
+      CROSS JOIN LATERAL (
+        SELECT saves.save_item_id, saves.created_at
+        FROM saves
+        WHERE saves.user_id = mf.user_id
+          AND saves.save_item_id = p.playlist_id
+          AND saves.save_type != 'track'
+          AND saves.is_delete = false
+        LIMIT 1
+      ) ls
+      ORDER BY mf.follower_count DESC
       LIMIT 6
     ) r
   )::jsonb as followee_favorites

--- a/api/dbv1/get_tracks.sql.go
+++ b/api/dbv1/get_tracks.sql.go
@@ -122,19 +122,24 @@ SELECT
     SELECT json_agg(
       json_build_object(
         'user_id', r.user_id::text,
-        'repost_item_id', repost_item_id::text, -- this is redundant
+        'repost_item_id', r.repost_item_id::text, -- this is redundant
         'repost_type', 'RepostType.track', -- some sqlalchemy bs
         'created_at', r.created_at -- this is not actually present in python response?
       )
     )
     FROM (
-      SELECT user_id, repost_item_id, reposts.created_at
-      FROM reposts
-      JOIN my_follows USING (user_id)
-      WHERE repost_item_id = t.track_id
-        AND repost_type = 'track'
-        AND reposts.is_delete = false
-      ORDER BY follower_count DESC
+      SELECT mf.user_id, lr.repost_item_id, lr.created_at, mf.follower_count
+      FROM my_follows mf
+      CROSS JOIN LATERAL (
+        SELECT reposts.repost_item_id, reposts.created_at
+        FROM reposts
+        WHERE reposts.user_id = mf.user_id
+          AND reposts.repost_item_id = t.track_id
+          AND reposts.repost_type = 'track'
+          AND reposts.is_delete = false
+        LIMIT 1
+      ) lr
+      ORDER BY mf.follower_count DESC
       LIMIT 3
     ) r
   )::jsonb as followee_reposts,
@@ -149,13 +154,18 @@ SELECT
       )
     )
     FROM (
-      SELECT user_id, save_item_id, saves.created_at
-      FROM saves
-      JOIN my_follows USING (user_id)
-      WHERE save_item_id = t.track_id
-        AND save_type = 'track'
-        AND saves.is_delete = false
-      ORDER BY follower_count DESC
+      SELECT mf.user_id, ls.save_item_id, ls.created_at, mf.follower_count
+      FROM my_follows mf
+      CROSS JOIN LATERAL (
+        SELECT saves.save_item_id, saves.created_at
+        FROM saves
+        WHERE saves.user_id = mf.user_id
+          AND saves.save_item_id = t.track_id
+          AND saves.save_type = 'track'
+          AND saves.is_delete = false
+        LIMIT 1
+      ) ls
+      ORDER BY mf.follower_count DESC
       LIMIT 3
     ) r
   )::jsonb as followee_favorites,

--- a/api/dbv1/queries/get_playlists.sql
+++ b/api/dbv1/queries/get_playlists.sql
@@ -74,19 +74,24 @@ SELECT
     SELECT json_agg(
       json_build_object(
         'user_id', r.user_id::text,
-        'repost_item_id', repost_item_id::text, -- this is redundant
+        'repost_item_id', r.repost_item_id::text, -- this is redundant
         'repost_type', 'RepostType.track', -- some sqlalchemy bs
         'created_at', r.created_at -- this is not actually present in python response?
       )
     )
     FROM (
-      SELECT user_id, repost_item_id, reposts.created_at
-      FROM reposts
-      JOIN my_follows USING (user_id)
-      WHERE repost_item_id = p.playlist_id
-        AND repost_type != 'track'
-        AND reposts.is_delete = false
-      ORDER BY follower_count DESC
+      SELECT mf.user_id, lr.repost_item_id, lr.created_at, mf.follower_count
+      FROM my_follows mf
+      CROSS JOIN LATERAL (
+        SELECT reposts.repost_item_id, reposts.created_at
+        FROM reposts
+        WHERE reposts.user_id = mf.user_id
+          AND reposts.repost_item_id = p.playlist_id
+          AND reposts.repost_type != 'track'
+          AND reposts.is_delete = false
+        LIMIT 1
+      ) lr
+      ORDER BY mf.follower_count DESC
       LIMIT 6
     ) r
   )::jsonb as followee_reposts,
@@ -101,13 +106,18 @@ SELECT
       )
     )
     FROM (
-      SELECT user_id, save_item_id, saves.created_at
-      FROM saves
-      JOIN my_follows USING (user_id)
-      WHERE save_item_id = p.playlist_id
-        AND save_type != 'track'
-        AND saves.is_delete = false
-      ORDER BY follower_count DESC
+      SELECT mf.user_id, ls.save_item_id, ls.created_at, mf.follower_count
+      FROM my_follows mf
+      CROSS JOIN LATERAL (
+        SELECT saves.save_item_id, saves.created_at
+        FROM saves
+        WHERE saves.user_id = mf.user_id
+          AND saves.save_item_id = p.playlist_id
+          AND saves.save_type != 'track'
+          AND saves.is_delete = false
+        LIMIT 1
+      ) ls
+      ORDER BY mf.follower_count DESC
       LIMIT 6
     ) r
   )::jsonb as followee_favorites

--- a/api/dbv1/queries/get_tracks.sql
+++ b/api/dbv1/queries/get_tracks.sql
@@ -107,19 +107,24 @@ SELECT
     SELECT json_agg(
       json_build_object(
         'user_id', r.user_id::text,
-        'repost_item_id', repost_item_id::text, -- this is redundant
+        'repost_item_id', r.repost_item_id::text, -- this is redundant
         'repost_type', 'RepostType.track', -- some sqlalchemy bs
         'created_at', r.created_at -- this is not actually present in python response?
       )
     )
     FROM (
-      SELECT user_id, repost_item_id, reposts.created_at
-      FROM reposts
-      JOIN my_follows USING (user_id)
-      WHERE repost_item_id = t.track_id
-        AND repost_type = 'track'
-        AND reposts.is_delete = false
-      ORDER BY follower_count DESC
+      SELECT mf.user_id, lr.repost_item_id, lr.created_at, mf.follower_count
+      FROM my_follows mf
+      CROSS JOIN LATERAL (
+        SELECT reposts.repost_item_id, reposts.created_at
+        FROM reposts
+        WHERE reposts.user_id = mf.user_id
+          AND reposts.repost_item_id = t.track_id
+          AND reposts.repost_type = 'track'
+          AND reposts.is_delete = false
+        LIMIT 1
+      ) lr
+      ORDER BY mf.follower_count DESC
       LIMIT 3
     ) r
   )::jsonb as followee_reposts,
@@ -134,13 +139,18 @@ SELECT
       )
     )
     FROM (
-      SELECT user_id, save_item_id, saves.created_at
-      FROM saves
-      JOIN my_follows USING (user_id)
-      WHERE save_item_id = t.track_id
-        AND save_type = 'track'
-        AND saves.is_delete = false
-      ORDER BY follower_count DESC
+      SELECT mf.user_id, ls.save_item_id, ls.created_at, mf.follower_count
+      FROM my_follows mf
+      CROSS JOIN LATERAL (
+        SELECT saves.save_item_id, saves.created_at
+        FROM saves
+        WHERE saves.user_id = mf.user_id
+          AND saves.save_item_id = t.track_id
+          AND saves.save_type = 'track'
+          AND saves.is_delete = false
+        LIMIT 1
+      ) ls
+      ORDER BY mf.follower_count DESC
       LIMIT 3
     ) r
   )::jsonb as followee_favorites,


### PR DESCRIPTION
## Summary
- Rewrites the followee_reposts and followee_favorites subqueries in both `get_playlists.sql` and `get_tracks.sql` to use `CROSS JOIN LATERAL`
- Forces Postgres to drive from the `my_follows` CTE (~5k rows max) and do index point lookups on saves/reposts PKs, instead of scanning the full saves/reposts table for a given item ID (92k+ rows for popular playlists)
- The planner was choosing hash joins that scan all saves for a playlist_id first — LATERAL prevents this by making the subquery depend on each followee row

## Test plan
- [x] Verified with `EXPLAIN ANALYZE` on production data: query time dropped significantly for popular playlists
- [x] `sqlc generate` succeeds
- [x] `go build ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)