### PR TITLE
Document allowed_api_keys in track upload/update request bodies

### DIFF
--- a/api/swagger/swagger-v1.yaml
+++ b/api/swagger/swagger-v1.yaml
@@ -10962,6 +10962,12 @@ components:
           items:
             type: string
           description: Wallet addresses that can sign to authorize stream access (programmable distribution). When empty or omitted, the track is public and validator/creator nodes can serve it.
+        allowed_api_keys:
+          type: array
+          nullable: true
+          items:
+            type: string
+          description: API keys allowed to stream this track
         stream_conditions:
           nullable: true
           allOf:
@@ -11191,6 +11197,12 @@ components:
           items:
             type: string
           description: Wallet addresses that can sign to authorize stream access (programmable distribution). When empty or omitted, the track is public and validator/creator nodes can serve it.
+        allowed_api_keys:
+          type: array
+          nullable: true
+          items:
+            type: string
+          description: API keys allowed to stream this track
         stream_conditions:
           nullable: true
           allOf:


### PR DESCRIPTION
## Summary

The track response schema already documents `allowed_api_keys`, but the `create_track_request_body` and `update_track_request_body` schemas in the OpenAPI spec did not include it. The Go request structs (`UploadTrackRequest`, `UpdateTrackRequest` in `api/v1_track.go`) already declare the field with the `allowed_api_keys` JSON tag, and the PUT/POST handlers already forward the full request body into the entity-manager metadata blob — only the OpenAPI documentation was incomplete.

This adds the field to both request body schemas. Once merged and synced, it'll also fix the rendered SDK / API reference on the docs site.

## Test plan

- [ ] Confirm swagger.yaml still parses (e.g. `swagger validate` or rendering in the docs site)
- [ ] Verify the docs site picks up the new field on the next openapi sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)