### PR TITLE
fix(favorites): filter deleted tracks and deactivated-owner tracks

### DIFF
--- a/api/testdata/save_fixtures.go
+++ b/api/testdata/save_fixtures.go
@@ -16,6 +16,18 @@ var SaveFixtures = []map[string]any{
 		"save_item_id": 100,
 		"save_type":    "track",
 	},
+	// Saves of a deleted track and a track owned by a deactivated user.
+	// The /users/:id/favorites endpoint must filter both out.
+	{
+		"user_id":      1,
+		"save_item_id": 950,
+		"save_type":    "track",
+	},
+	{
+		"user_id":      1,
+		"save_item_id": 951,
+		"save_type":    "track",
+	},
 }
 
 // user_id,save_item_id,save_item_type

--- a/api/testdata/track_fixtures.go
+++ b/api/testdata/track_fixtures.go
@@ -134,6 +134,12 @@ var TrackFixtures = []map[string]any{
 	{"track_id": 702, "genre": "Electronic", "owner_id": 500, "title": "UserTracksTester Track 3", "created_at": "2021-01-04 00:00:00"},
 	// created before other track but later release date
 	{"track_id": 703, "genre": "Electronic", "owner_id": 500, "title": "UserTracksTester Track 2", "release_date": "2021-01-05 00:00:00", "created_at": "2021-01-02 00:00:00"},
+
+	// regression fixtures for v1_users_favorites: deleted track + track
+	// owned by a deactivated user. Both are favorited by user 1 (see
+	// SaveFixtures) and must NOT appear in their /favorites response.
+	{"track_id": 950, "genre": "Electronic", "owner_id": 1, "title": "Deleted Track", "is_unlisted": "f", "is_delete": "t"},
+	{"track_id": 951, "genre": "Electronic", "owner_id": 91, "title": "Track Owned By Deactivated User", "is_unlisted": "f"},
 }
 
 /*

--- a/api/v1_users_account_test.go
+++ b/api/v1_users_account_test.go
@@ -16,7 +16,10 @@ func TestGetUsersAccount(t *testing.T) {
 	assert.Equal(t, 200, status)
 
 	assert.Equal(t, "0x7d273271690538cf855e5b3002a0dd8c154bb060", accountResponse.Data.User.Wallet.String)
-	assert.Equal(t, (int64)(1), accountResponse.Data.TrackSaveCount)
+	// User 1 has three track saves in SaveFixtures: 100 (live), 950 (deleted
+	// track), 951 (deactivated owner). TrackSaveCount comes from
+	// aggregate_user (raw count, unfiltered) so it sees all three.
+	assert.Equal(t, (int64)(3), accountResponse.Data.TrackSaveCount)
 
 	// Check playlists
 	assert.Equal(t, 3, len(accountResponse.Data.Playlists))

--- a/api/v1_users_favorites.go
+++ b/api/v1_users_favorites.go
@@ -27,16 +27,22 @@ func (app *ApiServer) v1UsersFavorites(c *fiber.Ctx) error {
 
 	sql := `
 	SELECT
-		save_item_id,
-		'SaveType.' || save_type as save_item_type, -- concat in "SaveType" to match sqlalchemy bs
-		user_id,
-		created_at
+		saves.save_item_id,
+		'SaveType.' || saves.save_type as save_item_type, -- concat in "SaveType" to match sqlalchemy bs
+		saves.user_id,
+		saves.created_at
 	FROM saves
-	WHERE user_id = @userId
-	  AND is_delete = false
-		AND is_current = true
-		AND save_type = 'track'
-	ORDER BY blocknumber, save_item_id desc
+	JOIN tracks t ON t.track_id = saves.save_item_id
+		AND t.is_current = true
+		AND t.is_delete = false
+	JOIN users u ON u.user_id = t.owner_id
+		AND u.is_current = true
+		AND u.is_deactivated = false
+	WHERE saves.user_id = @userId
+	  AND saves.is_delete = false
+		AND saves.is_current = true
+		AND saves.save_type = 'track'
+	ORDER BY saves.blocknumber, saves.save_item_id desc
 	LIMIT @limit
 	OFFSET @offset
 	`


### PR DESCRIPTION
## Summary

`GET /v1/users/:userId/favorites` was only filtering the **saves** row itself (`saves.is_delete = false`, `saves.is_current = true`, `save_type = 'track'`). It did **not** check the underlying track — so saves pointing at since-deleted tracks, or tracks whose owner had since deactivated, still came back.

That stale list flows into the **"Add some tracks"** UX on the playlist page in `audius/apps` (web): `useFavoritedTracks` dumps the IDs into `useTracks`, and the user ends up with a deleted track in their playlist when they click *Add*.

## Fix

Join `tracks` and `users` in the favorites query so saves pointing at deleted or deactivated-owner tracks are excluded:

```sql
JOIN tracks t ON t.track_id = saves.save_item_id
    AND t.is_current = true
    AND t.is_delete = false
JOIN users  u ON u.user_id = t.owner_id
    AND u.is_current = true
    AND u.is_deactivated = false
```

Existing column references qualified with `saves.` to avoid ambiguity post-JOIN.

## Why here, not `get_tracks.sql`?

Considered fixing the canonical `get_tracks.sql` (which is also missing `is_delete` and the deactivated-owner filter). Deferred for now:

- `get_tracks.sql` is consumed by many endpoints; some legitimately need to surface deleted-track metadata (e.g. the response already exposes `is_delete` and `is_available` columns to callers).
- The trending pipeline already filters `is_delete`/`is_unlisted`/`is_available` at the IDs step (`v1_tracks_trending_ids.go`), so the favorites endpoint is the only feeder leaking deleted tracks into the suggestions UI.
- Narrower change = lower regression surface.

A follow-up PR could add `is_delete`/`is_deactivated` to `get_tracks.sql` behind an opt-out flag (mirroring the existing `include_unlisted` pattern at line 229) for defense in depth.

## Test plan

- Extended `SaveFixtures` with two new track saves for user 1 — one of a deleted track (`TrackFixtures` 950, `is_delete=t`) and one of a track owned by the deactivated user 91. Left the existing `TestGetUserFavorites` assertions (`data.# = 1`, `favorite_item_id = 100`) unchanged. The test now also acts as a regression guard: without the new JOIN/filter pair, user 1 would see 3 favorites instead of 1.
- `go build ./api/...`, `go vet ./api/...`: clean.
- `go test ./api/ -run TestGetUserFavorites -v`: 4/4 pass.
- Full `go test ./api/` sweep: only failure is `TestSearch`, which requires an Elasticsearch test container not running locally (`dial tcp [::1]:21401: connect: connection refused`) — unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)