### PR TITLE
Filter out removed and unavailable tracks from user listening history

### DIFF
--- a/api/v1_users_history.go
+++ b/api/v1_users_history.go
@@ -62,7 +62,11 @@ func (app *ApiServer) v1UsersHistory(c *fiber.Ctx) error {
 		class = "track_activity_full"
 	}
 
-	filters := []string{}
+	filters := []string{
+		"tracks.is_delete = false",
+		"tracks.is_available = true",
+		"users.is_deactivated = false",
+	}
 	if params.Query != "" {
 		filters = append(filters, "tracks.title ILIKE '%' || @query || '%' OR users.name ILIKE '%' || @query || '%'")
 	}

--- a/api/v1_users_history_test.go
+++ b/api/v1_users_history_test.go
@@ -67,6 +67,96 @@ func TestUserListeningHistory(t *testing.T) {
 	})
 }
 
+func TestUserListeningHistoryExcludesRemovedTracks(t *testing.T) {
+	app := emptyTestApp(t)
+
+	fixtures := database.FixtureMap{
+		"users": []map[string]any{
+			{
+				"user_id": 1,
+				"handle":  "active_user",
+			},
+			{
+				"user_id": 2,
+				"handle":  "listener",
+				"wallet":  "0x7d273271690538cf855e5b3002a0dd8c154bb060",
+			},
+			{
+				"user_id": 3,
+				"handle":  "deactivated_user",
+				"is_deactivated": true,
+			},
+		},
+		"tracks": []map[string]any{
+			{
+				"track_id":   1,
+				"title":      "Active Track",
+				"owner_id":   1,
+				"is_delete":  false,
+				"created_at": parseTime(t, "2024-01-01"),
+			},
+			{
+				"track_id":   2,
+				"title":      "Deleted Track",
+				"owner_id":   1,
+				"is_delete":  true,
+				"created_at": parseTime(t, "2024-01-01"),
+			},
+			{
+				"track_id":      3,
+				"title":         "Unavailable Track",
+				"owner_id":      1,
+				"is_available":  false,
+				"created_at":    parseTime(t, "2024-01-01"),
+			},
+			{
+				"track_id":   4,
+				"title":      "Deactivated User Track",
+				"owner_id":   3,
+				"created_at": parseTime(t, "2024-01-01"),
+			},
+		},
+		"user_listening_history": []map[string]any{
+			{
+				"user_id": 2,
+				"listening_history": []map[string]any{
+					{
+						"track_id":   1,
+						"play_count": 1,
+						"timestamp":  parseTime(t, "2024-01-04"),
+					},
+					{
+						"track_id":   2,
+						"play_count": 1,
+						"timestamp":  parseTime(t, "2024-01-03"),
+					},
+					{
+						"track_id":   3,
+						"play_count": 1,
+						"timestamp":  parseTime(t, "2024-01-02"),
+					},
+					{
+						"track_id":   4,
+						"play_count": 1,
+						"timestamp":  parseTime(t, "2024-01-01"),
+					},
+				},
+			},
+		},
+	}
+
+	database.Seed(app.pool.Replicas[0], fixtures)
+	listenerId := trashid.MustEncodeHashID(2)
+
+	// Only the active track should appear; deleted, unavailable, and deactivated-user tracks are excluded
+	status, body := testGetWithWallet(t, app, "/v1/full/users/"+listenerId+"/history/tracks?user_id="+listenerId, "0x7d273271690538cf855e5b3002a0dd8c154bb060")
+	assert.Equal(t, 200, status)
+	jsonAssert(t, body, map[string]any{
+		"data.#":           1,
+		"data.0.item.title": "Active Track",
+	})
+}
+
 func TestUserListeningHistoryUnlisted(t *testing.T) {
 	app := emptyTestApp(t)
 


### PR DESCRIPTION
## Summary
Updated the user listening history endpoint to exclude deleted tracks, unavailable tracks, and tracks from deactivated users from the results.

## Changes
- Added three filter conditions to the `v1UsersHistory` endpoint:
  - `tracks.is_delete = false` - excludes tracks marked as deleted
  - `tracks.is_available = true` - excludes tracks marked as unavailable
  - `users.is_deactivated = false` - excludes tracks from deactivated users
- Added comprehensive test case `TestUserListeningHistoryExcludesRemovedTracks` that verifies:
  - Active tracks are included in the history
  - Deleted tracks are filtered out
  - Unavailable tracks are filtered out
  - Tracks from deactivated users are filtered out

## Implementation Details
The filters are applied at the database query level in the listening history endpoint, ensuring that only valid, accessible tracks are returned to users. This prevents users from seeing tracks that have been removed or are no longer available.

https://claude.ai/code/session_01PZcVKSnX4KGMcL9zmQvsC9