### PR TITLE
fix(migrations): propagate pg_migrate.sh failure to exit code

### DIFF
--- a/main.go
+++ b/main.go
@@ -27,7 +27,10 @@ func main() {
 		fmt.Println("Skipping migrations. Set env runMigrations=true to run.")
 	} else {
 		fmt.Println("Running migrations...")
-		ddl.RunMigrations()
+		if err := ddl.RunMigrations(); err != nil {
+			fmt.Println("migration failed:", err)
+			os.Exit(1)
+		}
 	}
 
 	switch command {


### PR DESCRIPTION
## Summary
- `api/main.go:30` called `ddl.RunMigrations()` and discarded its returned error. When `pg_migrate.sh` exited non-zero, the process kept going and reached `os.Exit(0)` in `case "migrate":` — so a failed migration produced a successful-looking pod exit.
- Check the error and `os.Exit(1)` immediately so the failure propagates out of the container. Affects every binary entrypoint (`server`, `indexer`, `es-indexer`, `solana-indexer`, `migrate`); none should run against a half-migrated DB.

## Background
Discovered today (2026-05-19). The migration Job in [audius-k8s#496](https://github.com/AudiusProject/audius-k8s/pull/496) is supposed to block its dependent Deployments via Pulumi `DependsOn` whenever the migration fails. During an incident, the 0201 backfill was manually killed (`pg_terminate_backend` on the stuck session) and pg_migrate.sh exited with code 2, but the bridge Deployment rolled out anyway.

Tracing the failure path:

1. `pg_migrate.sh` exited 2. ✓
2. `cmd.CombinedOutput()` in `ddl/run_migrations.go:19` returned `*exec.ExitError`. ✓
3. `RunMigrations()` printed `"Error running pg_migrate.sh: exit status 2"` and returned the error. ✓
4. `main.go:30` ignored the return value. ✗ ← bug
5. `case "migrate":` ran `os.Exit(0)`. Container exited 0.
6. K8s Job flipped to `condition=Complete`.
7. Pulumi-kubernetes's Job awaiter resolved success.
8. `DependsOn` unblocked → Deployments rolled.

K8s, Pulumi, and the Job spec all behaved correctly given the inputs they got — the API binary was reporting success on failure.

## Test plan
- [ ] Manually run `bridge migrate` against a DB with a deliberately-broken migration (e.g., temporarily put a syntax error in the latest `ddl/migrations/*.sql`). Confirm exit code is now non-zero.
- [ ] Run `bridge migrate` against a clean DB. Confirm exit 0 and no behavior change.
- [ ] After merge, watch the next auto-upgrader deploy: a failed `bridge migrate` invocation should leave the migration Job in `condition=Failed` and block the Deployment rollout (per the audius-k8s side's `DependsOn`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)