### PR TITLE
fix(rewards): point prod AAO at anti-abuse-oracle.audius.engineering

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -179,7 +179,7 @@ func init() {
 		if Cfg.DelegatePrivateKey == "" {
 			log.Fatalf("Missing required %s env var: delegatePrivateKey", env)
 		}
-		Cfg.AntiAbuseOracles = []string{"https://discoveryprovider.audius.co"}
+		Cfg.AntiAbuseOracles = []string{"https://anti-abuse-oracle.audius.engineering"}
 		Cfg.ArchiverNodes = []string{"https://archiver.audius.engineering"}
 		Cfg.DeadNodes = []string{
 			"https://content.grassfed.network",
@@ -274,6 +274,11 @@ func init() {
 	// Override archiver upstream(s) when set (e.g. rollback to discovery or point at different archiver)
 	if v := os.Getenv("archiverNodes"); v != "" {
 		Cfg.ArchiverNodes = strings.Split(v, ",")
+	}
+
+	// Override anti-abuse oracle endpoint(s) when set, so the URL can be rotated without a code deploy.
+	if v := os.Getenv("antiAbuseOracles"); v != "" {
+		Cfg.AntiAbuseOracles = strings.Split(v, ",")
 	}
 
 	if v := os.Getenv("featuredAudienceUserId"); v != "" {


### PR DESCRIPTION
## Summary
- Prod `AntiAbuseOracles` was pointing at `https://discoveryprovider.audius.co`, which no longer serves `/attestation` — breaking rewards claims. Switched to `https://anti-abuse-oracle.audius.engineering`.
- Added an `antiAbuseOracles` env-var override (comma-separated, matching the existing `archiverNodes` pattern) so the endpoint can be rotated without a code deploy.
- **Staging left unchanged** — couldn't find the correct staging AAO URL in the repo. If staging has the same problem, the env var can be set as a stop-gap; otherwise a follow-up should pin the right staging URL in `config.go:141`.

Re-opened off `main` so this PR contains only the AAO fix. Supersedes #846, which accidentally bundled in the contest-sort changes already covered by #845.

## Test plan
- [ ] `go build ./config/...` passes (verified locally)
- [ ] Confirm rewards claim flow against prod AAO at `anti-abuse-oracle.audius.engineering/attestation`
- [ ] Verify `antiAbuseOracles=https://foo,https://bar` env var overrides the prod default

🤖 Generated with [Claude Code](https://claude.com/claude-code)