### PR TITLE
chore(rewards): swap tikilabs for rickyrombo in prod static senders

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -227,11 +227,6 @@ func init() {
 				Owner:          "0xe5b256d302ea2f4e04B8F3bfD8695aDe147aB68d",
 			},
 			{
-				DelegateWallet: "0x159200F84c2cF000b3A014cD4D8244500CCc36ca",
-				Endpoint:       "https://audius-cn1.tikilabs.com",
-				Owner:          "0xe4882D9A38A2A1fc652996719AF0fb15CB968d0a",
-			},
-			{
 				DelegateWallet: "0x627d23D17a3eAaDB1D3823e73Ab80D474023Acab",
 				Endpoint:       "https://audius.bragi.cc",
 				Owner:          "0xC88C8F9a15453c7D8Ea83120Af54cc4C40EC094a",
@@ -240,6 +235,11 @@ func init() {
 				DelegateWallet: "0x422541273087beC833c57D3c15B9e17F919bFB1F",
 				Endpoint:       "https://v.monophonic.digital",
 				Owner:          "0x6470Daf3bd32f5014512bCdF0D02232f5640a5BD",
+			},
+			{
+				DelegateWallet: "0xae5d0507b6653589a03ae5becb35eb0c160e7131",
+				Endpoint:       "https://audius.rickyrombo.com",
+				Owner:          "0x923EC9976bfEcFd0E8b7fEeaC9115F740f8ddB00",
 			},
 		}
 	default:


### PR DESCRIPTION
## Summary
- Add `https://audius.rickyrombo.com` to `ArtistCoinRewardsStaticSenders` (prod).
- Remove `https://audius-cn1.tikilabs.com` from the same list.

## Test plan
- [ ] Confirm rickyrombo node's reported delegate wallet matches `0xae5d0507b6653589a03ae5becb35eb0c160e7131` (taken from its `/health_check`).
- [ ] Confirm `0x923EC9976bfEcFd0E8b7fEeaC9115F740f8ddB00` is the correct owner/staking address for rickyrombo.
- [ ] Verify the tikilabs removal is intentional and not needed for any in-flight reward attestations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)