### PR TITLE
Use user_challenges.amount in claim, not static reward config

### DIFF
--- a/api/dbv1/get_undisbursed_challenges.sql.go
+++ b/api/dbv1/get_undisbursed_challenges.sql.go
@@ -16,7 +16,8 @@ SELECT
     users.handle,
     users.wallet,
     user_challenges.challenge_id,
-    user_challenges.specifier
+    user_challenges.specifier,
+    user_challenges.amount
 FROM user_challenges
 JOIN users ON users.user_id = user_challenges.user_id
 LEFT JOIN challenge_disbursements
@@ -41,6 +42,7 @@ type GetUndisbursedChallengesRow struct {
 	Wallet      pgtype.Text `json:"wallet"`
 	ChallengeID string      `json:"challenge_id"`
 	Specifier   string      `json:"specifier"`
+	Amount      int32       `json:"amount"`
 }
 
 func (q *Queries) GetUndisbursedChallenges(ctx context.Context, arg GetUndisbursedChallengesParams) ([]GetUndisbursedChallengesRow, error) {
@@ -57,6 +59,7 @@ func (q *Queries) GetUndisbursedChallenges(ctx context.Context, arg GetUndisburs
 			&i.Wallet,
 			&i.ChallengeID,
 			&i.Specifier,
+			&i.Amount,
 		); err != nil {
 			return nil, err
 		}

--- a/api/dbv1/queries/get_undisbursed_challenges.sql
+++ b/api/dbv1/queries/get_undisbursed_challenges.sql
@@ -3,7 +3,8 @@ SELECT
     users.handle,
     users.wallet,
     user_challenges.challenge_id,
-    user_challenges.specifier
+    user_challenges.specifier,
+    user_challenges.amount
 FROM user_challenges
 JOIN users ON users.user_id = user_challenges.user_id
 LEFT JOIN challenge_disbursements

--- a/api/v1_claim_rewards.go
+++ b/api/v1_claim_rewards.go
@@ -801,19 +801,25 @@ func (app *ApiServer) v1ClaimRewards(c *fiber.Ctx) error {
 				Specifier:   row.Specifier,
 			}
 
-			reward, err := getReward(row.ChallengeID, app.rewardAttester.Rewards)
+			_, err := getReward(row.ChallengeID, app.rewardAttester.Rewards)
 			if err != nil {
 				results[i].Error = err.Error()
 				g.Done()
 				return
 			}
 
-			results[i].Amount = reward.Amount
+			// Use the per-challenge amount from user_challenges (set when the
+			// challenge was dispatched), not the static config reward.Amount.
+			// Trending tt/tut challenges pay rank-dependent amounts (e.g. 1000
+			// for ranks 1-5 and 100 for ranks 6-10) that the static reward
+			// config can't represent.
+			amount := uint64(row.Amount)
+			results[i].Amount = amount
 
 			rewardClaim := RewardClaim{
 				RewardClaim: rewards.RewardClaim{
 					RewardID:            row.ChallengeID,
-					Amount:              reward.Amount,
+					Amount:              amount,
 					Specifier:           row.Specifier,
 					RecipientEthAddress: row.Wallet.String,
 					ClaimAuthority:      antiAbuseOracle.DelegateWallet,


### PR DESCRIPTION
## Summary

The `/v1/rewards/claim` handler ignores `user_challenges.amount` and falls back to the static reward config (always 1000 for `tt`/`tut`). This breaks rank-dependent payouts introduced for the top-10 trending change — ranks 6-10 are written with `amount=100` but the API was claiming 1000 for everyone.

Visible symptoms during today's `/disburse 2026-05-01` from the trending-challenge-rewards bot:
- 9 of 10 `tt` and 0 of 10 `tut` claims succeeded
- Ranks 6-10 that succeeded were paid 1000 AUDIO instead of 100 (10x overpay)
- The ones that failed hit on-chain `IncorrectOwner` (custom code 0) on the EvaluateAttestation step — likely amount-mismatch state on verified_messages PDAs from earlier attempts

## Changes

- `api/dbv1/queries/get_undisbursed_challenges.sql` — select `user_challenges.amount`
- `api/dbv1/get_undisbursed_challenges.sql.go` — `GetUndisbursedChallengesRow.Amount int32`
- `api/v1_claim_rewards.go` — use `row.Amount` for both `results[i].Amount` and `RewardClaim.Amount`. Still call `getReward()` to validate the challenge id is configured, but discard the static amount.

## Test plan

- [x] `go build ./...` clean
- [ ] Local: claim a `tt:<week>:6` (rank 6, amount=100 in user_challenges) and verify the on-chain transfer is 100 AUDIO, not 1000
- [ ] Stage: full `/disburse` cycle for a recent week with 10 tt + 10 tut, confirm ranks 1-5 get 1000 and 6-10 get 100
- [ ] Prod: re-run `/disburse 2026-05-01` from pedalboard after deploy, confirm the 11 currently-failing claims now succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)