### PR TITLE
fix(test): unbreak CI for v_usdc_purchases-dependent tests

### DIFF
--- a/api/comms_blasts_test.go
+++ b/api/comms_blasts_test.go
@@ -59,8 +59,19 @@ func TestGetNewBlasts(t *testing.T) {
 			},
 			{
 				"track_id":   2,
-				"owner_id":   2,
+				"owner_id":   1,
 				"title":      "Remix Track",
+				"created_at": now.Add(-time.Minute * 10),
+				"updated_at": now.Add(-time.Minute * 10),
+			},
+			{
+				// Owned by user 2 so user 2 qualifies as a remixer of track 1.
+				// Track 2 is now owned by artist1 (so v_usdc_purchases reports
+				// user 1 as the seller for customer_audience filtering), which
+				// previously was what made user 2 a remixer.
+				"track_id":   3,
+				"owner_id":   2,
+				"title":      "Fan Remix",
 				"created_at": now.Add(-time.Minute * 10),
 				"updated_at": now.Add(-time.Minute * 10),
 			},
@@ -95,6 +106,11 @@ func TestGetNewBlasts(t *testing.T) {
 			{
 				"parent_track_id": 1,
 				"child_track_id":  2,
+			},
+			{
+				// Makes user 2 (owner of track 3) a remixer of track 1.
+				"parent_track_id": 1,
+				"child_track_id":  3,
 			},
 		},
 		"sol_purchases": {

--- a/api/v1_users_purchases_download_test.go
+++ b/api/v1_users_purchases_download_test.go
@@ -50,7 +50,7 @@ func TestV1UsersPurchasesDownload(t *testing.T) {
 		},
 		// Drives extra_amount = 500000 (amount=1000000 - base_price=50_cents*10000=500000)
 		"track_price_history": []map[string]any{
-			{"track_id": 1, "total_price_cents": 50, "blocknumber": 100, "block_timestamp": time.Date(2024, 6, 3, 0, 0, 0, 0, time.UTC), "splits": "[]"},
+			{"track_id": 1, "total_price_cents": 50, "block_timestamp": time.Date(2024, 6, 3, 0, 0, 0, 0, time.UTC), "splits": "[]"},
 		},
 	}
 
