### PR TITLE
fix(purchases): expose updated_at on v_usdc_purchases view

### DIFF
--- a/ddl/views/v_usdc_purchases.sql
+++ b/ddl/views/v_usdc_purchases.sql
@@ -13,6 +13,7 @@ SELECT
     sp.content_type::usdc_purchase_content_type AS content_type,
     sp.content_id,
     sp.created_at,
+    sp.created_at AS updated_at,
     GREATEST(
         sp.amount - COALESCE(
             CASE sp.content_type

--- a/sql/01_schema.sql
+++ b/sql/01_schema.sql
@@ -9631,6 +9631,7 @@ CREATE VIEW public.v_usdc_purchases AS
     (sp.content_type)::public.usdc_purchase_content_type AS content_type,
     sp.content_id,
     sp.created_at,
+    sp.created_at AS updated_at,
     GREATEST((sp.amount - COALESCE(
         CASE sp.content_type
             WHEN 'track'::text THEN ( SELECT (tph.total_price_cents * 10000)


### PR DESCRIPTION
## Summary

Hotfix for a regression introduced by #816. \`/v1/users/{id}/purchases\` crashes with:

\`\`\`
ERROR: column purchases_with_content.updated_at does not exist (SQLSTATE 42703)
\`\`\`

\`api/v1_users_purchases.go:123\` selects \`purchases_with_content.updated_at\` through a CTE wrapping \`v_usdc_purchases\`, but the view never exposed \`updated_at\`.

Fix: alias \`sp.created_at\` as \`updated_at\` in the view. The legacy \`usdc_purchases\` table set both columns to \`CURRENT_TIMESTAMP\` at insert and never updated rows, so \`created_at = updated_at\` in practice — the alias keeps the API contract intact.

I had this fix as a follow-up commit on the PR #815 branch (\"Expose updated_at on v_usdc_purchases view\") but it didn't make it into the squash-merge.

## Test plan

- [ ] \`/v1/users/{id}/purchases\` returns 200 again
- [ ] \`/v1/users/{id}/sales\` (which also selects \`updated_at\` in \`v1_users_sales.go:94\`) returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)