### PR TITLE
Fix track download count queries to exclude stem downloads

### DIFF
--- a/api/dbv1/get_track_download_counts.sql.go
+++ b/api/dbv1/get_track_download_counts.sql.go
@@ -15,10 +15,13 @@ SELECT
   (
     SELECT count(*)::bigint
     FROM track_downloads d
-    WHERE (t.stem_of IS NOT NULL
-           AND d.parent_track_id = (t.stem_of->>'parent_track_id')::int
-           AND d.track_id = t.track_id)
-       OR (t.stem_of IS NULL AND d.parent_track_id = t.track_id)
+    WHERE d.track_id = t.track_id
+      AND (
+           (t.stem_of IS NOT NULL
+            AND d.parent_track_id = (t.stem_of->>'parent_track_id')::int)
+        OR (t.stem_of IS NULL
+            AND d.parent_track_id = t.track_id)
+      )
   ) AS download_count
 FROM tracks t
 WHERE t.track_id = ANY($1::int[])

--- a/api/dbv1/get_user_track_download_count_total.sql.go
+++ b/api/dbv1/get_user_track_download_count_total.sql.go
@@ -18,11 +18,11 @@ WHERE EXISTS (
   WHERE t.owner_id = $1
     AND t.is_current = true
     AND t.is_delete = false
+    AND d.track_id = t.track_id
     AND (
       (t.stem_of IS NULL AND d.parent_track_id = t.track_id)
       OR (t.stem_of IS NOT NULL
-          AND (t.stem_of->>'parent_track_id')::int = d.parent_track_id
-          AND d.track_id = t.track_id)
+          AND (t.stem_of->>'parent_track_id')::int = d.parent_track_id)
     )
 )
 `

--- a/api/dbv1/queries/get_track_download_counts.sql
+++ b/api/dbv1/queries/get_track_download_counts.sql
@@ -4,10 +4,13 @@ SELECT
   (
     SELECT count(*)::bigint
     FROM track_downloads d
-    WHERE (t.stem_of IS NOT NULL
-           AND d.parent_track_id = (t.stem_of->>'parent_track_id')::int
-           AND d.track_id = t.track_id)
-       OR (t.stem_of IS NULL AND d.parent_track_id = t.track_id)
+    WHERE d.track_id = t.track_id
+      AND (
+           (t.stem_of IS NOT NULL
+            AND d.parent_track_id = (t.stem_of->>'parent_track_id')::int)
+        OR (t.stem_of IS NULL
+            AND d.parent_track_id = t.track_id)
+      )
   ) AS download_count
 FROM tracks t
 WHERE t.track_id = ANY(@track_ids::int[])

--- a/api/dbv1/queries/get_user_track_download_count_total.sql
+++ b/api/dbv1/queries/get_user_track_download_count_total.sql
@@ -9,10 +9,10 @@ WHERE EXISTS (
   WHERE t.owner_id = @user_id
     AND t.is_current = true
     AND t.is_delete = false
+    AND d.track_id = t.track_id
     AND (
       (t.stem_of IS NULL AND d.parent_track_id = t.track_id)
       OR (t.stem_of IS NOT NULL
-          AND (t.stem_of->>'parent_track_id')::int = d.parent_track_id
-          AND d.track_id = t.track_id)
+          AND (t.stem_of->>'parent_track_id')::int = d.parent_track_id)
     )
 );

--- a/api/v1_track_download_count_test.go
+++ b/api/v1_track_download_count_test.go
@@ -17,10 +17,16 @@ func TestV1TrackDownloadCount(t *testing.T) {
 	ctx := context.Background()
 	require.NotNil(t, app.writePool, "test requires write pool")
 
-	// Track 200 is "Culca Canyon" (eYJyn). Insert two download rows so download_count is 2.
+	// Track 200 is "Culca Canyon" (eYJyn). Insert two original-track download rows
+	// plus two stem download rows (same parent_track_id, different track_id).
+	// Only the originals should be counted.
 	_, err := app.writePool.Exec(ctx, `
 		INSERT INTO track_downloads (txhash, blocknumber, parent_track_id, track_id, user_id)
