### PR TITLE
[Fix] Add related field to notifications_response swagger spec

### DIFF
--- a/api/swagger/swagger-v1.yaml
+++ b/api/swagger/swagger-v1.yaml
@@ -15212,6 +15212,8 @@ components:
           $ref: "#/components/schemas/version_metadata"
         data:
           $ref: "#/components/schemas/notifications"
+        related:
+          $ref: "#/components/schemas/related"
     connected_wallets_response:
       type: object
       properties:


### PR DESCRIPTION
## Summary
- [PR #799](https://github.com/AudiusProject/api/pull/799) added a `related` block (`{ users, tracks, playlists }`) to the `/v1/notifications` response in Go but didn't update the swagger spec to match.
- Without this, generated SDK clients (e.g. `@audius/sdk`) don't see the field and consumers can't read it in a type-safe way.
- One-line addition — `$ref`s the existing `related` schema (already defined at line 13146 for other endpoints).

## Test plan
- [x] Spec lints / parses (single property addition under existing schema)
- [ ] Regenerating SDK clients picks up `related?: Related` on `NotificationsResponse` (verified locally against the `@audius/sdk` typescript-fetch generator)

🤖 Generated with [Claude Code](https://claude.com/claude-code)