### PR TITLE
Backfill sol_purchases from usdc_purchases

### DIFF
--- a/api/dbv1/models.go
+++ b/api/dbv1/models.go
@@ -2110,11 +2110,11 @@ type SolPurchase struct {
 	// Purchase transactions include the blocknumber that the content was most recently updated in order to ensure that the relevant pricing information has been indexed before evaluating whether the purchase is valid.
 	ValidAfterBlocknumber int64 `json:"valid_after_blocknumber"`
 	// A purchase is valid if it meets the pricing information set by the artist. If the pricing information is not available yet (as indicated by the valid_after_blocknumber), then is_valid will be NULL which indicates a "pending" state.
-	IsValid        pgtype.Bool        `json:"is_valid"`
-	City           pgtype.Text        `json:"city"`
-	Region         pgtype.Text        `json:"region"`
-	Country        pgtype.Text        `json:"country"`
-	BlockTimestamp pgtype.Timestamptz `json:"block_timestamp"`
+	IsValid   pgtype.Bool `json:"is_valid"`
+	City      pgtype.Text `json:"city"`
+	Region    pgtype.Text `json:"region"`
+	Country   pgtype.Text `json:"country"`
+	CreatedAt *time.Time  `json:"created_at"`
 }
 
 // Queue for retrying failed indexer updates.
