### PR TITLE
Add /v1/oauth/me legacy alias for @audius/sdk <= 14

### DIFF
--- a/api/server.go
+++ b/api/server.go
@@ -584,6 +584,9 @@ func NewApiServer(config config.Config) *ApiServer {
 		g.Post("/oauth/token", app.v1OAuthToken)
 		g.Post("/oauth/revoke", app.v1OAuthRevoke)
 		g.Get("/me", app.requireAuthMiddleware, app.v1Me)
+		// Legacy alias for @audius/sdk <= 14, which calls /v1/oauth/me and
+		// expects the DecodedUserToken shape (userId, name, handle, ...).
+		g.Get("/oauth/me", app.requireAuthMiddleware, app.v1OAuthMe)
 
 		// Rewards
 		g.Post("/rewards/claim", app.v1ClaimRewards)

--- a/api/v1_me.go
+++ b/api/v1_me.go
@@ -1,6 +1,8 @@
 package api
 
 import (
+	"time"
+
 	"api.audius.co/api/dbv1"
 	"github.com/gofiber/fiber/v2"
 	"go.uber.org/zap"
@@ -33,4 +35,46 @@ func (app *ApiServer) v1Me(c *fiber.Ctx) error {
 	}
 
 	return c.JSON(fiber.Map{"data": users[0]})
+}
+
+// v1OAuthMe handles GET /v1/oauth/me
+// Legacy endpoint that returns the user profile in the DecodedUserToken shape
+// expected by @audius/sdk versions <= 14. Newer SDKs use /v1/me which returns
+// the standard { data: User } envelope.
+func (app *ApiServer) v1OAuthMe(c *fiber.Ctx) error {
+	userId := app.getMyId(c)
+	if userId == 0 {
+		wallet := app.getAuthedWallet(c)
+		id, err := app.getUserIDFromWallet(c.Context(), wallet)
+		if err != nil {
+			return fiber.NewError(fiber.StatusUnauthorized, "Could not resolve authenticated user")
+		}
+		userId = int32(id)
+	}
+
+	users, err := app.queries.Users(c.Context(), dbv1.GetUsersParams{
+		Ids:  []int32{userId},
+		MyID: userId,
+	})
+	if err != nil {
+		app.logger.Error("Failed to query user for /oauth/me", zap.Error(err))
+		return fiber.NewError(fiber.StatusInternalServerError, "Failed to get user info")
+	}
+	if len(users) == 0 {
+		return fiber.NewError(fiber.StatusNotFound, "User not found")
+	}
+
+	user := users[0]
+	response := fiber.Map{
+		"userId":   user.ID,
+		"name":     user.Name.String,
+		"handle":   user.Handle.String,
+		"verified": user.IsVerified,
+		"sub":      user.ID,
+		"iat":      time.Now().Unix(),
+	}
+	if user.ProfilePicture != nil {
+		response["profilePicture"] = user.ProfilePicture
+	}
+	return c.JSON(response)
 }


### PR DESCRIPTION
## Summary

- Restores `GET /v1/oauth/me` as a legacy alias that returns the flat `DecodedUserToken` shape expected by `@audius/sdk` versions <= 14
- The endpoint was moved to `/v1/me` and reshaped to `{ data: User }` in 3c800aa / d65f2a8, which broke deployed v14 clients still calling `/v1/oauth/me` after the OAuth token exchange (e.g. the production crate.is bundle, which 404s on profile fetch and surfaces \"Failed to fetch user profile.\" to the user)
- Shares `v1Me`'s auth resolution but formats the response in the pre-3c800aa shape so older SDKs deserialize it correctly. New code should continue to use `/v1/me`

## Test plan

- [ ] `go build ./api/...` succeeds
- [ ] Hit `/v1/oauth/me` with a PKCE access token, confirm response includes `userId`, `handle`, `name`, `verified`, `sub`, `iat`
- [ ] Hit `/v1/me` with the same token, confirm response is unchanged (`{ data: User }`)
- [ ] Verify the production crate.is OAuth flow completes after this is deployed

🤖 Generated with [Claude Code](https://claude.com/claude-code)