### PR TITLE
fix(migrations): use ALTER TABLE DISABLE TRIGGER instead of SET session_replication_role

### DIFF
--- a/ddl/migrations/0201_backfill_missing_reward_disbursements.sql
+++ b/ddl/migrations/0201_backfill_missing_reward_disbursements.sql
@@ -42,14 +42,18 @@ CREATE INDEX IF NOT EXISTS
     sol_claimable_accounts_eth_mint_slot_idx
     ON sol_claimable_accounts (ethereum_address, mint, slot DESC);
 
--- Skip the on_sol_reward_disbursement trigger for this transaction. The
--- trigger fires per-row to create challenge_reward notifications and a
--- pg_notify announcement for the Python ChallengeEventBus. For a one-shot
--- backfill of months-old disbursements, those notifications would be
--- both noisy (~29k user-facing pushes for historical rewards) and slow
--- (extra SELECTs and an INSERT per row). SET LOCAL scopes this to the
--- transaction so concurrent indexer writes still fire the trigger normally.
-SET LOCAL session_replication_role = replica;
+-- Disable the on_sol_reward_disbursement trigger for the duration of the
+-- backfill. The trigger fires per-row to create challenge_reward
+-- notifications and a pg_notify announcement for the Python
+-- ChallengeEventBus. For a one-shot backfill of months-old disbursements,
+-- those notifications would be both noisy (~29k user-facing pushes for
+-- historical rewards) and slow (extra SELECTs and an INSERT per row).
+--
+-- ALTER TABLE ... DISABLE TRIGGER is rolled back with the transaction if
+-- the INSERT fails, so the trigger state is preserved on error. CloudSQL
+-- doesn't permit `SET session_replication_role` (requires true superuser),
+-- so this is the available mechanism here.
+ALTER TABLE sol_reward_disbursements DISABLE TRIGGER on_sol_reward_disbursement;
 
 -- Pre-compute the current AUDIO claimable account per wallet in one indexed
 -- scan rather than re-running the LATERAL subquery per challenge_disbursements
@@ -86,5 +90,7 @@ JOIN user_banks ub
        ON ub.ethereum_address = u.wallet
 WHERE rd.signature IS NULL
 ON CONFLICT (signature, instruction_index) DO NOTHING;
+
+ALTER TABLE sol_reward_disbursements ENABLE TRIGGER on_sol_reward_disbursement;
 
 COMMIT;


### PR DESCRIPTION
## Summary
- Replaces `SET LOCAL session_replication_role = replica` with `ALTER TABLE sol_reward_disbursements DISABLE TRIGGER on_sol_reward_disbursement` (and a matching `ENABLE TRIGGER` after the INSERT) in `0201_backfill_missing_reward_disbursements.sql`.

## Why
The migration Job in prod hit:
```
ERROR:  permission denied to set parameter "session_replication_role"
```
`session_replication_role` requires a true Postgres superuser. CloudSQL doesn't expose one — the `cloudsqlsuperuser` role the migration runs as can do most operations but specifically not this one.

`ALTER TABLE ... DISABLE TRIGGER` only needs table-owner privilege (which the migration role has) and is rolled back with the surrounding transaction on failure, so the trigger's enable state is preserved if anything goes wrong before COMMIT.

Targeting the specific trigger by name (rather than `DISABLE TRIGGER USER`) keeps the change surgical — unrelated triggers (none in practice on this table, but defensive) are untouched.

## Test plan
- [ ] Roll the new image; the migration Job should run through without the permission error.
- [ ] Confirm `on_sol_reward_disbursement` is `tgenabled = 'O'` (enabled) after the migration completes:
      ```sql
      SELECT tgname, tgenabled FROM pg_trigger
       WHERE tgname = 'on_sol_reward_disbursement';
      ```
- [ ] Confirm no rogue `challenge_reward` notifications were created from this backfill:
      ```sql
      SELECT COUNT(*) FROM notification
       WHERE type = 'challenge_reward' AND timestamp > NOW() - INTERVAL '1 hour';
      ```
      Expected: small (only from concurrent live writes that fired the trigger normally), not ~29k.

🤖 Generated with [Claude Code](https://claude.com/claude-code)