### PR TITLE
chore(rewards): authorize Phantom-Ledger test wallet for reward code creation

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -216,7 +216,7 @@ func init() {
 		Cfg.AudiusdChainID = core_config.ProdAcdcChainID
 		Cfg.AudiusdEntityManagerAddress = core_config.ProdAcdcAddress
 		Cfg.AudiusAppUrl = "https://audius.co"
-		Cfg.RewardCodeAuthorizedKeys = []string{"4oGhuh6MkypUTnwUzKbtnUwFzjfaMWAgKYudchPfbYu8", "Du1sGwqC5yJFeoKJ73m3DrFLaRnc7rHM7g1z3Xe8jy8d", "4mzunYiiFSRGGc5iS3SVQQNdek6JiCyvkFALwoWu2xhP"}
+		Cfg.RewardCodeAuthorizedKeys = []string{"4oGhuh6MkypUTnwUzKbtnUwFzjfaMWAgKYudchPfbYu8", "Du1sGwqC5yJFeoKJ73m3DrFLaRnc7rHM7g1z3Xe8jy8d", "4mzunYiiFSRGGc5iS3SVQQNdek6JiCyvkFALwoWu2xhP", "9WXR4YNXhG5PYfp4bD1uzFw1TNgrX2yKid5T1mcssKyF"}
 		Cfg.VerifierAddress = "0xbeef8E42e8B5964fDD2b7ca8efA0d9aef38AA996"
 		Cfg.ArtistCoinRewardsStaticSenders = []Node{
 			{


### PR DESCRIPTION
## Summary

- Adds `9WXR4YNXhG5PYfp4bD1uzFw1TNgrX2yKid5T1mcssKyF` to `RewardCodeAuthorizedKeys` in the prod config.
