### PR TITLE
[Perf] Feed query: LATERAL + OFFSET 0 fence + per-followee cap

### DIFF
--- a/api/v1_users_feed.go
+++ b/api/v1_users_feed.go
@@ -33,9 +33,20 @@ func (app *ApiServer) v1UsersFeed(c *fiber.Ctx) error {
 		return err
 	}
 
+	// follow_set is MATERIALIZED + each branch is a LATERAL with an OFFSET 0
+	// optimization fence. Without this, Postgres mis-estimates follow_set
+	// cardinality for some users (stale n_distinct stats on
+	// follows.follower_user_id) and flips from a sane nested-loop plan to
+	// "materialize all 2M reposts of the past year, then merge-join,"
+	// turning a sub-second feed into a 9-18 second feed.
+	//
+	// Per-followee LIMIT 100 (50 for playlists) caps the cost when a
+	// followee is very active. The outer query takes only the top-@limit
+	// by created_at, so any reposts/tracks past the per-followee top-100
+	// can never reach the response anyway.
 	sql := `
 	WITH
-	follow_set AS (
+	follow_set AS MATERIALIZED (
 		SELECT followee_user_id AS user_id
 		FROM follows
 		WHERE
@@ -50,27 +61,30 @@ func (app *ApiServer) v1UsersFeed(c *fiber.Ctx) error {
 	),
 	history as (
 
-		-- Track-type reposts. Splitting from playlist-type reposts so each
-		-- branch can use a per-row JOIN against the entity instead of forcing
-		-- the planner to hash every public playlist (~94k rows) just to filter
-		-- a handful of repost rows.
+		-- Track-type reposts.
 		(
 			SELECT
 				'track' as entity_type,
-				repost_item_id as entity_id,
-				min(reposts.created_at) as created_at
-			FROM reposts
-			JOIN follow_set using (user_id)
-			JOIN tracks ON repost_item_id = tracks.track_id
+				r.repost_item_id as entity_id,
+				min(r.created_at) as created_at
+			FROM follow_set fs
+			CROSS JOIN LATERAL (
+				SELECT repost_item_id, created_at
+				FROM reposts
+				WHERE reposts.user_id = fs.user_id
+					AND reposts.repost_type = 'track'
+					AND reposts.created_at < @before
+					AND reposts.created_at >= @before - INTERVAL '1 YEAR'
+					AND reposts.is_delete = false
+				ORDER BY created_at DESC
+				LIMIT 100
+				OFFSET 0
+			) r
+			JOIN tracks ON r.repost_item_id = tracks.track_id
 				AND tracks.is_delete = false
 				AND tracks.is_unlisted = false
 				AND tracks.is_available = true
-			WHERE
-				@filter in ('all', 'repost')
-				AND reposts.repost_type = 'track'
-				AND reposts.created_at < @before
-				AND reposts.created_at >= @before - INTERVAL '1 YEAR'
-				AND reposts.is_delete = false
+			WHERE @filter in ('all', 'repost')
 			GROUP BY entity_id
 		)
 
@@ -79,20 +93,26 @@ func (app *ApiServer) v1UsersFeed(c *fiber.Ctx) error {
 		-- Playlist/album-type reposts.
 		(
 			SELECT
-				reposts.repost_type::text as entity_type,
-				repost_item_id as entity_id,
-				min(reposts.created_at) as created_at
-			FROM reposts
-			JOIN follow_set using (user_id)
-			JOIN playlists ON repost_item_id = playlists.playlist_id
+				r.repost_type::text as entity_type,
+				r.repost_item_id as entity_id,
+				min(r.created_at) as created_at
+			FROM follow_set fs
+			CROSS JOIN LATERAL (
+				SELECT repost_type, repost_item_id, created_at
+				FROM reposts
+				WHERE reposts.user_id = fs.user_id
+					AND reposts.repost_type <> 'track'
+					AND reposts.created_at < @before
+					AND reposts.created_at >= @before - INTERVAL '1 YEAR'
+					AND reposts.is_delete = false
+				ORDER BY created_at DESC
+				LIMIT 100
+				OFFSET 0
+			) r
+			JOIN playlists ON r.repost_item_id = playlists.playlist_id
 				AND playlists.is_delete = false
 				AND playlists.is_private = false
-			WHERE
-				@filter in ('all', 'repost')
-				AND reposts.repost_type <> 'track'
-				AND reposts.created_at < @before
-				AND reposts.created_at >= @before - INTERVAL '1 YEAR'
-				AND reposts.is_delete = false
+			WHERE @filter in ('all', 'repost')
 			GROUP BY entity_type, entity_id
 		)
 
@@ -101,19 +121,26 @@ func (app *ApiServer) v1UsersFeed(c *fiber.Ctx) error {
 		(
 			SELECT
 				'track' as entity_type,
-				track_id as entity_id,
-				created_at
-			from tracks
-			join follow_set on owner_id = user_id
-			where @filter in ('all', 'original')
-				AND created_at < @before
-				AND created_at >= @before::timestamp - INTERVAL '1 YEAR'
-				AND is_unlisted = false
-				AND is_delete = false
-				AND stem_of is null
-				AND (access_authorities IS NULL
-				  OR (COALESCE(@authed_wallet, '') <> ''
-				      AND EXISTS (SELECT 1 FROM unnest(access_authorities) aa WHERE lower(aa) = lower(@authed_wallet))))
+				t.track_id as entity_id,
+				t.created_at
+			FROM follow_set fs
+			CROSS JOIN LATERAL (
+				SELECT track_id, created_at
+				FROM tracks
+				WHERE owner_id = fs.user_id
+					AND created_at < @before
+					AND created_at >= @before::timestamp - INTERVAL '1 YEAR'
+					AND is_unlisted = false
+					AND is_delete = false
+					AND stem_of IS NULL
+					AND (access_authorities IS NULL
+					  OR (COALESCE(@authed_wallet, '') <> ''
+					      AND EXISTS (SELECT 1 FROM unnest(access_authorities) aa WHERE lower(aa) = lower(@authed_wallet))))
+				ORDER BY created_at DESC
+				LIMIT 100
+				OFFSET 0
+			) t
+			WHERE @filter in ('all', 'original')
 		)
 
 		UNION ALL
@@ -121,15 +148,22 @@ func (app *ApiServer) v1UsersFeed(c *fiber.Ctx) error {
 		(
 			SELECT
 				'playlist' as entity_type,
-				playlist_id as entity_id,
-				created_at
-			from playlists
-			join follow_set on playlist_owner_id = user_id
-			where @filter in ('all', 'original')
-				AND created_at < @before
-				AND created_at >= @before - INTERVAL '1 YEAR'
-				AND is_delete = false
-				AND is_private = false
+				p.playlist_id as entity_id,
+				p.created_at
+			FROM follow_set fs
+			CROSS JOIN LATERAL (
+				SELECT playlist_id, created_at
+				FROM playlists
+				WHERE playlist_owner_id = fs.user_id
+					AND created_at < @before
+					AND created_at >= @before - INTERVAL '1 YEAR'
+					AND is_delete = false
+					AND is_private = false
+				ORDER BY created_at DESC
+				LIMIT 50
+				OFFSET 0
+			) p
+			WHERE @filter in ('all', 'original')
 		)
 
 	)


### PR DESCRIPTION
## Summary

Fix the planner-cliff in `/v1/users/:userId/feed` that makes the same query take 125 ms for one user and 9-18 s for another with nearly identical follow counts.

Three changes pin the planner to nested-loop semantics:

1. `follow_set` CTE → `MATERIALIZED` (row count fixed for downstream planning).
2. Each UNION branch uses `CROSS JOIN LATERAL` with an `OFFSET 0` optimization fence inside the lateral subquery — prevents Postgres from flattening the lateral back into a merge-join.
3. Per-followee `LIMIT 100` (50 for owned playlists) caps cost for users whose followees are very active. The outer query takes only the top-`@limit` by `created_at`, so older entries past the per-followee top-100 can never reach the response.

## Why

`/v1/users/:userId/feed` is the worst signed-in endpoint by p95 in Axiom. Per the post-merge histogram (13 hours, 5,831 calls), 60 % of requests took >2 s, 23 % took >5 s, and 137 took >10 s.

EXPLAIN on prod replica showed the smoking gun — three users with similar follow counts produce completely different plans:

| User | follows | Plan | Time |
|---|---|---|---|
| 20 (Phuture) | 1752 | nested-loop | 125 ms |
| 222 | 1820 | nested-loop, lots of data | 4.5 s |
| 755516 | 1816 | **merge join, materialize all 2M reposts of last year + hash-join 1.4M tracks** | **9-18 s** |

`follow_set` is estimated at 17,290 rows but actually returns 1,816. That bad cardinality flips the join strategy.

## Impact

End-to-end on local server pointed at prod replica:

| User | Before this PR | After |
|---|---|---|
| 20 (1752 follows) | 500-750 ms | **280-300 ms** |
| 222 (1820 follows) | ~4.5 s | **1.3-1.5 s** (3×) |
| 755516 (1816 follows) | 9-18 s | **640-700 ms** (~20×) |

EXPLAIN-only DB time on the same users (warm cache):

| User | Before | After |
|---|---|---|
| 20 | 113 ms | 105 ms |
| 222 | 4.4 s | 1.5 s |
| 755516 | 9-18 s | 700 ms |

## Risk

- **Per-followee LIMIT 100 trims the input set.** A followee who reposts >100 things in the past year contributes only their top-100 most recent. The outer query orders by `created_at DESC LIMIT @limit` (max 100), so older reposts past the per-followee top-100 *cannot* reach the rendered response. Equivalent for owned tracks (LIMIT 100) and owned playlists (LIMIT 50) — virtually no artist publishes more than that per year.
- `MATERIALIZED` and `OFFSET 0` are planner directives, not logic changes. The shape of `history` and the outer aggregation/sort/limit are unchanged.
- Existing `TestUsersFeed` covers the four entity branches plus the no-followees empty case. Full `./api/...` suite is green.

## Test plan

- [x] `go test -count=1 ./api/...` (full suite, all green)
- [x] EXPLAIN ANALYZE on prod read replica across four users (1545-1820 follows) confirms ~3-25× speedup on the slow cohort with no regression on the lucky cohort
- [x] Local server end-to-end timings confirm the same shape as the EXPLAIN data

🤖 Generated with [Claude Code](https://claude.com/claude-code)