### PR TITLE
perf(contests): partial index for shadowban CTE on aggregate_user.score

### DIFF
--- a/ddl/migrations/0198_aggregate_user_score_negative_idx.sql
+++ b/ddl/migrations/0198_aggregate_user_score_negative_idx.sql
@@ -1,0 +1,29 @@
+-- Partial index covering only shadowbanned users (aggregate_user.score < 0).
+--
+-- Several handlers — v1_event_comments, v1_events_remix_contests,
+-- v1_fan_club_feed, v1_track_comments, v1_track_comment_count — materialize
+-- a `low_abuse_score` CTE via:
+--
+--     SELECT user_id FROM aggregate_user WHERE score < 0
+--
+-- Without a covering index this is a sequential scan over the entire
+-- aggregate_user table (one row per user, in the millions). On cold cache,
+-- /v1/events/remix-contests?status=all measured ~22s end-to-end, dominated
+-- by that seq scan; on warm cache the same call returns in ~100ms.
+--
+-- aggregate_user.score < 0 is a very small fraction of users (shadowbanned
+-- accounts only), so a partial index is dramatically cheaper than a full
+-- btree on `score`.
+--
+-- Size budget: thousands of matching rows × ~12 bytes ≈ tens of KB.
+--
+-- NOTE: intentionally NOT wrapped in BEGIN/COMMIT so CREATE INDEX
+-- CONCURRENTLY can run without holding ACCESS EXCLUSIVE on aggregate_user.
+-- IF NOT EXISTS keeps the migration idempotent.
+
+create index concurrently if not exists idx_aggregate_user_score_negative
+    on aggregate_user (user_id)
+    where score < 0;
+
+comment on index idx_aggregate_user_score_negative is
+    'Partial index for the shadowban-author CTEs (score < 0); avoids a full table scan of aggregate_user.';


### PR DESCRIPTION
## Problem

`/v1/events/remix-contests?limit=12&offset=0&status=all` is timing out / hanging the contests page in production.

Measured from my machine against `api.audius.co` (presumably hitting whatever replica is cold per request):

| Call                              | First (cold)   | Subsequent (warm) |
|-----------------------------------|----------------|--------------------|
| `status=all`                      | **24.7s**      | 0.12s              |
| `status=ended`                    | **24.0s**      | 0.12s              |
| `status=active`                   | 1.96s          | 0.08s              |

The contests page lands cold and hangs for ~22s.

## Root cause

The shadowban filter PR (#803, [api/v1_events_remix_contests.go:46-47](api/v1_events_remix_contests.go#L46-L47)) added:

```sql
WITH
  low_abuse_score AS (
    SELECT user_id FROM aggregate_user WHERE score < 0
  )
SELECT ...
WHERE e.user_id NOT IN (SELECT user_id FROM low_abuse_score)
```

`aggregate_user` has one row per user (millions of rows). There is no index covering `score` — only `idx_aggregate_user_follower_count (user_id, follower_count)` exists ([ddl/migrations/...0126](ddl/migrations/)). So the CTE runs a full sequential scan of `aggregate_user` on every cold call, then the pages stay in `shared_buffers` and warm calls are fast.

The same CTE is used in `v1_event_comments`, `v1_fan_club_feed`, `v1_track_comments`, `v1_track_comment_count` — all pay the same cost on cold cache. Contests is hit hardest because `status=all`/`status=ended` keep most events past the WHERE filter and the sort then forces a per-row LATERAL `entry_count` count, but the seq scan is the dominant fixed cost.

## Fix

Add a partial index on the `score < 0` predicate so the planner can resolve the shadowban set with an index scan instead of touching the heap for non-shadowbanned rows:

```sql
create index concurrently if not exists idx_aggregate_user_score_negative
    on aggregate_user (user_id)
    where score < 0;
```

Only a small fraction of users have `score < 0` (shadowbanned only), so the partial form is dramatically smaller than a full btree on `score` — size budget is tens of KB.

`CREATE INDEX CONCURRENTLY` is used so the migration does not hold `ACCESS EXCLUSIVE` on `aggregate_user`. Following the [0197_playlists_albums_partial_idx.sql](ddl/migrations/0197_playlists_albums_partial_idx.sql) pattern: not wrapped in `BEGIN/COMMIT`, and idempotent via `IF NOT EXISTS`.

## Test plan

- [ ] Migration applies cleanly on staging
- [ ] `EXPLAIN ANALYZE` on `SELECT user_id FROM aggregate_user WHERE score < 0` shows `Index Only Scan using idx_aggregate_user_score_negative` instead of `Seq Scan`
- [ ] Time `/v1/events/remix-contests?status=all` cold on staging — expect sub-second
- [ ] Hit `/v1/events/remix-contests`, `/v1/event-comments/...`, `/v1/fan-club-feed/...` and confirm shadowbanned authors still excluded
- [ ] Production rollout: keep an eye on `aggregate_user` write throughput; this index only updates on rows that flip `score` across zero, which is rare

🤖 Generated with [Claude Code](https://claude.com/claude-code)