### PR TITLE
fix(eth-indexer): make /eth/health O(1)

### DIFF
--- a/eth/indexer/eth_indexer.go
+++ b/eth/indexer/eth_indexer.go
@@ -501,28 +501,19 @@ type ethHealth struct {
 	LastBlockSeen   uint64     `json:"last_block_seen"`
 	CheckpointBlock uint64     `json:"checkpoint_block"`
 	LastEventAt     *time.Time `json:"last_event_at"`
-	TrackedWallets  int64      `json:"tracked_wallets"`
-	CachedWallets   int64      `json:"cached_wallets"`
 }
 
+// GetHealth returns indexer liveness in O(1) — all values are either in
+// memory or come from a single-row PK lookup. Wallet-population counts
+// previously lived on this response but were expensive on prod
+// (UNION/COUNT across users + associated_wallets ≈ 3M rows, no index, can
+// take 30s+) and don't actually answer "is the indexer alive?", which is
+// what a health endpoint is for. If you want population stats, query
+// eth_wallet_balances directly.
 func (e *EthIndexer) GetHealth(ctx context.Context, maxEventLagSecs int64) (*ethHealth, error) {
 	checkpoint, err := e.loadCheckpoint(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("loading checkpoint: %w", err)
-	}
-
-	var tracked, cached int64
-	err = e.pool.QueryRow(ctx, `
-		SELECT
-			(SELECT COUNT(*) FROM (
-				SELECT LOWER(wallet) FROM users WHERE wallet IS NOT NULL AND wallet <> ''
-				UNION
-				SELECT LOWER(wallet) FROM associated_wallets WHERE chain = 'eth' AND is_delete = FALSE
-			) t) AS tracked,
-			(SELECT COUNT(*) FROM eth_wallet_balances) AS cached
-	`).Scan(&tracked, &cached)
-	if err != nil {
-		return nil, fmt.Errorf("counting wallets: %w", err)
 	}
 
 	errs := make([]string, 0)
@@ -545,8 +536,6 @@ func (e *EthIndexer) GetHealth(ctx context.Context, maxEventLagSecs int64) (*eth
 		LastBlockSeen:   e.lastBlockSeen.Load(),
 		CheckpointBlock: checkpoint,
 		LastEventAt:     e.lastEventAt.Load(),
-		TrackedWallets:  tracked,
-		CachedWallets:   cached,
 	}, nil
 }
 

--- a/eth/indexer/server.go
+++ b/eth/indexer/server.go
@@ -5,11 +5,18 @@ import (
 	"encoding/json"
 	"net"
 	"net/http"
+	"time"
 
 	"github.com/gofiber/fiber/v2"
 	"github.com/mcuadros/go-defaults"
 	"go.uber.org/zap"
 )
+
+// healthHandlerTimeout caps how long /eth/health is willing to wait on
+// downstream work (DB, etc.) before returning an error. The endpoint is
+// supposed to be O(1); a 2s ceiling is generous and stops a future slow
+// query from hanging the handler indefinitely.
+const healthHandlerTimeout = 2 * time.Second
 
 type Server struct {
 	*fiber.App
@@ -39,7 +46,9 @@ func NewServer(indexer *EthIndexer) *Server {
 		}
 		defaults.SetDefaults(&q)
 
-		health, err := indexer.GetHealth(c.Context(), q.MaxEventLagSecs)
+		ctx, cancel := context.WithTimeout(c.Context(), healthHandlerTimeout)
+		defer cancel()
+		health, err := indexer.GetHealth(ctx, q.MaxEventLagSecs)
 		if err != nil {
 			return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
 				"error": err.Error(),


### PR DESCRIPTION
## Summary

`https://api.audius.co/eth/health` was hanging on prod because the handler ran:

\`\`\`sql
SELECT COUNT(*) FROM (
    SELECT LOWER(wallet) FROM users WHERE wallet IS NOT NULL AND wallet <> ''
    UNION
    SELECT LOWER(wallet) FROM associated_wallets WHERE chain='eth' AND is_delete=FALSE
) t
\`\`\`

On prod that's ~3.15M rows through a seq scan + dedup sort and takes long enough to keep the HTTP request open indefinitely (no statement timeout, no handler timeout). Cheap locally with one seeded user, lethal in prod.

These counts (`tracked_wallets`, `cached_wallets`) were nice-to-have stats, not liveness signals. They don't belong on a health endpoint.

## Changes

- **`GetHealth`**: drop the COUNT subqueries and the corresponding fields from the response. What remains is all O(1):
  - `connected`, `rpc_configured`, `last_block_seen`, `last_event_at` — in-memory atomics
  - `checkpoint_block` — single-row PK lookup on `eth_indexer_checkpoints`
- **`/eth/health` handler**: wrap `GetHealth` in a 2s context timeout. Even if a future query turns slow, the request fails fast instead of hanging the ingress.

## After merge

Wait for the auto-upgrader to pick up the new image (every 3 min, see `Pulumi.prod-api.yaml`'s `autoUpgradeSchedule`), or roll the deployment manually:

\`\`\`bash
kubectl -n api rollout restart deployment/eth-indexer
\`\`\`

Then:
\`\`\`bash
time curl -s https://api.audius.co/eth/health | jq
# Expect: <1s, JSON returned
\`\`\`

If you want population stats, query directly:
\`\`\`bash
kubectl -n api exec -i deploy/bridge -- psql "\$writeDbUrl" -c \\
  "SELECT COUNT(*) FROM eth_wallet_balances;"
\`\`\`

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./eth/...` clean
- [ ] After deploy, `curl -m 5 https://api.audius.co/eth/health` returns JSON in well under 1s
- [ ] Field set: `errors`, `connected`, `rpc_configured`, `last_block_seen`, `checkpoint_block`, `last_event_at`