### PR TITLE
chore(rewards): authorize new prod wallet for reward code creation

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -216,7 +216,7 @@ func init() {
 		Cfg.AudiusdChainID = core_config.ProdAcdcChainID
 		Cfg.AudiusdEntityManagerAddress = core_config.ProdAcdcAddress
 		Cfg.AudiusAppUrl = "https://audius.co"
-		Cfg.RewardCodeAuthorizedKeys = []string{"4oGhuh6MkypUTnwUzKbtnUwFzjfaMWAgKYudchPfbYu8", "Du1sGwqC5yJFeoKJ73m3DrFLaRnc7rHM7g1z3Xe8jy8d"}
+		Cfg.RewardCodeAuthorizedKeys = []string{"4oGhuh6MkypUTnwUzKbtnUwFzjfaMWAgKYudchPfbYu8", "Du1sGwqC5yJFeoKJ73m3DrFLaRnc7rHM7g1z3Xe8jy8d", "4mzunYiiFSRGGc5iS3SVQQNdek6JiCyvkFALwoWu2xhP"}
 		Cfg.VerifierAddress = "0xbeef8E42e8B5964fDD2b7ca8efA0d9aef38AA996"
 		Cfg.ArtistCoinRewardsStaticSenders = []Node{
 			{


### PR DESCRIPTION
## Summary

- Adds `4mzunYiiFSRGGc5iS3SVQQNdek6JiCyvkFALwoWu2xhP` to `RewardCodeAuthorizedKeys` in the prod config so this wallet can sign `POST /v1/rewards/code` via the gift-rewards admin tool.
- Pairs with the matching frontend allowlist update in `AudiusProject/gift-rewards`.

## Test plan

- [ ] After deploy, the new wallet can successfully create a reward code via the gift-rewards UI (returns 201 with a code).
- [ ] Existing wallets continue to work (no regression).