### PR TITLE
fix(purchases): default extra_amount to 0 when price_history is missing

### DIFF
--- a/ddl/views/v_usdc_purchases.sql
+++ b/ddl/views/v_usdc_purchases.sql
@@ -34,7 +34,7 @@ SELECT
                  LIMIT 1
               )
             END,
-            0
+            sp.amount  -- no price_history match -> treat full amount as base price (extra_amount = 0)
         ),
         0
     ) AS extra_amount,

--- a/sql/01_schema.sql
+++ b/sql/01_schema.sql
@@ -9644,7 +9644,7 @@ CREATE VIEW public.v_usdc_purchases AS
               WHERE ((aph.playlist_id = sp.content_id) AND (aph.block_timestamp <= sp.created_at))
               ORDER BY aph.block_timestamp DESC
              LIMIT 1)
-        END, (0)::bigint)), (0)::bigint) AS extra_amount,
+        END, sp.amount)), (0)::bigint) AS extra_amount,
     (sp.access_type)::public.usdc_purchase_access_type AS access,
     sp.city,
     sp.region,


### PR DESCRIPTION
## Summary

Companion to #819. The same PR #815 branch had a third follow-up commit that didn't make it into the squash-merge — this is it.

The view's \`extra_amount\` computation is \`sp.amount - COALESCE(<price_history_lookup>, 0)\`. When the price-history lookup returns NULL (no matching row applicable at purchase time), the fallback to \`0\` makes the subtraction return \`sp.amount\` itself, i.e. the entire purchase amount is reported as a "tip."

Cases this hits in practice:
- Content deleted before its price was ever indexed
- Backfilled historical purchases whose content predates price_history tracking
- Test environments that don't fixture price_history

Production purchases written by the Go indexer always have price_history coverage (the indexer validates against it before writing), so this only affects the fallback path — but the fallback path is wrong as-shipped.

Change \`COALESCE(..., 0)\` to \`COALESCE(..., sp.amount)\` so the subtraction nets to 0 when we don't know the base price. Matches the legacy semantic of "no tip declared."

## Test plan

- [ ] On a prod replica: \`SELECT signature, amount, extra_amount FROM v_usdc_purchases WHERE extra_amount = amount LIMIT 10\` — should be empty (or much smaller) after the fix
- [ ] \`/v1/users/{id}/purchases\` for a historical user shows \`extra_amount: "0"\` instead of \`extra_amount: <full amount>\` for content without price history

🤖 Generated with [Claude Code](https://claude.com/claude-code)