@@ -163,7 +163,7 @@ func TestV1UsersPurchasesDownloadWithGrantee(t *testing.T) {
 			{"signature": "def", "instruction_index": 0, "route_index": 1, "to_account": app.solanaConfig.StakingBridgeUsdcTokenAccount.String(), "amount": 100000, "slot": 101},
 		},
 		"track_price_history": []map[string]any{
-			{"track_id": 1, "total_price_cents": 50, "blocknumber": 100, "block_timestamp": time.Date(2024, 6, 3, 0, 0, 0, 0, time.UTC), "splits": "[]"},
+			{"track_id": 1, "total_price_cents": 50, "block_timestamp": time.Date(2024, 6, 3, 0, 0, 0, 0, time.UTC), "splits": "[]"},
 		},
 		"grants": []map[string]any{
 			{

--- a/api/v1_users_purchases_test.go
+++ b/api/v1_users_purchases_test.go
@@ -33,7 +33,7 @@ func TestV1UsersPurchases(t *testing.T) {
 		// For the purchase with non-zero extra_amount (signature "abc"), seed a track_price_history
 		// row so the view's amount - base_price computation produces extra_amount = 1000000.
 		"track_price_history": []map[string]any{
-			{"track_id": 1, "total_price_cents": 0, "blocknumber": 100, "block_timestamp": time.Date(2024, 6, 2, 23, 0, 0, 0, time.UTC), "splits": "[]"},
+			{"track_id": 1, "total_price_cents": 0, "block_timestamp": time.Date(2024, 6, 2, 23, 0, 0, 0, time.UTC), "splits": "[]"},
 		},
 		"sol_purchases": []map[string]any{
 			{

--- a/api/v1_users_sales_download_test.go
+++ b/api/v1_users_sales_download_test.go
@@ -49,7 +49,7 @@ func TestV1UsersSalesDownload(t *testing.T) {
 			{"signature": "def", "instruction_index": 0, "route_index": 1, "to_account": app.solanaConfig.StakingBridgeUsdcTokenAccount.String(), "amount": 100000, "slot": 101},
 		},
 		"track_price_history": []map[string]any{
-			{"track_id": 1, "total_price_cents": 50, "blocknumber": 100, "block_timestamp": time.Date(2024, 6, 3, 0, 0, 0, 0, time.UTC), "splits": "[]"},
+			{"track_id": 1, "total_price_cents": 50, "block_timestamp": time.Date(2024, 6, 3, 0, 0, 0, 0, time.UTC), "splits": "[]"},
 		},
 		"encrypted_emails": []map[string]any{
 			{
@@ -193,7 +193,7 @@ func TestV1UsersSalesDownloadWithGrantee(t *testing.T) {
 			{"signature": "def", "instruction_index": 0, "route_index": 1, "to_account": app.solanaConfig.StakingBridgeUsdcTokenAccount.String(), "amount": 100000, "slot": 101},
 		},
 		"track_price_history": []map[string]any{
-			{"track_id": 1, "total_price_cents": 50, "blocknumber": 100, "block_timestamp": time.Date(2024, 6, 3, 0, 0, 0, 0, time.UTC), "splits": "[]"},
+			{"track_id": 1, "total_price_cents": 50, "block_timestamp": time.Date(2024, 6, 3, 0, 0, 0, 0, time.UTC), "splits": "[]"},
 		},
 		"encrypted_emails": []map[string]any{
 			{

--- a/api/v1_users_sales_test.go
+++ b/api/v1_users_sales_test.go
@@ -32,7 +32,7 @@ func TestV1UsersSales(t *testing.T) {
 		},
 		"track_price_history": []map[string]any{
 			// Drives extra_amount = 1000000 for signature "abc" (amount=1000000, base_price=0)
-			{"track_id": 1, "total_price_cents": 0, "blocknumber": 100, "block_timestamp": time.Date(2024, 6, 2, 23, 0, 0, 0, time.UTC), "splits": "[]"},
+			{"track_id": 1, "total_price_cents": 0, "block_timestamp": time.Date(2024, 6, 2, 23, 0, 0, 0, time.UTC), "splits": "[]"},
 		},
 		"sol_purchases": []map[string]any{
 			{"signature": "gfsgf", "instruction_index": 0, "buyer_user_id": 5, "amount": 2000000, "content_type": "playlist", "content_id": 1, "created_at": time.Date(2024, 6, 1, 0, 0, 0, 0, time.UTC), "is_valid": true},


### PR DESCRIPTION
## Summary

Two related CI breakages on main from the recent `v_usdc_purchases` view migration. Both were pre-existing — surfaced when our PRs ran on main after the view changes landed.

### 1. `track_price_history_blocknumber_fkey` panics

`TestV1UsersPurchases`, `TestV1UsersSales`, `TestV1UsersPurchasesDownload`, `TestV1UsersSalesDownload` were all panicking with:

```
panic: ERROR: insert or update on table "track_price_history" violates foreign key constraint "track_price_history_blocknumber_fkey"
```

Each fixture hardcoded `blocknumber: 100`, but `database.Seed` only pre-inserts one block (`number = 101`). Just dropping the explicit `blocknumber` from each fixture row makes them inherit the baseRow default (`101`), and the view's lookup keys on `block_timestamp` anyway — so this is strictly fewer lines, no magic numbers.

### 2. `TestGetNewBlasts/get_blasts_for_all_audiences` missing `blast_customer_track2`

The fixture had track 2 owned by user 2 (the buyer). The new `v_usdc_purchases` view reports `seller_user_id = current owner`, so for that purchase seller=2. The customer_audience filter `p.seller_user_id = blast.from_user_id` then requires `2 = 1`, never matches.

Fix: move track 2's ownership to user 1 (the artist) so the customer match works, and add a track 3 owned by user 2 with a matching `remixes` entry so user 2 still qualifies as a remixer of track 1.

## Verification

Ran locally against `docker compose` DB:

```
go test ./api/ -run 'TestGetNewBlasts|TestV1UsersPurchases|TestV1UsersSales' -v
...
PASS
ok    api.audius.co/api    6.645s
```

15 tests pass including all five originally-broken ones.