### PR TITLE
docs(swagger): add user_id query to three cache-priming endpoints

### DIFF
--- a/api/swagger/swagger-v1.yaml
+++ b/api/swagger/swagger-v1.yaml
@@ -1232,6 +1232,14 @@ paths:
               - active
               - ended
               - all
+        - name: user_id
+          in: query
+          description:
+            The user ID of the user making the request. Required for
+            personalization of related users (e.g. does_current_user_follow)
+            in the response.
+          schema:
+            type: string
       responses:
         "200":
           description: Success
@@ -1785,6 +1793,14 @@ paths:
             enum:
               - playlist
               - album
+        - name: user_id
+          in: query
+          description:
+            The user ID of the user making the request. Required for
+            personalization of related users (e.g. does_current_user_follow)
+            in the response.
+          schema:
+            type: string
       responses:
         "200":
           description: Success
@@ -5580,6 +5596,14 @@ paths:
               - active
               - ended
               - all
+        - name: user_id
+          in: query
+          description:
+            The user ID of the user making the request. Required for
+            personalization of related users (e.g. does_current_user_follow)
+            in the response.
+          schema:
+            type: string
       responses:
         "200":
           description: Success


### PR DESCRIPTION
## Summary

Adds an optional `user_id` query parameter to three routes that embed user objects in their response and rely on `app.getMyId(c)` to personalize them. Today the SDK request types don't expose this field, so clients never send `?user_id=` and the backend computes personalization against `MyID = 0` — i.e. `does_current_user_follow` and friends return false for every embedded user.

- `GET /events/remix-contests` ([v1_events_remix_contests.go:187,195,215](https://github.com/AudiusProject/api/blob/main/api/v1_events_remix_contests.go#L187))
- `GET /users/{id}/contests` ([v1_users_contests.go:114,122,142](https://github.com/AudiusProject/api/blob/main/api/v1_users_contests.go#L114))
- `GET /playlists/new-releases` ([v1_playlists_new_releases.go:74](https://github.com/AudiusProject/api/blob/main/api/v1_playlists_new_releases.go#L74))

## Why

Audit follow-up to [#837](https://github.com/AudiusProject/api/pull/837) / [#838](https://github.com/AudiusProject/api/pull/838) (notifications). Same bug class:

1. Endpoint embeds users in `related.users` (or a collection's `user` field).
2. Backend handler passes `MyID: app.getMyId(c)` into `dbv1.ParallelParams` to personalize those users.
3. `getMyId(c)` reads from the query string `?user_id=`. With no query value, `MyID = 0` and the SQL [short-circuits](https://github.com/AudiusProject/api/blob/main/api/dbv1/get_users.sql.go#L129-L136) `does_current_user_follow` to false.
4. Web/mobile prime those un-personalized users into a shared tan-query cache (via `primeRelatedData` for remix-contests, `primeCollectionData` → `primeUserData` for new-releases). The cache write only happens when the slot is empty, so once poisoned the entry sticks until the user navigates to that profile and a personalized fetch overwrites it.

Affected client hooks:

- `useAllRemixContests` ([apps/packages/common/src/api/tan-query/events/useAllRemixContests.ts](https://github.com/AudiusProject/apps/blob/main/packages/common/src/api/tan-query/events/useAllRemixContests.ts))
- `useUserRemixContests` ([apps/packages/common/src/api/tan-query/events/useUserRemixContests.ts](https://github.com/AudiusProject/apps/blob/main/packages/common/src/api/tan-query/events/useUserRemixContests.ts))
- `useNewAlbumReleases` ([apps/packages/common/src/api/tan-query/collection/useNewAlbumReleases.ts](https://github.com/AudiusProject/apps/blob/main/packages/common/src/api/tan-query/collection/useNewAlbumReleases.ts))

## Spec-only change

`resolveMyIdMiddleware` already reads `c.Query(\"user_id\")` globally ([resolve_middleware.go:24-28](https://github.com/AudiusProject/api/blob/main/api/resolve_middleware.go#L24)), so the Go handlers personalize correctly as soon as the SDK starts sending the param. No backend code change required, no Go test updates required.

No path-placeholder collision this time — all three routes are either query-only (`new-releases`, `remix-contests`) or already use `id` as the path placeholder (`users/{id}/contests`). The generator will emit a clean `userId?: string` field.

## Test plan

- [ ] Spec validates in CI.
- [ ] After SDK regen + apps update (follow-up PR): on a fresh app load with a signed-in account that follows artists surfaced on the Browse → New Albums and Explore → Contests pages, confirm Following state renders correctly without first having to visit each artist's profile.
- [ ] Network inspector on the three endpoints shows `?user_id=<hashed-current-user-id>` and `does_current_user_follow: true` for users actually followed in `related.users`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)