### PR TITLE
Bound /v1/notifications initial load to last 90 days

### DIFF
--- a/api/v1_notifications.go
+++ b/api/v1_notifications.go
@@ -185,7 +185,10 @@ WHERE
 		)
 	)
   AND (
-    (@timestamp_offset = 0 AND @group_id_offset = '') OR
+    -- Initial load: bound to the last 90 days so heavy users don't fan out
+    -- over their entire notification history. Pagination (timestamp_offset > 0)
+    -- is unbounded so scrolling further back still works.
+    (@timestamp_offset = 0 AND @group_id_offset = '' AND n.timestamp > (now()::timestamp - interval '90 days')) OR
     (@timestamp_offset = 0 AND @group_id_offset != '' AND n.group_id < @group_id_offset) OR
     (@timestamp_offset > 0 AND n.timestamp < to_timestamp(@timestamp_offset)) OR
     (


### PR DESCRIPTION
Heavy users saw /v1/notifications/:id p50 ~2.2s (max 8.9s) because the query had no upfront time bound on the initial load path — the planner had to materialize every notification matching user_ids, run per-row EXISTS checks and joins, then group/sort/limit at the very end.

On the initial load (timestamp_offset=0 AND group_id_offset='') bound n.timestamp to the last 90 days. Pagination (timestamp_offset > 0) stays unbounded so scrolling further back still works.