### PR TITLE
events: document follow/follow_state/followers/comments in swagger

### DIFF
--- a/api/swagger/swagger-v1.yaml
+++ b/api/swagger/swagger-v1.yaml
@@ -1245,6 +1245,276 @@ paths:
         "500":
           description: Server error
           content: {}
+  /events/{eventId}/comments:
+    get:
+      tags:
+        - events
+      summary: Get event comments
+      description:
+        Paginated stream of top-level comments (with nested replies) for a
+        remix-contest event. Host-authored top-level comments represent
+        "post updates"; everything else is a community comment.
+      operationId: Get Event Comments
+      security:
+        - {}
+        - OAuth2:
+            - read
+      parameters:
+        - name: eventId
+          in: path
+          description: An Event ID
+          required: true
+          schema:
+            type: string
+        - name: offset
+          in: query
+          description:
+            The number of items to skip. Useful for pagination (page number
+            * limit)
+          schema:
+            type: integer
+        - name: limit
+          in: query
+          description: The number of items to fetch
+          schema:
+            type: integer
+        - name: user_id
+          in: query
+          description: The user ID of the user making the request
+          schema:
+            type: string
+        - name: sort_method
+          in: query
+          description: The sort method
+          schema:
+            type: string
+            default: newest
+            enum:
+              - top
+              - newest
+              - timestamp
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/track_comments_response"
+        "400":
+          description: Bad request
+          content: {}
+        "500":
+          description: Server error
+          content: {}
+  /events/{eventId}/follow:
+    post:
+      tags:
+        - events
+      summary: Follow event
+      description:
+        Subscribe to a remix-contest event. Emits a Subscribe/Event
+        ManageEntity transaction so the indexer records the follow.
+      operationId: Follow Event
+      security:
+        - BearerAuth: []
+        - BasicAuth: []
+        - OAuth2:
+            - write
+      parameters:
+        - name: eventId
+          in: path
+          description: An Event ID
+          required: true
+          schema:
+            type: string
+        - name: user_id
+          in: query
+          description: The user ID of the user making the request
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Event followed successfully
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/write_response"
+        "401":
+          description: Unauthorized
+          content: {}
+        "404":
+          description: Event not found
+          content: {}
+        "500":
+          description: Server error
+          content: {}
+    delete:
+      tags:
+        - events
+      summary: Unfollow event
+      description:
+        Unsubscribe from a remix-contest event. Emits an
+        Unsubscribe/Event ManageEntity transaction.
+      operationId: Unfollow Event
+      security:
+        - BearerAuth: []
+        - BasicAuth: []
+        - OAuth2:
+            - write
+      parameters:
+        - name: eventId
+          in: path
+          description: An Event ID
+          required: true
+          schema:
+            type: string
+        - name: user_id
+          in: query
+          description: The user ID of the user making the request
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Event unfollowed successfully
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/write_response"
+        "401":
+          description: Unauthorized
+          content: {}
+        "500":
+          description: Server error
+          content: {}
+  /events/{eventId}/follow_state:
+    get:
+      tags:
+        - events
+      summary: Get event follow state
+      description:
+        Returns whether the current user is subscribed to (follows) a given
+        remix-contest event, plus the total follower count. Useful for
+        rendering the Follow / Following button.
+      operationId: Get Event Follow State
+      security:
+        - {}
+        - OAuth2:
+            - read
+      parameters:
+        - name: eventId
+          in: path
+          description: An Event ID
+          required: true
+          schema:
+            type: string
+        - name: user_id
+          in: query
+          description: The user ID of the user making the request
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/event_follow_state_response"
+        "400":
+          description: Bad request
+          content: {}
+        "500":
+          description: Server error
+          content: {}
+  /events/{eventId}/follow-state:
+    get:
+      tags:
+        - events
+      summary: Get event follow state (hyphenated alias)
+      description: Hyphenated alias of /events/{eventId}/follow_state.
+      operationId: Get Event Follow State Alias
+      security:
+        - {}
+        - OAuth2:
+            - read
+      parameters:
+        - name: eventId
+          in: path
+          description: An Event ID
+          required: true
+          schema:
+            type: string
+        - name: user_id
+          in: query
+          description: The user ID of the user making the request
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/event_follow_state_response"
+        "400":
+          description: Bad request
+          content: {}
+        "500":
+          description: Server error
+          content: {}
+  /events/{eventId}/followers:
+    get:
+      tags:
+        - events
+      summary: Get event followers
+      description:
+        Returns the list of users subscribed to a given remix-contest
+        event, ordered by each follower's own follower count so the
+        most-followed fans surface first. Used by the contest page's
+        Followers card (avatar stack + leaderboard).
+      operationId: Get Event Followers
+      security:
+        - {}
+        - OAuth2:
+            - read
+      parameters:
+        - name: eventId
+          in: path
+          description: An Event ID
+          required: true
+          schema:
+            type: string
+        - name: offset
+          in: query
+          description:
+            The number of items to skip. Useful for pagination (page number
+            * limit)
+          schema:
+            type: integer
+        - name: limit
+          in: query
+          description: The number of items to fetch
+          schema:
+            type: integer
+        - name: user_id
+          in: query
+          description: The user ID of the user making the request
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/followers_response"
+        "400":
+          description: Bad request
+          content: {}
+        "500":
+          description: Server error
+          content: {}
   /events/unclaimed_id:
     get:
       tags:
@@ -11522,6 +11792,25 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/event"
+    event_follow_state:
+      required:
+        - is_followed
+        - follower_count
+      type: object
+      properties:
+        is_followed:
+          type: boolean
+          description:
+            Whether the authenticated / requested user is currently
+            subscribed to this event.
+        follower_count:
+          type: integer
+          description: Total number of users following this event.
+    event_follow_state_response:
+      type: object
+      properties:
+        data:
+          $ref: "#/components/schemas/event_follow_state"
     version_metadata:
       required:
         - service


### PR DESCRIPTION
These handlers existed on the Go side already (v1EventFollowState, postV1EventFollow, deleteV1EventFollow, v1EventComments, plus the new v1EventsFollowers) but never got entries in the hand-maintained swagger-v1.yaml. As a result the SDK generator — which reads that YAML — produced no TS types for them, and every consumer had to either hand-stub the types or route through the entity-manager escape hatch.

Adds paths for:
- GET  /events/{eventId}/comments      → track_comments_response
- POST /events/{eventId}/follow        → write_response (auth required)
- DELETE /events/{eventId}/follow      → write_response (auth required)
- GET  /events/{eventId}/follow_state  → event_follow_state_response
- GET  /events/{eventId}/follow-state  → event_follow_state_response
                                         (hyphenated alias)
- GET  /events/{eventId}/followers     → followers_response

Adds event_follow_state / event_follow_state_response schemas. Other endpoints reuse existing track_comments_response / write_response / followers_response shapes since the response envelopes are identical.