-		VALUES ('tx-dl-1', 101, 200, 200, 1), ('tx-dl-2', 101, 200, 200, 2)
+		VALUES
+			('tx-dl-1', 101, 200, 200, 1),
+			('tx-dl-2', 101, 200, 200, 2),
+			('tx-dl-stem-1', 101, 200, 9001, 1),
+			('tx-dl-stem-2', 101, 200, 9002, 1)
 	`)
 	require.NoError(t, err)
 
@@ -37,10 +43,14 @@ func TestV1TracksDownloadCounts(t *testing.T) {
 	ctx := context.Background()
 	require.NotNil(t, app.writePool, "test requires write pool")
 
-	// Track 200 (eYJyn) gets 2 downloads; track 201 (eYZmn) has none.
+	// Track 200 (eYJyn) gets 2 original-track downloads plus a stem download that
+	// should be ignored; track 201 (eYZmn) has none.
 	_, err := app.writePool.Exec(ctx, `
 		INSERT INTO track_downloads (txhash, blocknumber, parent_track_id, track_id, user_id)
-		VALUES ('tx-dl-1', 101, 200, 200, 1), ('tx-dl-2', 101, 200, 200, 2)
+		VALUES
+			('tx-dl-1', 101, 200, 200, 1),
+			('tx-dl-2', 101, 200, 200, 2),
+			('tx-dl-stem-1', 101, 200, 9001, 1)
 	`)
 	require.NoError(t, err)
 
@@ -64,10 +74,14 @@ func TestV1UserTracksDownloadCount(t *testing.T) {
 	ctx := context.Background()
 	require.NotNil(t, app.writePool, "test requires write pool")
 
-	// Track 200 (eYJyn) is owned by user 2. Insert two download rows.
+	// Track 200 (eYJyn) is owned by user 2. Insert two original-track download rows
+	// plus a stem download row that should be excluded from the total.
 	_, err := app.writePool.Exec(ctx, `
 		INSERT INTO track_downloads (txhash, blocknumber, parent_track_id, track_id, user_id)
-		VALUES ('tx-user-total-1', 101, 200, 200, 1), ('tx-user-total-2', 101, 200, 200, 2)
+		VALUES
+			('tx-user-total-1', 101, 200, 200, 1),
+			('tx-user-total-2', 101, 200, 200, 2),
+			('tx-user-total-stem-1', 101, 200, 9001, 1)
 	`)
 	require.NoError(t, err)
 


### PR DESCRIPTION
## Summary
This PR fixes the track download count queries to properly exclude stem track downloads from the count. Previously, the queries were incorrectly counting downloads of stem tracks as downloads of their parent tracks.

## Key Changes
- **Query Logic Fix**: Restructured the WHERE clause in `get_track_download_counts.sql` and `get_user_track_download_count_total.sql` to add an explicit `d.track_id = t.track_id` condition. This ensures that only downloads of the exact track (not stems of that track) are counted.
  - For original tracks: downloads where `parent_track_id = track_id`
  - For stem tracks: downloads where `parent_track_id` matches the stem's parent and `track_id` matches the stem itself
  
- **Test Updates**: Enhanced test cases in `v1_track_download_count_test.go` to verify the fix:
  - Added stem download rows to test data to ensure they are properly excluded from counts
  - Updated test comments to clarify the expected behavior
  - Reformatted INSERT statements for better readability

## Implementation Details
The key fix moves the `d.track_id = t.track_id` condition outside the OR clause and into the main WHERE clause. This ensures that:
1. For original tracks (where `stem_of IS NULL`), we count downloads where the download's `parent_track_id` equals the track's `track_id`
2. For stem tracks (where `stem_of IS NOT NULL`), we count downloads where the download's `parent_track_id` matches the stem's parent AND the download's `track_id` matches the stem's `track_id`

This prevents stem track downloads from being incorrectly attributed to their parent tracks.

https://claude.ai/code/session_01M8ZDgw87vg9S2weug8Jj9P