@@ -2647,6 +2647,23 @@ type VChallengeDisbursement struct {
 	Slot        int64      `json:"slot"`
 	CreatedAt   *time.Time `json:"created_at"`
 	UserID      int32      `json:"user_id"`
+}
+
+type VUsdcPurchase struct {
+	Signature    string                  `json:"signature"`
+	Slot         int64                   `json:"slot"`
+	BuyerUserID  int32                   `json:"buyer_user_id"`
+	SellerUserID interface{}             `json:"seller_user_id"`
+	Amount       int64                   `json:"amount"`
+	ContentType  UsdcPurchaseContentType `json:"content_type"`
+	ContentID    int32                   `json:"content_id"`
+	CreatedAt    *time.Time              `json:"created_at"`
+	ExtraAmount  interface{}             `json:"extra_amount"`
+	Access       UsdcPurchaseAccessType  `json:"access"`
+	City         pgtype.Text             `json:"city"`
+	Region       pgtype.Text             `json:"region"`
+	Country      pgtype.Text             `json:"country"`
+	Splits       interface{}             `json:"splits"`
 }
 
 type VolumeLeaderExclusion struct {

--- a/ddl/functions/handle_usdc_purchase.sql
+++ b/ddl/functions/handle_usdc_purchase.sql
@@ -56,3 +56,91 @@ do $$ begin
 exception
   when others then null;
 end $$;
+
+
+-- Mirror of handle_usdc_purchase for the new indexer's table. Resolves
+-- seller_user_id from current content ownership (same CASE used in
+-- v_usdc_purchases). Notification shape and group_id format match the legacy
+-- trigger so the two can dual-fire during cutover (second insert is a no-op
+-- via on conflict). extra_amount and vendor are emitted as null in the new
+-- payload because they aren't denormalized onto sol_purchases.
+create or replace function handle_sol_purchase() returns trigger as $$
+declare
+  resolved_seller_user_id integer;
+begin
+  if new.is_valid is not true then
+    return null;
+  end if;
+
+  if new.content_type = 'track' then
+    select owner_id into resolved_seller_user_id
+      from tracks
+     where track_id = new.content_id
+       and is_current = true
+     limit 1;
+  else
+    select playlist_owner_id into resolved_seller_user_id
+      from playlists
+     where playlist_id = new.content_id
+       and is_current = true
+     limit 1;
+  end if;
+
+  if resolved_seller_user_id is null then
+    return null;
+  end if;
+
+  insert into notification
+        (slot, user_ids, timestamp, type, specifier, group_id, data)
+      values
+        (
+          new.slot,
+          ARRAY [resolved_seller_user_id],
+          new.created_at,
+          'usdc_purchase_seller',
+          new.buyer_user_id,
+          'usdc_purchase_seller:' || 'seller_user_id:' || resolved_seller_user_id || ':buyer_user_id:' || new.buyer_user_id || ':content_id:' || new.content_id || ':content_type:' || new.content_type,
+          json_build_object(
+              'content_type',   new.content_type,
+              'buyer_user_id',  new.buyer_user_id,
+              'seller_user_id', resolved_seller_user_id,
+              'amount',         new.amount,
+              'extra_amount',   null,
+              'content_id',     new.content_id,
+              'vendor',         null
+          )
+        ),
+        (
+          new.slot,
+          ARRAY [new.buyer_user_id],
+          new.created_at,
+          'usdc_purchase_buyer',
+          new.buyer_user_id,
+          'usdc_purchase_buyer:' || 'seller_user_id:' || resolved_seller_user_id || ':buyer_user_id:' || new.buyer_user_id || ':content_id:' || new.content_id || ':content_type:' || new.content_type,
+          json_build_object(
+              'content_type',   new.content_type,
+              'buyer_user_id',  new.buyer_user_id,
+              'seller_user_id', resolved_seller_user_id,
+              'amount',         new.amount,
+              'extra_amount',   null,
+              'content_id',     new.content_id,
+              'vendor',         null
+          )
+        )
+      on conflict do nothing;
+
+  return null;
+  exception
+    when others then
+        raise warning 'An error occurred in %: %', tg_name, sqlerrm;
+        return null;
+end;
+$$ language plpgsql;
+
+do $$ begin
+  create trigger on_sol_purchase
+  after insert on sol_purchases
+  for each row execute procedure handle_sol_purchase();
+exception
+  when others then null;
+end $$;

--- a/ddl/migrations/0199_backfill_sol_purchases.sql
+++ b/ddl/migrations/0199_backfill_sol_purchases.sql
@@ -1,0 +1,73 @@
+BEGIN;
+SET LOCAL statement_timeout = 0;
+
+-- Parity with the legacy usdc_purchases.created_at column. The Go indexer
+-- writes new rows close to on-chain time, so DEFAULT NOW() is acceptable; the
+-- backfill below corrects rows that came from the legacy table.
+ALTER TABLE sol_purchases
+    ADD COLUMN IF NOT EXISTS created_at TIMESTAMP DEFAULT NOW();
+
+-- Backfill historical purchases that predate the Go indexer. from_account is
+-- resolved via the buyer's USDC user_bank so the NOT NULL column has a real
+-- value. Falls back to '' for buyers whose bank account is unknown — the
+-- sol_purchases_from_account_idx tolerates empty strings.
+INSERT INTO sol_purchases (
+    signature, instruction_index, amount, slot,
+    from_account, content_type, content_id, buyer_user_id,
+    access_type, valid_after_blocknumber, is_valid,
+    city, region, country, created_at
+)
+SELECT
+    up.signature,
+    0 AS instruction_index,
+    up.amount,
+    up.slot,
+    COALESCE(uuba.bank_account, '') AS from_account,
+    up.content_type::text,
+    up.content_id,
+    up.buyer_user_id,
+    up.access::text,
+    0 AS valid_after_blocknumber,
+    TRUE AS is_valid,
+    up.city, up.region, up.country,
+    up.created_at
+FROM usdc_purchases up
+LEFT JOIN users u
+    ON u.user_id = up.buyer_user_id AND u.is_current = TRUE
+LEFT JOIN usdc_user_bank_accounts uuba
+    ON uuba.ethereum_address = u.wallet
+ON CONFLICT (signature, instruction_index) DO NOTHING;
+
+-- Correct created_at for rows the Go indexer wrote before this migration ran:
+-- those rows got NOW() from the column default, but the legacy table has the
+-- real on-chain time. Only updates rows whose existing created_at is later
+-- than the legacy value, so it leaves accurate Go-indexer writes alone.
+UPDATE sol_purchases sp
+   SET created_at = up.created_at
+  FROM usdc_purchases up
+ WHERE up.signature = sp.signature
+   AND up.created_at < sp.created_at;
+
+-- Explode legacy usdc_purchases.splits JSONB into sol_payments rows. The
+-- element shape is {payout_wallet, amount, percentage, user_id, eth_wallet}
+-- per add_wallet_info_to_splits() in
+-- discovery-provider/src/queries/get_extended_purchase_gate.py.
+INSERT INTO sol_payments (signature, instruction_index, route_index, to_account, amount, slot)
+SELECT
+    up.signature,
+    0 AS instruction_index,
+    (ord - 1)::int AS route_index,
+    elem->>'payout_wallet' AS to_account,
+    (elem->>'amount')::bigint AS amount,
+    up.slot
+FROM usdc_purchases up
+CROSS JOIN LATERAL jsonb_array_elements(up.splits) WITH ORDINALITY arr(elem, ord)
+WHERE elem->>'payout_wallet' IS NOT NULL
+ON CONFLICT (signature, instruction_index, route_index) DO NOTHING;
+
+-- Default sort across the purchases / sales / library routes is by created_at;
+-- restore the index parity the legacy table had via idx_usdc_purchases_created_at.
+CREATE INDEX IF NOT EXISTS sol_purchases_created_at_idx
+    ON sol_purchases (created_at);
+
+COMMIT;

--- a/ddl/views/v_usdc_purchases.sql
+++ b/ddl/views/v_usdc_purchases.sql
@@ -1,0 +1,79 @@
+DROP VIEW IF EXISTS v_usdc_purchases;
+CREATE VIEW v_usdc_purchases AS
+SELECT
+    sp.signature,
+    sp.slot,
+    sp.buyer_user_id,
+    CASE sp.content_type
+      WHEN 'track'    THEN t.owner_id
+      WHEN 'album'    THEN p.playlist_owner_id
+      WHEN 'playlist' THEN p.playlist_owner_id
+    END AS seller_user_id,
+    sp.amount,
+    sp.content_type::usdc_purchase_content_type AS content_type,
+    sp.content_id,
+    sp.created_at,
+    GREATEST(
+        sp.amount - COALESCE(
+            CASE sp.content_type
+              WHEN 'track' THEN (
+                SELECT tph.total_price_cents * 10000
+                  FROM track_price_history tph
+                 WHERE tph.track_id = sp.content_id
+                   AND tph.block_timestamp <= sp.created_at
+                 ORDER BY tph.block_timestamp DESC
+                 LIMIT 1
+              )
+              ELSE (
+                SELECT aph.total_price_cents * 10000
+                  FROM album_price_history aph
+                 WHERE aph.playlist_id = sp.content_id
+                   AND aph.block_timestamp <= sp.created_at
+                 ORDER BY aph.block_timestamp DESC
+                 LIMIT 1
+              )
+            END,
+            0
+        ),
+        0
+    ) AS extra_amount,
+    sp.access_type::usdc_purchase_access_type AS access,
+    sp.city, sp.region, sp.country,
+    (
+      SELECT COALESCE(
+        jsonb_agg(
+          jsonb_build_object(
+            'user_id',       COALESCE(u_payout.user_id, u_sca.user_id),
+            'payout_wallet', pay.to_account,
+            'amount',        pay.amount,
+            'percentage',    pay.amount * 100.0 / NULLIF(sp.amount, 0)
+          )
+          ORDER BY pay.route_index
+        ),
+        '[]'::jsonb
+      )
+        FROM sol_payments pay
+        LEFT JOIN users u_payout
+          ON u_payout.spl_usdc_payout_wallet = pay.to_account
+         AND u_payout.is_current = TRUE
+        LEFT JOIN sol_claimable_accounts sca
+          ON sca.account = pay.to_account
+         AND sca.mint = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v'
+        LEFT JOIN users u_sca
+          ON u_sca.wallet = sca.ethereum_address
+         AND u_sca.is_current = TRUE
+       WHERE pay.signature = sp.signature
+         AND pay.instruction_index = sp.instruction_index
+    ) AS splits
+FROM sol_purchases sp
+LEFT JOIN tracks t
+  ON sp.content_type = 'track'
+ AND t.track_id = sp.content_id
+ AND t.is_current = TRUE
+LEFT JOIN playlists p
+  ON sp.content_type IN ('album', 'playlist')
+ AND p.playlist_id = sp.content_id
+ AND p.is_current = TRUE
+WHERE sp.is_valid IS TRUE;
+
+COMMENT ON VIEW v_usdc_purchases IS 'Compatibility view exposing sol_purchases + sol_payments in the column shape API routes used to read from usdc_purchases. seller_user_id is the current content owner (not snapshotted at purchase time). extra_amount is amount paid minus base price from price history. vendor is intentionally dropped.';

--- a/sql/01_schema.sql
+++ b/sql/01_schema.sql
@@ -8320,7 +8320,7 @@ CREATE TABLE public.sol_purchases (
     city character varying,
     region character varying,
     country character varying,
-    block_timestamp timestamp with time zone
+    created_at timestamp without time zone DEFAULT now()
 );
 
 
@@ -11957,6 +11957,13 @@ COMMENT ON INDEX public.sol_purchases_from_account_idx IS 'Used for getting purc
 
 
 --
+-- Name: sol_purchases_created_at_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX sol_purchases_created_at_idx ON public.sol_purchases USING btree (created_at);
+
+
+--
 -- Name: sol_purchases_valid_idx; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -12887,6 +12894,89 @@ CREATE VIEW public.v_challenge_disbursements AS
     users.user_id
    FROM (public.sol_reward_disbursements rd
      JOIN public.users ON (((users.wallet = rd.recipient_eth_address) AND (users.is_current = true))));
+
+
+--
+-- Name: v_usdc_purchases; Type: VIEW; Schema: public; Owner: -
+--
+
+CREATE VIEW public.v_usdc_purchases AS
+ SELECT sp.signature,
+    sp.slot,
+    sp.buyer_user_id,
+    CASE sp.content_type
+        WHEN 'track'::text    THEN t.owner_id
+        WHEN 'album'::text    THEN p.playlist_owner_id
+        WHEN 'playlist'::text THEN p.playlist_owner_id
+    END AS seller_user_id,
+    sp.amount,
+    (sp.content_type)::public.usdc_purchase_content_type AS content_type,
+    sp.content_id,
+    sp.created_at,
+    GREATEST(
+        sp.amount - COALESCE(
+            CASE sp.content_type
+                WHEN 'track'::text THEN (
+                    SELECT (tph.total_price_cents * 10000)
+                      FROM public.track_price_history tph
+                     WHERE tph.track_id = sp.content_id
+                       AND tph.block_timestamp <= sp.created_at
+                     ORDER BY tph.block_timestamp DESC
+                     LIMIT 1
+                )
+                ELSE (
+                    SELECT (aph.total_price_cents * 10000)
+                      FROM public.album_price_history aph
+                     WHERE aph.playlist_id = sp.content_id
+                       AND aph.block_timestamp <= sp.created_at
+                     ORDER BY aph.block_timestamp DESC
+                     LIMIT 1
+                )
+            END,
+            0
+        ),
+        0
+    ) AS extra_amount,
+    (sp.access_type)::public.usdc_purchase_access_type AS access,
+    sp.city,
+    sp.region,
+    sp.country,
+    (
+        SELECT COALESCE(
+            jsonb_agg(
+                jsonb_build_object(
+                    'user_id', COALESCE(u_payout.user_id, u_sca.user_id),
+                    'payout_wallet', pay.to_account,
+                    'amount', pay.amount,
+                    'percentage', ((pay.amount * 100.0) / NULLIF(sp.amount, 0))
+                )
+                ORDER BY pay.route_index
+            ),
+            '[]'::jsonb
+        )
+          FROM public.sol_payments pay
+          LEFT JOIN public.users u_payout
+            ON u_payout.spl_usdc_payout_wallet = pay.to_account
+           AND u_payout.is_current = true
+          LEFT JOIN public.sol_claimable_accounts sca
+            ON sca.account = pay.to_account
+           AND sca.mint = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v'::text
+          LEFT JOIN public.users u_sca
+            ON u_sca.wallet = sca.ethereum_address
+           AND u_sca.is_current = true
+         WHERE pay.signature = sp.signature
+           AND pay.instruction_index = sp.instruction_index
+    ) AS splits
+   FROM public.sol_purchases sp
+   LEFT JOIN public.tracks t
+     ON sp.content_type = 'track'::text
+    AND t.track_id = sp.content_id
+    AND t.is_current = true
+   LEFT JOIN public.playlists p
+     ON sp.content_type IN ('album'::text, 'playlist'::text)
+    AND p.playlist_id = sp.content_id
+    AND p.is_current = true
+  WHERE sp.is_valid IS TRUE;
 
 
 --


### PR DESCRIPTION
## Summary

Step 1 of the purchases-domain cutover. This PR populates the new Go-indexer tables with the historical data they're missing today, adds the compatibility view + parallel notification trigger, but **leaves all readers on the legacy `usdc_purchases` table**. The route swap is a separate PR (step 2) that lands after this one is verified on production.

The shape mirrors PR #809 (challenges cutover): bounded migration, view-based read translation, parallel trigger that dedupes via shared `group_id`.

## What's in this PR

**Schema / migration** — `ddl/migrations/0199_backfill_sol_purchases.sql`
- Adds `created_at TIMESTAMP DEFAULT NOW()` to `sol_purchases`. Same gap we hit on `sol_reward_disbursements` in #809.
- Copies historical purchases from `usdc_purchases` into `sol_purchases`. `from_account` is resolved to the buyer's USDC user_bank via `usdc_user_bank_accounts` so the NOT NULL column has a real value.
- Patches `created_at` on rows the Go indexer wrote before this migration (their `created_at` was just `NOW()` from the default; corrects them from the legacy table where the legacy value is older).
- Explodes `usdc_purchases.splits` JSONB into one `sol_payments` row per element. Element shape is `{payout_wallet, amount, percentage, user_id, eth_wallet}` per `add_wallet_info_to_splits()` in the Python source.
- Adds `sol_purchases_created_at_idx` so the route-side default sort by `created_at` doesn't degrade.

**View** — `ddl/views/v_usdc_purchases.sql`
- Exposes `sol_purchases` + `sol_payments` in the legacy column shape so step 2's route swap is mostly a one-token rename.
- `seller_user_id` is derived from current content ownership (`tracks.owner_id` / `playlists.playlist_owner_id`). Note: this is current owner, not snapshotted at purchase time. Legacy was a snapshot — accepting this drift per design discussion.
- `extra_amount` is derived as `amount - base_price` via a correlated subquery against `track_price_history` / `album_price_history` (block_timestamp <= purchase created_at, ORDER BY DESC LIMIT 1).
- `splits` JSON is aggregated over `sol_payments` with user_id resolved via `COALESCE(users.spl_usdc_payout_wallet match, sol_claimable_accounts mint=USDC match)`. Network-cut payments (to the staking bridge wallet) emit `user_id: null`.
- `vendor` is intentionally dropped from the view.
- Filtered to `is_valid IS TRUE` to match the legacy table's semantics (Python only wrote validated purchases).

**Trigger** — `ddl/functions/handle_usdc_purchase.sql`
- Appends a `handle_sol_purchase` function and `on_sol_purchase AFTER INSERT ON sol_purchases` trigger.
- Notification shape and `group_id` format match the legacy trigger byte-for-byte (verified against the existing function body), so during the backfill — where every inserted row fires the new trigger and tries to recreate notifications whose `group_id`s were created by the legacy trigger long ago — `ON CONFLICT DO NOTHING` makes them no-ops.
- `vendor` and `extra_amount` are emitted as `null` in the new payload; downstream consumers must tolerate this.

**Cleanup** — `sql/01_schema.sql`
- Dropped a stale `block_timestamp` column from the `sol_purchases` table definition. No migration creates it and nothing in the repo references it; the dump had drifted from reality.

## What's NOT in this PR

- **Reader changes.** All 14+ Go routes that join `usdc_purchases` (`v1_users_purchases`, `v1_users_sales`, `v1_users_purchasers`, `v1_explore_best_selling`, `v1_users_library_*`, `v1_fan_club_feed`, `comms_blasts`, `dbv1/access.go`, `comms/chat.go`, etc.) are unchanged. Until this PR's backfill is verified in production, swapping readers would risk old purchases disappearing.
- **Python decommission.** `index_payment_router` keeps writing `usdc_purchases` (legacy trigger keeps firing on insert). The new trigger dedupes against it via `group_id`.
- **Go indexer update for `created_at`.** A small follow-up: `solana/indexer/program/payment_router.go` should explicitly write `created_at` so new rows get the on-chain time rather than `NOW()` from the column default. Default is correct-enough until then.
- **Vendor field.** Lost in the view; if anything frontend-side breaks on `vendor: null` notifications we'll need a workaround.

## Test plan

After this lands, before opening the step-2 PR, verify on a prod replica:

- [ ] Row-count parity:
  ```sql
  SELECT (SELECT count(*) FROM usdc_purchases) AS legacy,
         (SELECT count(*) FROM sol_purchases WHERE is_valid IS TRUE) AS new_valid;
  ```
- [ ] Splits parity for a 50-row sample:
  ```sql
  SELECT up.signature,
         jsonb_array_length(up.splits) AS legacy_splits,
         (SELECT count(*) FROM sol_payments WHERE signature = up.signature AND instruction_index = 0) AS new_splits
    FROM usdc_purchases up ORDER BY random() LIMIT 50;
  ```
- [ ] Spot-check `v_usdc_purchases` against `usdc_purchases` for a few signatures: same `buyer_user_id`, same `amount`, comparable `splits[*].user_id` and `payout_wallet`.
- [ ] Confirm trigger dedupe: insert a `sol_purchases` row matching an existing `usdc_purchases` row in dev; assert no new notification row appears.
- [ ] Cloud SQL logs during deploy: no `statement_timeout`, no `pg_type_typname_nsp_index`, no `deadlock detected`.
- [ ] `go test ./api/...` green (no reader changes, no test changes expected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)