### PR TITLE
perf(migrations): speed up reward disbursements backfill

### DIFF
--- a/ddl/migrations/0201_backfill_missing_reward_disbursements.sql
+++ b/ddl/migrations/0201_backfill_missing_reward_disbursements.sql
@@ -1,5 +1,3 @@
-BEGIN;
-
 -- One-shot recovery of challenge_disbursements rows that never made it into
 -- sol_reward_disbursements. Two historical loss sources contributed:
 --
@@ -16,6 +14,46 @@ BEGIN;
 -- relational state: a current users row plus an indexed AUDIO sol_claimable
 -- account. Rows whose user record no longer exists are intentionally skipped;
 -- they would need on-chain signature replay (via program.Indexer) to recover.
+
+-- CREATE INDEX CONCURRENTLY cannot run inside an explicit transaction, so
+-- these statements stay outside the BEGIN/COMMIT below. psql executes each in
+-- its own implicit transaction. Both indexes pay off well beyond this
+-- migration: the first lets the dedup LEFT JOIN on (challenge_id, specifier)
+-- use an index instead of a sequential scan; the second lets the live
+-- reward_manager indexer (and this migration's LATERAL lookup) resolve a
+-- user's current claimable account in O(log n) rather than scanning the table.
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS
+    sol_reward_disbursements_challenge_specifier_idx
+    ON sol_reward_disbursements (challenge_id, specifier);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS
+    sol_claimable_accounts_eth_mint_slot_idx
+    ON sol_claimable_accounts (ethereum_address, mint, slot DESC);
+
+BEGIN;
+
+-- Skip the on_sol_reward_disbursement trigger for this transaction. The
+-- trigger fires per-row to create challenge_reward notifications and a
+-- pg_notify announcement for the Python ChallengeEventBus. For a one-shot
+-- backfill of months-old disbursements, those notifications would be
+-- both noisy (~29k user-facing pushes for historical rewards) and slow
+-- (extra SELECTs and an INSERT per row). SET LOCAL scopes this to the
+-- transaction so concurrent indexer writes still fire the trigger normally.
+SET LOCAL session_replication_role = replica;
+
+-- Pre-compute the current AUDIO claimable account per wallet in one indexed
+-- scan rather than re-running the LATERAL subquery per challenge_disbursements
+-- row. MATERIALIZED forces a one-time evaluation that the planner can hash-
+-- join against, instead of inlining the CTE into the main query.
+WITH user_banks AS MATERIALIZED (
+    SELECT DISTINCT ON (ethereum_address)
+        ethereum_address,
+        account
+    FROM sol_claimable_accounts
+    WHERE mint = '9LzCMqDgTKYz9Drzqnpgee3SGa89up3a247ypMj2xrqM'
+    ORDER BY ethereum_address, slot DESC
+)
 INSERT INTO sol_reward_disbursements
     (signature, instruction_index, amount, slot, user_bank, challenge_id, specifier, recipient_eth_address, created_at)
 SELECT
@@ -23,7 +61,7 @@ SELECT
     0 AS instruction_index,
     cd.amount::bigint,
     cd.slot,
-    sca.account AS user_bank,
+    ub.account AS user_bank,
     cd.challenge_id,
     cd.specifier,
     LOWER(u.wallet) AS recipient_eth_address,
@@ -35,16 +73,8 @@ LEFT JOIN sol_reward_disbursements rd
 JOIN users u
        ON u.user_id    = cd.user_id
       AND u.is_current = TRUE
-JOIN LATERAL (
-    -- A user can have multiple sol_claimable_accounts rows (one per on-chain
-    -- Create instruction over time). Pick the latest as the active user_bank.
-    SELECT account
-    FROM sol_claimable_accounts
-    WHERE ethereum_address = u.wallet
-      AND mint = '9LzCMqDgTKYz9Drzqnpgee3SGa89up3a247ypMj2xrqM'
-    ORDER BY slot DESC
-    LIMIT 1
-) sca ON TRUE
+JOIN user_banks ub
+       ON ub.ethereum_address = u.wallet
 WHERE rd.signature IS NULL
 ON CONFLICT (signature, instruction_index) DO NOTHING;
 


### PR DESCRIPTION
## Summary
- Adds two `CREATE INDEX CONCURRENTLY` statements at the top of `0201_backfill_missing_reward_disbursements.sql` (outside the `BEGIN/COMMIT`):
  - `sol_reward_disbursements (challenge_id, specifier)` — lets the dedup `LEFT JOIN` find existing rows by index instead of a per-row sequential scan.
  - `sol_claimable_accounts (ethereum_address, mint, slot DESC)` — supports the "latest claimable account per wallet" lookup pattern (used by this migration and the live reward_manager indexer).
- Replaces the per-row `LATERAL` subquery with a `WITH user_banks AS MATERIALIZED` CTE that pre-computes `DISTINCT ON (ethereum_address)` once and hash-joins against the result.
- `SET LOCAL session_replication_role = replica` inside the backfill transaction to suppress the `on_sol_reward_disbursement` trigger, which fires per row to create `challenge_reward` notifications + `pg_notify`. For a one-shot backfill of months-old historical rewards we don't want to spam users, and the trigger work was a meaningful chunk of the per-row cost.

## Why
The 0201 backfill is taking over an hour against prod. Diagnosis:
1. The LEFT JOIN on `(challenge_id, specifier)` had no index — `sol_reward_disbursements` is keyed by `(signature, instruction_index)`, and the only other indexes (from 0198) are on `recipient_eth_address` and `created_at`.
2. The `LATERAL` against `sol_claimable_accounts` reran `ORDER BY slot DESC LIMIT 1` per row.
3. The row-level trigger added DB work and unwanted historical notifications.

With the new index alone, the LEFT JOIN goes from O(n×m) to O(n log m). With the trigger off and the CTE substitution, the per-row work drops correspondingly. Expected runtime: well under a minute, vs >1h currently.

## Migration idempotency
- `CREATE INDEX CONCURRENTLY IF NOT EXISTS` — safe to re-run; existing valid indexes are no-ops, existing invalid indexes (from a previous failed CONCURRENTLY run) require manual `DROP INDEX` first.
- `INSERT … ON CONFLICT (signature, instruction_index) DO NOTHING` — unchanged; safe on re-run.
- Since the migration was never committed in prod (the in-flight one is what we're killing), changing the SQL body just bumps the md5 in pg_migrate.sh's check; the next deploy will run the new shape.

## Test plan
- [ ] Cancel the in-flight 0201 backfill (`pg_cancel_backend(<pid>)` on the stuck session).
- [ ] Confirm both indexes don't already exist as invalid: `SELECT indexname, indisvalid FROM pg_indexes JOIN pg_class ON relname = indexname JOIN pg_index USING (indexrelid) WHERE indexname IN ('sol_reward_disbursements_challenge_specifier_idx', 'sol_claimable_accounts_eth_mint_slot_idx');` — drop any invalid ones.
- [ ] Deploy via the migration Job; expect the Job to complete in seconds rather than hours.
- [ ] Verify recovered row count: `SELECT COUNT(*) FROM challenge_disbursements cd LEFT JOIN sol_reward_disbursements rd ON rd.challenge_id = cd.challenge_id AND rd.specifier = cd.specifier WHERE rd.signature IS NULL AND cd.slot > 355300886;` — should drop from ~29k toward 0 (modulo the no-current-user bucket which is intentionally not recoverable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)