### PR TITLE
Capture transfer-memo types in the Solana indexer

### DIFF
--- a/api/handle_sol_usdc_withdrawal_test.go
+++ b/api/handle_sol_usdc_withdrawal_test.go
@@ -1,0 +1,182 @@
+package api
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"api.audius.co/database"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Exercises the handle_sol_usdc_withdrawal trigger end-to-end: insert into
+// sol_claimable_account_transfers (with the indexer's ordering so the
+// memo marker is already present) and check that a notification row pops
+// out with the right type + group_id. Mirrors the legacy
+// handle_usdc_withdrawal trigger contract.
+func TestHandleSolUsdcWithdrawalTrigger(t *testing.T) {
+	const usdcMintAddr = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+	app := emptyTestApp(t)
+	ctx := context.Background()
+
+	userWallet := "0x7d273271690538cf855e5b3002a0dd8c154bb060"
+	userBank := "User1UsdcBank_trigger_test__________________"
+	external := "0xextdest0000000000000000000000000000000000"
+
+	// Seed explicitly (not via Seed()), because the trigger fires on
+	// sol_claimable_account_transfers and reads sol_transfer_memo_types —
+	// the memo marker must be present at trigger time. Mirrors the order the
+	// indexer uses in claimable_tokens.go.
+	_, err := app.writePool.Exec(ctx, `
+		INSERT INTO public.blocks (blockhash, parenthash, is_current, number)
+		VALUES ('block1', 'block0', true, 101)
+		ON CONFLICT DO NOTHING;`)
+	require.NoError(t, err)
+	database.SeedTable(app.writePool, "users", []map[string]any{
+		{"user_id": 1, "handle": "u", "wallet": userWallet, "is_current": true},
+	})
+	database.SeedTable(app.writePool, "sol_claimable_accounts", []map[string]any{
+		{
+			"signature":         "create_sig",
+			"instruction_index": 0,
+			"slot":              1,
+			"mint":              usdcMintAddr,
+			"ethereum_address":  userWallet,
+			"account":           userBank,
+		},
+	})
+	database.SeedTable(app.writePool, "sol_token_account_balance_changes", []map[string]any{
+		{
+			"signature":       "withdraw_sig",
+			"mint":            usdcMintAddr,
+			"owner":           "claimable-tokens-pda",
+			"account":         userBank,
+			"change":          -1500000,
+			"balance":         500000,
+			"slot":            100,
+			"block_timestamp": time.Date(2024, 7, 1, 0, 0, 0, 0, time.UTC),
+		},
+		// Second flow: plain transfer (no memo) to assert that branch.
+		{
+			"signature":       "xfer_sig",
+			"mint":            usdcMintAddr,
+			"owner":           "claimable-tokens-pda",
+			"account":         userBank,
+			"change":          -250000,
+			"balance":         250000,
+			"slot":            200,
+			"block_timestamp": time.Date(2024, 7, 2, 0, 0, 0, 0, time.UTC),
+		},
+	})
+	// Memo marker BEFORE the claimable transfer (real-world ordering).
+	database.SeedTable(app.writePool, "sol_transfer_memo_types", []map[string]any{
+		{
+			"signature":         "withdraw_sig",
+			"instruction_index": 1,
+			"slot":              100,
+			"memo_type":         "withdrawal",
+		},
+	})
+	// Trigger fires on these inserts.
+	database.SeedTable(app.writePool, "sol_claimable_account_transfers", []map[string]any{
+		{
+			"signature":          "withdraw_sig",
+			"instruction_index":  1,
+			"amount":             1500000,
+			"slot":               100,
+			"from_account":       userBank,
+			"to_account":         external,
+			"sender_eth_address": userWallet,
+		},
+		{
+			"signature":          "xfer_sig",
+			"instruction_index":  1,
+			"amount":             250000,
+			"slot":               200,
+			"from_account":       userBank,
+			"to_account":         external,
+			"sender_eth_address": userWallet,
+		},
+	})
+
+	// Withdrawal row → usdc_withdrawal notification with the correct payload.
+	var (
+		notifType   string
+		groupId     string
+		userIds     []int32
+		userBankOut string
+		signature   string
+		change      int64
+		balance     int64
+		receiver    string
+	)
+	err = app.writePool.QueryRow(ctx, `
+		SELECT type, group_id, user_ids,
+		       data->>'user_bank',
+		       data->>'signature',
+		       (data->>'change')::bigint,
+		       (data->>'balance')::bigint,
+		       data->>'receiver_account'
+		  FROM notification
+		 WHERE data->>'signature' = 'withdraw_sig'
+	`).Scan(&notifType, &groupId, &userIds, &userBankOut, &signature, &change, &balance, &receiver)
+	require.NoError(t, err)
+	assert.Equal(t, "usdc_withdrawal", notifType)
+	assert.Equal(t, "usdc_withdrawal:1:signature:withdraw_sig", groupId)
+	assert.Equal(t, []int32{1}, userIds)
+	assert.Equal(t, userBank, userBankOut)
+	assert.Equal(t, "withdraw_sig", signature)
+	assert.Equal(t, int64(-1500000), change)
+	assert.Equal(t, int64(500000), balance)
+	assert.Equal(t, external, receiver)
+
+	// Plain transfer (no memo) → usdc_transfer notification.
+	err = app.writePool.QueryRow(ctx, `
+		SELECT type, group_id
+		  FROM notification
+		 WHERE data->>'signature' = 'xfer_sig'
+	`).Scan(&notifType, &groupId)
+	require.NoError(t, err)
+	assert.Equal(t, "usdc_transfer", notifType)
+	assert.Equal(t, "usdc_transfer:1:signature:xfer_sig", groupId)
+}
+
+// Sanity check: prepare_withdrawal / internal_transfer don't fire the
+// notification (legacy trigger didn't notify on those types either).
+func TestHandleSolUsdcWithdrawalTrigger_SkipsSystemTypes(t *testing.T) {
+	const usdcMintAddr = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+	app := emptyTestApp(t)
+	ctx := context.Background()
+
+	userWallet := "0x7d273271690538cf855e5b3002a0dd8c154bb060"
+	userBank := "User1UsdcBank_skip_test_____________________"
+
+	_, err := app.writePool.Exec(ctx, `
+		INSERT INTO public.blocks (blockhash, parenthash, is_current, number)
+		VALUES ('block1', 'block0', true, 101)
+		ON CONFLICT DO NOTHING;`)
+	require.NoError(t, err)
+	database.SeedTable(app.writePool, "users", []map[string]any{
+		{"user_id": 1, "handle": "u", "wallet": userWallet, "is_current": true},
+	})
+	database.SeedTable(app.writePool, "sol_claimable_accounts", []map[string]any{
+		{"signature": "create_sig", "instruction_index": 0, "slot": 1, "mint": usdcMintAddr, "ethereum_address": userWallet, "account": userBank},
+	})
+	database.SeedTable(app.writePool, "sol_token_account_balance_changes", []map[string]any{
+		{"signature": "prep_sig", "mint": usdcMintAddr, "owner": "p", "account": userBank, "change": -1000, "balance": 0, "slot": 10, "block_timestamp": time.Now()},
+	})
+	database.SeedTable(app.writePool, "sol_transfer_memo_types", []map[string]any{
+		{"signature": "prep_sig", "instruction_index": 1, "slot": 10, "memo_type": "prepare_withdrawal"},
+	})
+	database.SeedTable(app.writePool, "sol_claimable_account_transfers", []map[string]any{
+		{"signature": "prep_sig", "instruction_index": 1, "amount": 1000, "slot": 10, "from_account": userBank, "to_account": "jupiter", "sender_eth_address": userWallet},
+	})
+
+	var count int
+	err = app.writePool.QueryRow(ctx, `
+		SELECT count(*) FROM notification WHERE data->>'signature' = 'prep_sig'
+	`).Scan(&count)
+	require.NoError(t, err)
+	assert.Equal(t, 0, count, "prepare_withdrawal should not produce a usdc_* notification")
+}

--- a/api/v_token_transactions_history_test.go
+++ b/api/v_token_transactions_history_test.go
@@ -164,6 +164,87 @@ func TestVTokenTransactionsHistory_TrendingReward(t *testing.T) {
 	})
 }
 
+// Memo-tagged transfer types: when sol_transfer_memo_types carries a row for
+// a transfer's signature, the view returns that type (withdrawal /
+// prepare_withdrawal / internal_transfer) instead of bare `transfer`. Also
+// asserts the tx_metadata override for `withdrawal` (returns to_account).
+func TestVTokenTransactionsHistory_MemoTaggedTransfers(t *testing.T) {
+	app := emptyTestApp(t)
+
+	t0 := time.Date(2024, 5, 1, 0, 0, 0, 0, time.UTC)
+	externalDest := "ExternalWithdrawDest____________________________"
+
+	fixtures := tthBaseFixtures(database.FixtureMap{
+		"sol_token_account_balance_changes": []map[string]any{
+			// Three outbound transfers from user A's bank to varied destinations.
+			{"signature": "withdraw_sig", "mint": tthWAudioMint, "owner": tthClaimablePDA, "account": tthUserABank, "change": -100, "balance": 900, "slot": 100, "block_timestamp": t0},
+			{"signature": "prep_sig", "mint": tthWAudioMint, "owner": tthClaimablePDA, "account": tthUserABank, "change": -200, "balance": 700, "slot": 200, "block_timestamp": t0.Add(time.Hour)},
+			{"signature": "intern_sig", "mint": tthWAudioMint, "owner": tthClaimablePDA, "account": tthUserABank, "change": -300, "balance": 400, "slot": 300, "block_timestamp": t0.Add(2 * time.Hour)},
+		},
+		"sol_claimable_account_transfers": []map[string]any{
+			{"signature": "withdraw_sig", "instruction_index": 1, "amount": 100, "slot": 100, "from_account": tthUserABank, "to_account": externalDest, "sender_eth_address": tthUserAWallet},
+			{"signature": "prep_sig", "instruction_index": 1, "amount": 200, "slot": 200, "from_account": tthUserABank, "to_account": externalDest, "sender_eth_address": tthUserAWallet},
+			// Internal transfer counterpart is user B (a known bank). The memo
+			// marker takes precedence over the tip branch.
+			{"signature": "intern_sig", "instruction_index": 1, "amount": 300, "slot": 300, "from_account": tthUserABank, "to_account": tthUserBBank, "sender_eth_address": tthUserAWallet},
+		},
+		"sol_transfer_memo_types": []map[string]any{
+			{"signature": "withdraw_sig", "instruction_index": 1, "slot": 100, "memo_type": "withdrawal"},
+			{"signature": "prep_sig", "instruction_index": 1, "slot": 200, "memo_type": "prepare_withdrawal"},
+			{"signature": "intern_sig", "instruction_index": 1, "slot": 300, "memo_type": "internal_transfer"},
+		},
+	})
+	database.Seed(app.pool.Replicas[0], fixtures)
+
+	// Default sort is transaction_date DESC.
+	status, body := testGet(t, app, "/v1/users/"+trashid.MustEncodeHashID(1)+"/transactions/audio")
+	assert.Equal(t, 200, status)
+	jsonAssert(t, body, map[string]any{
+		"data.#": 3,
+
+		"data.0.transaction_type": "internal_transfer",
+		"data.0.method":           "send",
+		"data.0.change":           float64(300),
+
+		"data.1.transaction_type": "prepare_withdrawal",
+		"data.1.method":           "send",
+		"data.1.change":           float64(200),
+
+		"data.2.transaction_type": "withdrawal",
+		"data.2.method":           "send",
+		"data.2.change":           float64(100),
+		// Withdrawal-specific tx_metadata: surfaces cat.to_account.
+		"data.2.metadata": externalDest,
+	})
+}
+
+// Recover-withdrawal markers are populated from the payment_router branch.
+// The view should classify the balance change as `recover_withdrawal` even
+// though there is no sol_claimable_account_transfers row for it.
+func TestVTokenTransactionsHistory_RecoverWithdrawal(t *testing.T) {
+	app := emptyTestApp(t)
+
+	t0 := time.Date(2024, 5, 2, 0, 0, 0, 0, time.UTC)
+
+	fixtures := tthBaseFixtures(database.FixtureMap{
+		"sol_token_account_balance_changes": []map[string]any{
+			{"signature": "recover_sig", "mint": tthWAudioMint, "owner": tthClaimablePDA, "account": tthUserABank, "change": 500, "balance": 500, "slot": 400, "block_timestamp": t0},
+		},
+		"sol_transfer_memo_types": []map[string]any{
+			{"signature": "recover_sig", "instruction_index": 0, "slot": 400, "memo_type": "recover_withdrawal"},
+		},
+	})
+	database.Seed(app.pool.Replicas[0], fixtures)
+
+	status, body := testGet(t, app, "/v1/users/"+trashid.MustEncodeHashID(1)+"/transactions/audio")
+	assert.Equal(t, 200, status)
+	jsonAssert(t, body, map[string]any{
+		"data.0.transaction_type": "recover_withdrawal",
+		"data.0.method":           "receive",
+		"data.0.change":           float64(500),
+	})
+}
+
 // Mint isolation: the view must not surface rows from other mints when filtered
 // to wAUDIO. Set up a USDC balance change on the same user_bank account and
 // confirm /transactions/audio doesn't return it.

--- a/api/v_token_transactions_history_test.go
+++ b/api/v_token_transactions_history_test.go
@@ -245,6 +245,48 @@ func TestVTokenTransactionsHistory_RecoverWithdrawal(t *testing.T) {
 	})
 }
 
+// AUDIO vendor purchases (Stripe / Coinbase / Unknown) — populated by the
+// token indexer when it detects the "In-App $AUDIO Purchase: <Vendor>" memo
+// on an inbound wAUDIO transfer. The view returns memo_type directly as
+// transaction_type, so the indexer just needs to write the right string.
+func TestVTokenTransactionsHistory_AudioVendorPurchases(t *testing.T) {
+	cases := []struct {
+		memoType        string
+		transactionType string
+	}{
+		{"purchase_stripe", "purchase_stripe"},
+		{"purchase_coinbase", "purchase_coinbase"},
+		{"purchase_unknown", "purchase_unknown"},
+	}
+	for _, c := range cases {
+		t.Run(c.memoType, func(t *testing.T) {
+			app := emptyTestApp(t)
+			t0 := time.Date(2024, 5, 3, 0, 0, 0, 0, time.UTC)
+			sig := "vendor_sig_" + c.memoType
+
+			fixtures := tthBaseFixtures(database.FixtureMap{
+				// Direct SPL token transfer in — no claimable_account_transfers
+				// row, just the balance change + memo marker.
+				"sol_token_account_balance_changes": []map[string]any{
+					{"signature": sig, "mint": tthWAudioMint, "owner": tthClaimablePDA, "account": tthUserABank, "change": 50000, "balance": 50000, "slot": 500, "block_timestamp": t0},
+				},
+				"sol_transfer_memo_types": []map[string]any{
+					{"signature": sig, "instruction_index": 1, "slot": 500, "memo_type": c.memoType},
+				},
+			})
+			database.Seed(app.pool.Replicas[0], fixtures)
+
+			status, body := testGet(t, app, "/v1/users/"+trashid.MustEncodeHashID(1)+"/transactions/audio")
+			assert.Equal(t, 200, status)
+			jsonAssert(t, body, map[string]any{
+				"data.0.transaction_type": c.transactionType,
+				"data.0.method":           "receive",
+				"data.0.change":           float64(50000),
+			})
+		})
+	}
+}
+
 // Mint isolation: the view must not surface rows from other mints when filtered
 // to wAUDIO. Set up a USDC balance change on the same user_bank account and
 // confirm /transactions/audio doesn't return it.

--- a/database/seed.go
+++ b/database/seed.go
@@ -567,6 +567,12 @@ var (
 			"amount":            nil,
 			"slot":              101,
 		},
+		"sol_transfer_memo_types": {
+			"signature":         nil,
+			"instruction_index": 0,
+			"slot":              101,
+			"memo_type":         nil,
+		},
 		"album_price_history": {
 			"playlist_id":       nil,
 			"splits":            "[]",

--- a/ddl/functions/handle_usdc_withdrawal.sql
+++ b/ddl/functions/handle_usdc_withdrawal.sql
@@ -52,3 +52,105 @@ do $$ begin
 exception
   when others then null;
 end $$;
+
+-- Sol-indexer-side equivalent: fires on sol_claimable_account_transfers for
+-- USDC transfers out of a user_bank. Mirrors handle_usdc_purchase's parallel
+-- handle_sol_purchase pattern. Same notification shape and group_id as the
+-- legacy trigger so on-conflict-do-nothing dedupes while both pipelines run
+-- side by side; once the Python indexer is decommissioned only this fires.
+--
+-- Depends on the Go indexer inserting sol_transfer_memo_types BEFORE
+-- sol_claimable_account_transfers so the memo lookup below resolves on the
+-- first attempt (see solana/indexer/program/claimable_tokens.go).
+create or replace function handle_sol_usdc_withdrawal() returns trigger as $$
+DECLARE
+    users_row users%ROWTYPE;
+    mint_addr varchar;
+    memo_type_str varchar;
+    notification_type varchar;
+    change_value bigint;
+    balance_value bigint;
+    block_ts timestamp;
+begin
+  -- Resolve sender's mint + user via sol_claimable_accounts. Skip rows
+  -- whose from_account isn't a tracked user_bank, and skip non-USDC mints
+  -- (AUDIO is not part of the legacy withdrawal-notification surface).
+  select sca.mint into mint_addr
+    from sol_claimable_accounts sca
+   where sca.account = new.from_account
+   limit 1;
+  select u.* into users_row
+    from users u
+    join sol_claimable_accounts sca on sca.ethereum_address = u.wallet
+   where sca.account = new.from_account
+     and u.is_current = true
+   limit 1;
+
+  if mint_addr is null or mint_addr not in (
+        'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v', -- prod/stage USDC
+        '26Q7gP8UfkDzi7GMFEQxTJaNJ8D2ybCUjex58M5MLu8y'  -- dev USDC
+      ) then
+    return null;
+  end if;
+
+  -- Look up memo type. The legacy trigger only notified for `transfer` and
+  -- `withdrawal` — so we skip prepare_withdrawal / internal_transfer /
+  -- recover_withdrawal to preserve that behavior.
+  select memo_type into memo_type_str
+    from sol_transfer_memo_types
+   where signature = new.signature and instruction_index = new.instruction_index;
+
+  if memo_type_str is null then
+    notification_type := 'usdc_transfer';
+  elsif memo_type_str = 'withdrawal' then
+    notification_type := 'usdc_withdrawal';
+  else
+    return null;
+  end if;
+
+  -- Pull the per-account balance change (sign + post-balance). Indexer
+  -- writes this in common.ProcessBalanceChanges before claimable_tokens
+  -- handling, so it's guaranteed to be visible.
+  select change, balance, block_timestamp
+    into change_value, balance_value, block_ts
+    from sol_token_account_balance_changes
+   where signature = new.signature
+     and account = new.from_account
+   limit 1;
+
+  insert into notification
+    (slot, user_ids, timestamp, type, specifier, group_id, data)
+  values
+    (
+      new.slot,
+      ARRAY[users_row.user_id],
+      coalesce(block_ts, now()),
+      notification_type,
+      users_row.user_id,
+      notification_type || ':' || users_row.user_id || ':' || 'signature:' || new.signature,
+      json_build_object(
+        'user_id', users_row.user_id,
+        'user_bank', new.from_account,
+        'signature', new.signature,
+        'change', change_value,
+        'balance', balance_value,
+        'receiver_account', new.to_account
+      )
+    )
+    on conflict do nothing;
+
+  return null;
+  exception
+    when others then
+        raise warning 'An error occurred in %: %', tg_name, sqlerrm;
+        return null;
+end;
+$$ language plpgsql;
+
+do $$ begin
+  create trigger on_sol_usdc_withdrawal
+  after insert on sol_claimable_account_transfers
+  for each row execute procedure handle_sol_usdc_withdrawal();
+exception
+  when others then null;
+end $$;

--- a/ddl/migrations/0205_sol_transfer_memo_tables.sql
+++ b/ddl/migrations/0205_sol_transfer_memo_tables.sql
@@ -1,0 +1,25 @@
+BEGIN;
+SET LOCAL statement_timeout = 0;
+
+-- Memo-derived transfer classifications. One row per (signature,
+-- instruction_index) where the enclosing transaction's memo (or, for
+-- Jupiter-touching transactions, the program list) identifies the transfer
+-- as a non-bare type — `withdrawal`, `prepare_withdrawal`,
+-- `internal_transfer`, or `recover_withdrawal`. Joins by
+-- (signature, instruction_index) to either sol_claimable_account_transfers
+-- (the first three) or sol_payments (recover_withdrawal). Drives the type
+-- derivation in v_token_transactions_history without duplicating the
+-- transfer/payment data itself.
+CREATE TABLE IF NOT EXISTS sol_transfer_memo_types (
+    signature VARCHAR NOT NULL,
+    instruction_index INTEGER NOT NULL,
+    slot BIGINT NOT NULL,
+    memo_type VARCHAR NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (signature, instruction_index)
+);
+COMMENT ON TABLE sol_transfer_memo_types IS 'Memo-tagged classifications for claimable_tokens transfers and payment_router routes. memo_type is one of: withdrawal, prepare_withdrawal, internal_transfer, recover_withdrawal.';
+CREATE INDEX IF NOT EXISTS sol_transfer_memo_types_slot_idx ON sol_transfer_memo_types (slot);
+CREATE INDEX IF NOT EXISTS sol_transfer_memo_types_type_idx ON sol_transfer_memo_types (memo_type);
+
+COMMIT;

--- a/ddl/migrations/0206_backfill_sol_transfer_memo_types.sql
+++ b/ddl/migrations/0206_backfill_sol_transfer_memo_types.sql
@@ -1,0 +1,48 @@
+BEGIN;
+SET LOCAL statement_timeout = 0;
+
+-- Backfill sol_transfer_memo_types from the legacy
+-- usdc_transactions_history table so v_token_transactions_history can
+-- classify historical USDC transfers correctly before the Go indexer has
+-- reprocessed them.
+--
+-- Notification safety: handle_sol_usdc_withdrawal triggers on
+-- sol_claimable_account_transfers, NOT on sol_transfer_memo_types — these
+-- INSERTs do not fire it. Historical sol_claimable_account_transfers rows
+-- were inserted before this PR existed so the trigger did not exist for
+-- them either; we are tagging already-inserted rows.
+--
+-- Coverage:
+--   withdrawal / prepare_withdrawal / internal_transfer
+--     -> claimable_tokens Transfer, joined via sol_claimable_account_transfers
+--   recover_withdrawal
+--     -> payment_router Route, joined via sol_payments
+--
+-- Skipped (intentional):
+--   transfer            — no marker needed (bare transfer is the view's default)
+--   purchase_content    — already covered by sol_purchases
+--   purchase_stripe / coinbase / unknown — out of scope until vendor-memo
+--                         capture lands on the Go token indexer
+
+-- Claimable-tokens transfer memo types.
+INSERT INTO sol_transfer_memo_types (signature, instruction_index, slot, memo_type)
+SELECT cat.signature, cat.instruction_index, cat.slot,
+       uth.transaction_type
+  FROM usdc_transactions_history uth
+  JOIN sol_claimable_account_transfers cat
+    ON cat.signature = uth.signature
+ WHERE uth.transaction_type IN ('withdrawal', 'prepare_withdrawal', 'internal_transfer')
+ON CONFLICT (signature, instruction_index) DO NOTHING;
+
+-- Payment-router recovery memo type. Multiple payment rows can share a
+-- signature (one per route destination); DISTINCT keeps the dedup explicit
+-- before ON CONFLICT collapses the rest.
+INSERT INTO sol_transfer_memo_types (signature, instruction_index, slot, memo_type)
+SELECT DISTINCT p.signature, p.instruction_index, p.slot, 'recover_withdrawal'
+  FROM usdc_transactions_history uth
+  JOIN sol_payments p
+    ON p.signature = uth.signature
+ WHERE uth.transaction_type = 'recover_withdrawal'
+ON CONFLICT (signature, instruction_index) DO NOTHING;
+
+COMMIT;

--- a/ddl/views/v_token_transactions_history.sql
+++ b/ddl/views/v_token_transactions_history.sql
@@ -18,10 +18,14 @@ SELECT
       -- Reward disbursement to this user_bank (USER_REWARD or TRENDING_REWARD).
       WHEN rd.signature IS NOT NULL THEN
         CASE WHEN c.type = 'trending' THEN 'trending_reward' ELSE 'user_reward' END
-      -- Content purchase via Payment Router (USDC). Checked before the claimable
-      -- branch since these never overlap, but ordered defensively so a purchase
-      -- never gets misclassified as a generic transfer.
+      -- Content purchase via Payment Router (USDC). Checked before the
+      -- recover_withdrawal branch because on chain they're mutually exclusive;
+      -- if both somehow appeared a content purchase is the higher-fidelity label.
       WHEN p.signature IS NOT NULL THEN 'purchase_content'
+      -- Memo-tagged transfer types. sol_transfer_memo_types is populated by
+      -- the program indexer when a recognized memo (or, for prepare_withdrawal,
+      -- the Jupiter program) accompanies the claimable transfer / route.
+      WHEN tmt.memo_type IS NOT NULL THEN tmt.memo_type
       -- Claimable Tokens transfer (in or out). Tips are claimable transfers where
       -- both endpoints resolve to distinct Audius users; everything else is a
       -- bare transfer.
@@ -38,9 +42,14 @@ SELECT
     -- Match legacy audio_transactions_history.tx_metadata format:
     --   tips: str(counterpart_user_id)
     --   rewards: challenge_id
+    --   withdrawal: the on-chain destination account (legacy stored the
+    --     resolved wallet; the Go indexer surfaces cat.to_account as the
+    --     closest equivalent — resolved-wallet capture is a follow-up).
     --   else: null
     CASE
       WHEN rd.signature IS NOT NULL THEN rd.challenge_id
+      WHEN tmt.memo_type = 'withdrawal' AND cat.to_account IS NOT NULL
+        THEN cat.to_account
       WHEN cat.signature IS NOT NULL AND bc.change > 0 AND from_owner.user_id IS NOT NULL
         THEN from_owner.user_id::text
       WHEN cat.signature IS NOT NULL AND bc.change < 0 AND to_owner.user_id IS NOT NULL
@@ -76,6 +85,8 @@ LEFT JOIN challenges c
     ON c.id = rd.challenge_id
 LEFT JOIN sol_purchases p
     ON p.signature = bc.signature
-   AND p.from_account = bc.account;
+   AND p.from_account = bc.account
+LEFT JOIN sol_transfer_memo_types tmt
+    ON tmt.signature = bc.signature;
 
-COMMENT ON VIEW v_token_transactions_history IS 'Mint-agnostic transactions history derived from sol_token_account_balance_changes (the hub: only table with both mint and block_timestamp). Per-row transaction_type derived by LEFT JOIN to typed tables (sol_claimable_account_transfers, sol_reward_disbursements, sol_purchases). Callers filter by mint at query time. Powers /v1/users/{id}/transactions/audio today; will power /transactions/usdc once sol_withdrawals + vendor-memo capture land. Vendor purchase types (PURCHASE_STRIPE/COINBASE/UNKNOWN) degrade to bare transfer until that indexer work ships.';
+COMMENT ON VIEW v_token_transactions_history IS 'Mint-agnostic transactions history derived from sol_token_account_balance_changes (the hub: only table with both mint and block_timestamp). Per-row transaction_type derived by LEFT JOIN to typed tables (sol_claimable_account_transfers, sol_reward_disbursements, sol_purchases, sol_transfer_memo_types). Callers filter by mint at query time. Vendor purchase types (PURCHASE_STRIPE/COINBASE/UNKNOWN) on AUDIO still degrade to bare transfer until the AUDIO mint subscription + vendor-memo capture land.';

--- a/solana/indexer/program/claimable_tokens.go
+++ b/solana/indexer/program/claimable_tokens.go
@@ -76,6 +76,19 @@ func processClaimableTokensInstruction(
 						return fmt.Errorf("failed to parse signed transfer data at instruction %d: %w", instructionIndex-1, err)
 					}
 				}
+				// Insert the memo marker BEFORE the transfer row so the
+				// AFTER INSERT trigger on sol_claimable_account_transfers
+				// (handle_sol_usdc_withdrawal) can resolve the memo_type when
+				// it fires — without this ordering it would default every
+				// outbound USDC notification to `usdc_transfer`.
+				transferType := findTransferTypeMemo(tx)
+				if transferType == TransferTypeUnknown && transactionTouchesJupiter(tx) {
+					transferType = TransferTypePrepareWithdrawal
+				}
+				if err := insertTransferTypeMarker(ctx, db, transferType, signature, instructionIndex, slot); err != nil {
+					return fmt.Errorf("failed to insert transfer-type marker at instruction %d: %w", instructionIndex, err)
+				}
+
 				err = insertClaimableAccountTransfer(ctx, db, claimableAccountTransfersRow{
 					signature:        signature,
 					instructionIndex: instructionIndex,
@@ -87,16 +100,6 @@ func processClaimableTokensInstruction(
 				})
 				if err != nil {
 					return fmt.Errorf("failed to insert claimable tokens transfer at instruction %d: %w", instructionIndex, err)
-				}
-
-				// Classify by memo (or by Jupiter presence) into one of the
-				// derived tables that v_token_transactions_history reads.
-				transferType := findTransferTypeMemo(tx)
-				if transferType == TransferTypeUnknown && transactionTouchesJupiter(tx) {
-					transferType = TransferTypePrepareWithdrawal
-				}
-				if err := insertTransferTypeMarker(ctx, db, transferType, signature, instructionIndex, slot); err != nil {
-					return fmt.Errorf("failed to insert transfer-type marker at instruction %d: %w", instructionIndex, err)
 				}
 
 				instLogger.Info("claimable_tokens transfer",

--- a/solana/indexer/program/claimable_tokens.go
+++ b/solana/indexer/program/claimable_tokens.go
@@ -88,16 +88,63 @@ func processClaimableTokensInstruction(
 				if err != nil {
 					return fmt.Errorf("failed to insert claimable tokens transfer at instruction %d: %w", instructionIndex, err)
 				}
+
+				// Classify by memo (or by Jupiter presence) into one of the
+				// derived tables that v_token_transactions_history reads.
+				transferType := findTransferTypeMemo(tx)
+				if transferType == TransferTypeUnknown && transactionTouchesJupiter(tx) {
+					transferType = TransferTypePrepareWithdrawal
+				}
+				if err := insertTransferTypeMarker(ctx, db, transferType, signature, instructionIndex, slot); err != nil {
+					return fmt.Errorf("failed to insert transfer-type marker at instruction %d: %w", instructionIndex, err)
+				}
+
 				instLogger.Info("claimable_tokens transfer",
 					zap.String("ethAddress", transferInst.SenderEthAddress.String()),
 					zap.String("userBank", transferInst.SenderUserBank().PublicKey.String()),
 					zap.String("destination", transferInst.Destination().PublicKey.String()),
 					zap.Uint64("amount", signedData.Amount),
+					zap.Stringer("transferType", transferType),
 				)
 			}
 		}
 	}
 	return nil
+}
+
+// insertTransferTypeMarker writes a row into sol_transfer_memo_types tagging
+// the given (signature, instruction_index) with its memo-derived type.
+// TransferTypeUnknown is a no-op — bare transfers don't get a marker row.
+func insertTransferTypeMarker(ctx context.Context, db database.DBTX, t TransferType, signature string, instructionIndex int, slot uint64) error {
+	if t == TransferTypeUnknown {
+		return nil
+	}
+	sql := `
+		INSERT INTO sol_transfer_memo_types (signature, instruction_index, slot, memo_type)
+		VALUES (@signature, @instructionIndex, @slot, @memoType)
+		ON CONFLICT DO NOTHING
+	;`
+	_, err := db.Exec(ctx, sql, pgx.NamedArgs{
+		"signature":        signature,
+		"instructionIndex": instructionIndex,
+		"slot":             slot,
+		"memoType":         t.String(),
+	})
+	return err
+}
+
+func (t TransferType) String() string {
+	switch t {
+	case TransferTypeWithdrawal:
+		return "withdrawal"
+	case TransferTypePrepareWithdrawal:
+		return "prepare_withdrawal"
+	case TransferTypeInternalTransfer:
+		return "internal_transfer"
+	case TransferTypeRecoverWithdrawal:
+		return "recover_withdrawal"
+	}
+	return "unknown"
 }
 
 type claimableAccountsRow struct {

--- a/solana/indexer/program/memos.go
+++ b/solana/indexer/program/memos.go
@@ -14,6 +14,80 @@ import (
 // OLD_MEMO_PROGRAM_ID is the old memo program ID used for legacy memos.
 var OLD_MEMO_PROGRAM_ID = solana.MustPublicKeyFromBase58("Memo1UhkJRfHyvLMcVucJwxXeuD728EqVDDwQDxFMNo")
 
+// Jupiter V6 router. When this program is in a claimable_tokens transfer's
+// account_keys, the transfer is the "prepare" step of a swap-out withdrawal
+// (user_bank USDC → some other token via Jupiter), regardless of memo.
+var JUPITER_V6_PROGRAM_ID = solana.MustPublicKeyFromBase58("JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4")
+
+// TransferType is the classification a claimable_tokens transfer or
+// payment_router route gets based on the memos in its transaction.
+type TransferType int
+
+const (
+	// TransferTypeUnknown means no recognized type memo was found — treat as
+	// a bare transfer.
+	TransferTypeUnknown TransferType = iota
+	TransferTypeWithdrawal
+	TransferTypePrepareWithdrawal
+	TransferTypeInternalTransfer
+	TransferTypeRecoverWithdrawal
+)
+
+// Memo string constants — these match the strings the legacy Python indexer
+// (and the Audius web clients) write into the memo instruction at send time.
+const (
+	memoWithdrawal         = "Withdrawal"
+	memoPrepareWithdrawal  = "Prepare Withdrawal"
+	memoInternalTransfer   = "Internal Transfer"
+	memoRecoverWithdrawal  = "Recover Withdrawal"
+)
+
+// parseTransferTypeMemo returns the TransferType that matches the memo's
+// exact string, or TransferTypeUnknown if it doesn't match any known label.
+func parseTransferTypeMemo(memo []byte) TransferType {
+	switch string(memo) {
+	case memoWithdrawal:
+		return TransferTypeWithdrawal
+	case memoPrepareWithdrawal:
+		return TransferTypePrepareWithdrawal
+	case memoInternalTransfer:
+		return TransferTypeInternalTransfer
+	case memoRecoverWithdrawal:
+		return TransferTypeRecoverWithdrawal
+	}
+	return TransferTypeUnknown
+}
+
+// findTransferTypeMemo scans every memo instruction in the transaction and
+// returns the first recognized TransferType. Unlike findNextPurchaseMemo it
+// scans from the beginning — memos can land anywhere in the instruction list
+// (e.g. before the secp256k1 signature or after the Transfer call), and
+// there's at most one type-label memo per transaction in practice.
+func findTransferTypeMemo(tx *solana.Transaction) TransferType {
+	for _, inst := range tx.Message.Instructions {
+		programId := tx.Message.AccountKeys[inst.ProgramIDIndex]
+		if programId.Equals(solana.MemoProgramID) || programId.Equals(OLD_MEMO_PROGRAM_ID) {
+			if t := parseTransferTypeMemo(inst.Data); t != TransferTypeUnknown {
+				return t
+			}
+		}
+	}
+	return TransferTypeUnknown
+}
+
+// transactionTouchesJupiter reports whether the Jupiter V6 router appears in
+// the transaction's account_keys (including LUT-resolved entries). Used by
+// the claimable_tokens classifier to mark a transfer as "prepare withdrawal"
+// even when the memo is missing.
+func transactionTouchesJupiter(tx *solana.Transaction) bool {
+	for _, key := range tx.Message.AccountKeys {
+		if key.Equals(JUPITER_V6_PROGRAM_ID) {
+			return true
+		}
+	}
+	return false
+}
+
 type parsedPurchaseMemo struct {
 	ContentType           string
 	ContentId             int

--- a/solana/indexer/program/memos_test.go
+++ b/solana/indexer/program/memos_test.go
@@ -3,8 +3,33 @@ package program
 import (
 	"testing"
 
+	"github.com/gagliardetto/solana-go"
 	"github.com/test-go/testify/assert"
 )
+
+// makeMemoOnlyTx constructs a minimal solana.Transaction whose only
+// instruction is a memo with the given payload, so the scanner helpers can be
+// exercised without pulling in a real on-chain fixture.
+func makeMemoOnlyTx(payload string) *solana.Transaction {
+	tx := &solana.Transaction{}
+	tx.Message.AccountKeys = solana.PublicKeySlice{solana.MemoProgramID}
+	tx.Message.Instructions = []solana.CompiledInstruction{
+		{
+			ProgramIDIndex: 0,
+			Data:           []byte(payload),
+		},
+	}
+	return tx
+}
+
+// makeJupiterTouchingTx returns a transaction whose account_keys include the
+// Jupiter V6 router — the prepare-withdrawal-by-program fallback should fire
+// even without a "Prepare Withdrawal" memo.
+func makeJupiterTouchingTx() *solana.Transaction {
+	tx := &solana.Transaction{}
+	tx.Message.AccountKeys = solana.PublicKeySlice{JUPITER_V6_PROGRAM_ID}
+	return tx
+}
 
 func TestParsePurchaseMemo(t *testing.T) {
 	// happy case
@@ -28,6 +53,51 @@ func TestParsePurchaseMemo(t *testing.T) {
 	assert.EqualError(t, err, "failed to parse validAfterBlocknumber: strconv.Atoi: parsing \"foo\": invalid syntax")
 	_, err = parsePurchaseMemo([]byte("track:1:2:foo:download"))
 	assert.EqualError(t, err, "failed to parse buyerUserId: strconv.Atoi: parsing \"foo\": invalid syntax")
+}
+
+func TestParseTransferTypeMemo(t *testing.T) {
+	cases := []struct {
+		memo string
+		want TransferType
+	}{
+		{"Withdrawal", TransferTypeWithdrawal},
+		{"Prepare Withdrawal", TransferTypePrepareWithdrawal},
+		{"Internal Transfer", TransferTypeInternalTransfer},
+		{"Recover Withdrawal", TransferTypeRecoverWithdrawal},
+		{"withdrawal", TransferTypeUnknown},   // case-sensitive
+		{"track:1:2:3:download", TransferTypeUnknown},
+		{"", TransferTypeUnknown},
+	}
+	for _, c := range cases {
+		assert.Equal(t, c.want, parseTransferTypeMemo([]byte(c.memo)), c.memo)
+	}
+}
+
+func TestFindTransferTypeMemo(t *testing.T) {
+	// A memo-only tx with a recognized payload should be classified.
+	assert.Equal(t, TransferTypeWithdrawal, findTransferTypeMemo(makeMemoOnlyTx("Withdrawal")))
+	assert.Equal(t, TransferTypeInternalTransfer, findTransferTypeMemo(makeMemoOnlyTx("Internal Transfer")))
+
+	// Unrecognized payload returns Unknown.
+	assert.Equal(t, TransferTypeUnknown, findTransferTypeMemo(makeMemoOnlyTx("Hello")))
+
+	// Empty tx returns Unknown.
+	assert.Equal(t, TransferTypeUnknown, findTransferTypeMemo(&solana.Transaction{}))
+}
+
+func TestTransactionTouchesJupiter(t *testing.T) {
+	assert.True(t, transactionTouchesJupiter(makeJupiterTouchingTx()))
+	assert.False(t, transactionTouchesJupiter(makeMemoOnlyTx("Withdrawal")))
+	assert.False(t, transactionTouchesJupiter(&solana.Transaction{}))
+}
+
+func TestTransferTypeString(t *testing.T) {
+	// String values must match the legacy `transaction_type` strings the API
+	// returns, since the view inserts them directly into the `memo_type` column.
+	assert.Equal(t, "withdrawal", TransferTypeWithdrawal.String())
+	assert.Equal(t, "prepare_withdrawal", TransferTypePrepareWithdrawal.String())
+	assert.Equal(t, "internal_transfer", TransferTypeInternalTransfer.String())
+	assert.Equal(t, "recover_withdrawal", TransferTypeRecoverWithdrawal.String())
 }
 
 func TestParseLocationMemo(t *testing.T) {

--- a/solana/indexer/program/payment_router.go
+++ b/solana/indexer/program/payment_router.go
@@ -51,6 +51,16 @@ func processPaymentRouterInstruction(
 				}
 			}
 
+			// Recover-withdrawal route: tag it so v_token_transactions_history
+			// reports `recover_withdrawal` instead of a bare transfer. Detected
+			// independently of the purchase-memo branch because the two memo
+			// types are mutually exclusive on chain.
+			if findTransferTypeMemo(tx) == TransferTypeRecoverWithdrawal {
+				if err := insertTransferTypeMarker(ctx, db, TransferTypeRecoverWithdrawal, signature, instructionIndex, slot); err != nil {
+					return fmt.Errorf("failed to insert recover_withdrawal marker at instruction %d: %w", instructionIndex, err)
+				}
+			}
+
 			parsedPurchaseMemo, ok := findNextPurchaseMemo(tx, instructionIndex, instLogger)
 			if ok {
 				parsedLocationMemo := findNextLocationMemo(tx, instructionIndex, instLogger)

--- a/solana/indexer/token/indexer.go
+++ b/solana/indexer/token/indexer.go
@@ -229,6 +229,18 @@ func (d *Indexer) HandleUpdate(ctx context.Context, msg *pb.SubscribeUpdate) err
 		if err != nil {
 			return fmt.Errorf("failed to process balance changes: %w", err)
 		}
+
+		// Detect AUDIO top-up memos (Stripe / Coinbase Pay / Unknown) and tag
+		// the signature in sol_transfer_memo_types so
+		// v_token_transactions_history surfaces transaction_type as the right
+		// purchase_* value instead of a bare transfer. Cheap: scans
+		// instructions once, skips non-memo programs immediately. Idempotent
+		// via ON CONFLICT.
+		if memoType, instIdx, ok := findAudioVendorMemoType(tx); ok {
+			if err := insertAudioVendorMemoMarker(ctx, d.pool, txSig.String(), instIdx, txRes.Slot, memoType); err != nil {
+				logger.Warn("failed to insert audio vendor memo marker", zap.Error(err))
+			}
+		}
 	}
 	return nil
 }

--- a/solana/indexer/token/memos.go
+++ b/solana/indexer/token/memos.go
@@ -1,0 +1,67 @@
+package token
+
+import (
+	"context"
+	"strings"
+
+	"api.audius.co/database"
+	"github.com/gagliardetto/solana-go"
+	"github.com/jackc/pgx/v5"
+)
+
+// OLD_MEMO_PROGRAM_ID is the legacy memo program ID; some clients still
+// emit memos under this one alongside the canonical solana.MemoProgramID.
+var oldMemoProgramID = solana.MustPublicKeyFromBase58("Memo1UhkJRfHyvLMcVucJwxXeuD728EqVDDwQDxFMNo")
+
+// Vendor map for AUDIO top-up memos written by the web client / wAUDIO
+// Stripe-Coinbase rails (mirrors the Python index_spl_token purchase_vendor_map).
+// Memo format: "In-App $AUDIO Purchase: <Vendor>"
+const audioPurchaseMemoPrefix = "In-App $AUDIO Purchase: "
+
+var audioPurchaseVendorMemoTypes = map[string]string{
+	"Link by Stripe": "purchase_stripe",
+	"Coinbase Pay":   "purchase_coinbase",
+	"Unknown":        "purchase_unknown",
+}
+
+// findAudioVendorMemoType scans every memo instruction in the transaction for
+// the AUDIO vendor purchase prefix and returns the matching memo_type string
+// (purchase_stripe / purchase_coinbase / purchase_unknown) along with the
+// instruction index where the memo was found. Returns ("", -1, false) if no
+// recognized vendor memo is present.
+func findAudioVendorMemoType(tx *solana.Transaction) (memoType string, instructionIndex int, ok bool) {
+	for i, inst := range tx.Message.Instructions {
+		programId := tx.Message.AccountKeys[inst.ProgramIDIndex]
+		if !programId.Equals(solana.MemoProgramID) && !programId.Equals(oldMemoProgramID) {
+			continue
+		}
+		data := string(inst.Data)
+		if !strings.HasPrefix(data, audioPurchaseMemoPrefix) {
+			continue
+		}
+		vendor := strings.TrimPrefix(data, audioPurchaseMemoPrefix)
+		if t, found := audioPurchaseVendorMemoTypes[vendor]; found {
+			return t, i, true
+		}
+	}
+	return "", -1, false
+}
+
+// insertAudioVendorMemoMarker writes a row into sol_transfer_memo_types so
+// v_token_transactions_history classifies the balance change as the right
+// purchase_* type instead of a bare transfer. Same destination table as the
+// claimable-tokens / payment-router memo markers — the view reads memo_type
+// by signature, so a single (signature, instruction_index) row is enough.
+func insertAudioVendorMemoMarker(ctx context.Context, db database.DBTX, signature string, instructionIndex int, slot uint64, memoType string) error {
+	_, err := db.Exec(ctx, `
+		INSERT INTO sol_transfer_memo_types (signature, instruction_index, slot, memo_type)
+		VALUES (@signature, @instructionIndex, @slot, @memoType)
+		ON CONFLICT DO NOTHING
+	;`, pgx.NamedArgs{
+		"signature":        signature,
+		"instructionIndex": instructionIndex,
+		"slot":             slot,
+		"memoType":         memoType,
+	})
+	return err
+}

--- a/solana/indexer/token/memos_test.go
+++ b/solana/indexer/token/memos_test.go
@@ -1,0 +1,83 @@
+package token
+
+import (
+	"testing"
+
+	"github.com/gagliardetto/solana-go"
+	"github.com/test-go/testify/assert"
+)
+
+// makeMemoTx builds a minimal solana.Transaction whose instructions are a
+// list of memo-program payloads in order. Anything in `payloads` becomes a
+// memo instruction; non-memo instructions are not modelled (findAudioVendorMemoType
+// only cares about memo-program entries anyway).
+func makeMemoTx(payloads ...string) *solana.Transaction {
+	tx := &solana.Transaction{}
+	tx.Message.AccountKeys = solana.PublicKeySlice{solana.MemoProgramID}
+	for _, p := range payloads {
+		tx.Message.Instructions = append(tx.Message.Instructions, solana.CompiledInstruction{
+			ProgramIDIndex: 0,
+			Data:           []byte(p),
+		})
+	}
+	return tx
+}
+
+func TestFindAudioVendorMemoType(t *testing.T) {
+	cases := []struct {
+		name     string
+		payloads []string
+		wantType string
+		wantOk   bool
+	}{
+		{
+			name:     "stripe",
+			payloads: []string{"In-App $AUDIO Purchase: Link by Stripe"},
+			wantType: "purchase_stripe",
+			wantOk:   true,
+		},
+		{
+			name:     "coinbase",
+			payloads: []string{"In-App $AUDIO Purchase: Coinbase Pay"},
+			wantType: "purchase_coinbase",
+			wantOk:   true,
+		},
+		{
+			name:     "unknown",
+			payloads: []string{"In-App $AUDIO Purchase: Unknown"},
+			wantType: "purchase_unknown",
+			wantOk:   true,
+		},
+		{
+			name:     "unrecognized vendor name skipped",
+			payloads: []string{"In-App $AUDIO Purchase: Apple Pay"},
+			wantOk:   false,
+		},
+		{
+			name:     "non-vendor memo skipped",
+			payloads: []string{"Withdrawal"},
+			wantOk:   false,
+		},
+		{
+			name:     "empty tx",
+			payloads: nil,
+			wantOk:   false,
+		},
+		{
+			name:     "picks first matching vendor when multiple memos present",
+			payloads: []string{"some other memo", "In-App $AUDIO Purchase: Link by Stripe"},
+			wantType: "purchase_stripe",
+			wantOk:   true,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			gotType, gotIdx, gotOk := findAudioVendorMemoType(makeMemoTx(c.payloads...))
+			assert.Equal(t, c.wantOk, gotOk)
+			if c.wantOk {
+				assert.Equal(t, c.wantType, gotType)
+				assert.True(t, gotIdx >= 0)
+			}
+		})
+	}
+}

--- a/sql/01_schema.sql
+++ b/sql/01_schema.sql
@@ -3958,6 +3958,98 @@ $$;
 
 
 --
+-- Name: handle_sol_usdc_withdrawal(); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.handle_sol_usdc_withdrawal() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+DECLARE
+    users_row users%ROWTYPE;
+    mint_addr varchar;
+    memo_type_str varchar;
+    notification_type varchar;
+    change_value bigint;
+    balance_value bigint;
+    block_ts timestamp;
+begin
+  -- Resolve sender's mint + user via sol_claimable_accounts. Skip rows
+  -- whose from_account isn't a tracked user_bank, and skip non-USDC mints
+  -- (AUDIO is not part of the legacy withdrawal-notification surface).
+  select sca.mint into mint_addr
+    from sol_claimable_accounts sca
+   where sca.account = new.from_account
+   limit 1;
+  select u.* into users_row
+    from users u
+    join sol_claimable_accounts sca on sca.ethereum_address = u.wallet
+   where sca.account = new.from_account
+     and u.is_current = true
+   limit 1;
+
+  if mint_addr is null or mint_addr not in (
+        'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v', -- prod/stage USDC
+        '26Q7gP8UfkDzi7GMFEQxTJaNJ8D2ybCUjex58M5MLu8y'  -- dev USDC
+      ) then
+    return null;
+  end if;
+
+  -- Look up memo type. The legacy trigger only notified for `transfer` and
+  -- `withdrawal` — so we skip prepare_withdrawal / internal_transfer /
+  -- recover_withdrawal to preserve that behavior.
+  select memo_type into memo_type_str
+    from sol_transfer_memo_types
+   where signature = new.signature and instruction_index = new.instruction_index;
+
+  if memo_type_str is null then
+    notification_type := 'usdc_transfer';
+  elsif memo_type_str = 'withdrawal' then
+    notification_type := 'usdc_withdrawal';
+  else
+    return null;
+  end if;
+
+  -- Pull the per-account balance change (sign + post-balance). Indexer
+  -- writes this in common.ProcessBalanceChanges before claimable_tokens
+  -- handling, so it's guaranteed to be visible.
+  select change, balance, block_timestamp
+    into change_value, balance_value, block_ts
+    from sol_token_account_balance_changes
+   where signature = new.signature
+     and account = new.from_account
+   limit 1;
+
+  insert into notification
+    (slot, user_ids, timestamp, type, specifier, group_id, data)
+  values
+    (
+      new.slot,
+      ARRAY[users_row.user_id],
+      coalesce(block_ts, now()),
+      notification_type,
+      users_row.user_id,
+      notification_type || ':' || users_row.user_id || ':' || 'signature:' || new.signature,
+      json_build_object(
+        'user_id', users_row.user_id,
+        'user_bank', new.from_account,
+        'signature', new.signature,
+        'change', change_value,
+        'balance', balance_value,
+        'receiver_account', new.to_account
+      )
+    )
+    on conflict do nothing;
+
+  return null;
+  exception
+    when others then
+        raise warning 'An error occurred in %: %', tg_name, sqlerrm;
+        return null;
+end;
+$$;
+
+
+--
 -- Name: handle_supporter_rank_up(); Type: FUNCTION; Schema: public; Owner: -
 --
 
@@ -8988,6 +9080,26 @@ COMMENT ON TABLE public.sol_token_transfers IS 'Stores SPL token transfers for t
 
 
 --
+-- Name: sol_transfer_memo_types; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.sol_transfer_memo_types (
+    signature character varying NOT NULL,
+    instruction_index integer NOT NULL,
+    slot bigint NOT NULL,
+    memo_type character varying NOT NULL,
+    created_at timestamp without time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: TABLE sol_transfer_memo_types; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON TABLE public.sol_transfer_memo_types IS 'Memo-tagged classifications for claimable_tokens transfers and payment_router routes. memo_type is one of: withdrawal, prepare_withdrawal, internal_transfer, recover_withdrawal.';
+
+
+--
 -- Name: sol_user_balances; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -9762,17 +9874,19 @@ CREATE VIEW public.v_token_transactions_history AS
                 ELSE 'user_reward'::text
             END
             WHEN (p.signature IS NOT NULL) THEN 'purchase_content'::text
+            WHEN (tmt.memo_type IS NOT NULL) THEN (tmt.memo_type)::text
             WHEN ((cat.signature IS NOT NULL) AND (from_owner.user_id IS NOT NULL) AND (to_owner.user_id IS NOT NULL) AND (from_owner.user_id <> to_owner.user_id)) THEN 'tip'::text
             WHEN (cat.signature IS NOT NULL) THEN 'transfer'::text
             ELSE 'transfer'::text
         END AS transaction_type,
         CASE
             WHEN (rd.signature IS NOT NULL) THEN rd.challenge_id
+            WHEN (((tmt.memo_type)::text = 'withdrawal'::text) AND (cat.to_account IS NOT NULL)) THEN cat.to_account
             WHEN ((cat.signature IS NOT NULL) AND (bc.change > 0) AND (from_owner.user_id IS NOT NULL)) THEN ((from_owner.user_id)::text)::character varying
             WHEN ((cat.signature IS NOT NULL) AND (bc.change < 0) AND (to_owner.user_id IS NOT NULL)) THEN ((to_owner.user_id)::text)::character varying
             ELSE NULL::character varying
         END AS tx_metadata
-   FROM ((((((((((public.sol_token_account_balance_changes bc
+   FROM (((((((((((public.sol_token_account_balance_changes bc
      JOIN public.sol_claimable_accounts sca ON ((((sca.account)::text = (bc.account)::text) AND ((sca.mint)::text = (bc.mint)::text))))
      LEFT JOIN public.users ON ((((users.wallet)::text = (sca.ethereum_address)::text) AND (users.is_current = true))))
      LEFT JOIN public.sol_claimable_account_transfers cat ON ((((cat.signature)::text = (bc.signature)::text) AND (((cat.from_account)::text = (bc.account)::text) OR ((cat.to_account)::text = (bc.account)::text)))))
@@ -9782,14 +9896,15 @@ CREATE VIEW public.v_token_transactions_history AS
      LEFT JOIN public.users to_owner ON ((((to_owner.wallet)::text = (to_sca.ethereum_address)::text) AND (to_owner.is_current = true))))
      LEFT JOIN public.sol_reward_disbursements rd ON ((((rd.signature)::text = (bc.signature)::text) AND ((rd.user_bank)::text = (bc.account)::text))))
      LEFT JOIN public.challenges c ON (((c.id)::text = (rd.challenge_id)::text)))
-     LEFT JOIN public.sol_purchases p ON ((((p.signature)::text = (bc.signature)::text) AND ((p.from_account)::text = (bc.account)::text))));
+     LEFT JOIN public.sol_purchases p ON ((((p.signature)::text = (bc.signature)::text) AND ((p.from_account)::text = (bc.account)::text))))
+     LEFT JOIN public.sol_transfer_memo_types tmt ON (((tmt.signature)::text = (bc.signature)::text)));
 
 
 --
 -- Name: VIEW v_token_transactions_history; Type: COMMENT; Schema: public; Owner: -
 --
 
-COMMENT ON VIEW public.v_token_transactions_history IS 'Mint-agnostic transactions history derived from sol_token_account_balance_changes (the hub: only table with both mint and block_timestamp). Per-row transaction_type derived by LEFT JOIN to typed tables (sol_claimable_account_transfers, sol_reward_disbursements, sol_purchases). Callers filter by mint at query time. Powers /v1/users/{id}/transactions/audio today; will power /transactions/usdc once sol_withdrawals + vendor-memo capture land. Vendor purchase types (PURCHASE_STRIPE/COINBASE/UNKNOWN) degrade to bare transfer until that indexer work ships.';
+COMMENT ON VIEW public.v_token_transactions_history IS 'Mint-agnostic transactions history derived from sol_token_account_balance_changes (the hub: only table with both mint and block_timestamp). Per-row transaction_type derived by LEFT JOIN to typed tables (sol_claimable_account_transfers, sol_reward_disbursements, sol_purchases, sol_transfer_memo_types). Callers filter by mint at query time. Vendor purchase types (PURCHASE_STRIPE/COINBASE/UNKNOWN) on AUDIO still degrade to bare transfer until the AUDIO mint subscription + vendor-memo capture land.';
 
 
 --
@@ -11105,6 +11220,14 @@ ALTER TABLE ONLY public.sol_token_account_balances
 
 ALTER TABLE ONLY public.sol_token_transfers
     ADD CONSTRAINT sol_token_transfers_pkey PRIMARY KEY (signature, instruction_index);
+
+
+--
+-- Name: sol_transfer_memo_types sol_transfer_memo_types_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.sol_transfer_memo_types
+    ADD CONSTRAINT sol_transfer_memo_types_pkey PRIMARY KEY (signature, instruction_index);
 
 
 --
@@ -12725,6 +12848,20 @@ CREATE INDEX sol_token_transfers_to_account_idx ON public.sol_token_transfers US
 
 
 --
+-- Name: sol_transfer_memo_types_slot_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX sol_transfer_memo_types_slot_idx ON public.sol_transfer_memo_types USING btree (slot);
+
+
+--
+-- Name: sol_transfer_memo_types_type_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX sol_transfer_memo_types_type_idx ON public.sol_transfer_memo_types USING btree (memo_type);
+
+
+--
 -- Name: sol_user_balances_mint_user_id_idx; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -13142,6 +13279,13 @@ CREATE TRIGGER on_sol_token_account_balance_changes AFTER INSERT ON public.sol_t
 --
 
 COMMENT ON TRIGGER on_sol_token_account_balance_changes ON public.sol_token_account_balance_changes IS 'Updates sol_token_account_balances whenever a sol_token_balance_change is inserted with a higher slot.';
+
+
+--
+-- Name: sol_claimable_account_transfers on_sol_usdc_withdrawal; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER on_sol_usdc_withdrawal AFTER INSERT ON public.sol_claimable_account_transfers FOR EACH ROW EXECUTE FUNCTION public.handle_sol_usdc_withdrawal();
 
 
 --

--- a/sql/03_migration_tracker.sql
+++ b/sql/03_migration_tracker.sql
@@ -132,7 +132,6 @@ functions/handle_sol_token_balance_change.sql	212ea3ca708570c506051a167e1e9117	2
 functions/handle_supporter_rank_ups.sql	dea497f1859ade282b4f7d33687e6fe7	2026-05-27 00:22:37.633644+00
 functions/handle_track.sql	89ef5a957b3662310fb30f914aab9ed4	2026-05-27 00:22:37.715524+00
 functions/handle_usdc_purchase.sql	c35bccc2789ae0641d413d28a131ef8d	2026-05-27 00:22:37.800109+00
-functions/handle_usdc_withdrawal.sql	ad7910b1d374c1a195b4ebc154c18d7b	2026-05-27 00:22:37.876178+00
 functions/handle_user.sql	169778112e5362ee20af56d9b8f274c5	2026-05-27 00:22:37.955619+00
 functions/handle_user_balance_changes.sql	1ae7f99f4f37194cdf27dc3189ebc858	2026-05-27 00:22:38.02983+00
 functions/handle_user_challenges.sql	c2adfee92cab36dee37ab7b8af5449c1	2026-05-27 00:22:38.103198+00
@@ -146,11 +145,14 @@ functions/update_sol_user_balance.sql	4a297a671c74a683814ff217bd097589	2026-05-2
 functions/user_mint_balance_at.sql	6d227781d4d97500e0ec2bb76e8fa295	2026-05-27 00:22:38.701765+00
 views/artist_coin_prices.sql	10a65b64b7d13aaabe18ad1055e9fd7b	2026-05-27 00:22:38.820919+00
 views/v_challenge_disbursements.sql	74a0a05af6a02f82af3695d5c3ade45c	2026-05-27 00:22:38.899214+00
-views/v_token_transactions_history.sql	fd753db4177640b9cfed9ef6b6359d7d	2026-05-27 00:22:38.98482+00
 views/v_usdc_purchases.sql	322a527e132aed647c39b70d63aa6b51	2026-05-27 00:22:39.061667+00
 preflight/0001_initial_block.sql	1e59cca66b2208eda67a87ac0d09b67d	2026-05-27 00:22:39.249328+00
 migrations/0204_backfill_eth_wallet_balances_tracked.sql	d8b752794c42edb94f0d43633e14208c	2026-05-28 00:56:10.178339+00
 views/v_user_balances.sql	ff6db739c1a77101021d4629647a44df	2026-05-28 17:28:07.629633+00
+migrations/0205_sol_transfer_memo_tables.sql	49aa6bdf68df733710e7820153a78393	2026-05-28 19:54:42.181969+00
+migrations/0206_backfill_sol_transfer_memo_types.sql	8b63b2e420c94b740a15e7f1fbd02ae7	2026-05-28 19:54:42.266989+00
+functions/handle_usdc_withdrawal.sql	f590eb5d53ec82c63d3d2d7b1913cbef	2026-05-28 19:54:42.61986+00
+views/v_token_transactions_history.sql	a00eeaf663c8b16dd60e26b7c75a8fff	2026-05-28 19:54:42.836012+00
 \.
 
 


### PR DESCRIPTION
## Summary

Closes the seven legacy `transaction_type` classifications that the new sol_*-backed pipeline was dropping. Two indexers contribute markers to a single new `sol_transfer_memo_types` table, and `v_token_transactions_history` joins by signature to return the right type instead of degrading to a bare `transfer`.

## Memo handling

Memo strings match the legacy Python indexer + Audius web clients:

| Memo | Mapped type | Where it's parsed |
|---|---|---|
| `Withdrawal` | `withdrawal` | program indexer · claimable_tokens Transfer |
| `Prepare Withdrawal` | `prepare_withdrawal` | program indexer · claimable_tokens Transfer |
| `Internal Transfer` | `internal_transfer` | program indexer · claimable_tokens Transfer |
| `Recover Withdrawal` | `recover_withdrawal` | program indexer · payment_router Route |
| `In-App $AUDIO Purchase: Link by Stripe` | `purchase_stripe` | token indexer · SPL token transfer |
| `In-App $AUDIO Purchase: Coinbase Pay` | `purchase_coinbase` | token indexer · SPL token transfer |
| `In-App $AUDIO Purchase: Unknown` | `purchase_unknown` | token indexer · SPL token transfer |

Plus the Jupiter fallback in the program indexer: if Jupiter V6 (`JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4`) appears in the transaction's `account_keys`, the transfer is classified as `prepare_withdrawal` regardless of memo — same heuristic the Python indexer uses, covers swap-out withdrawals whose memo got stripped.

## Schema

One discriminated table, joined by signature to whatever balance-change / transfer row needs the label:

```sql
CREATE TABLE sol_transfer_memo_types (
    signature VARCHAR NOT NULL,
    instruction_index INTEGER NOT NULL,
    slot BIGINT NOT NULL,
    memo_type VARCHAR NOT NULL,
    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
    PRIMARY KEY (signature, instruction_index)
);
```

One-table-per-type vs. discriminated-column: the variants are structurally identical (a marker plus optional metadata that none of them carry), and consolidating keeps the view's JOIN count to one.

## View changes

`v_token_transactions_history` gets one LEFT JOIN to `sol_transfer_memo_types` and one new CASE branch ahead of the bare-transfer fallback. Because the view returns `memo_type` verbatim as `transaction_type`, adding the AUDIO vendor purchases needed zero view changes — just three new strings in the indexer's vendor map.

There's also a `tx_metadata` override for `memo_type='withdrawal'`: the view returns the claimable transfer's `to_account` (the closest on-chain proxy for the destination wallet). Fully resolved-wallet capture would still require additional SPL-token-side indexing — out of scope here.

## Two indexers, one table

Each handler owns a different on-chain path but writes to the same `sol_transfer_memo_types` table:

- **Program indexer** (`solana/indexer/program/`): in `processClaimableTokensInstruction`, after inserting the claimable transfer row, scan the tx for a recognized memo (or detect Jupiter) and call `insertTransferTypeMarker`. The marker is inserted *before* the transfer row so the `handle_sol_usdc_withdrawal` notification trigger (added here too) can read `memo_type` when it fires. Same logic for `processPaymentRouterInstruction` covers `recover_withdrawal`.
- **Token indexer** (`solana/indexer/token/`): in `HandleUpdate`, after `ProcessBalanceChanges`, run `findAudioVendorMemoType` and write the marker. This path covers Stripe/Coinbase top-ups, which arrive as direct SPL token transfers — they never touch the claimable_tokens or payment_router programs, so the program indexer can't see them. Works because `subscribeToArtistCoins` already covers wAUDIO (it's in `artist_coins` on prod), giving the token indexer the per-mint subscription it needs to fetch these transactions.

## Notification trigger

`handle_usdc_withdrawal` only fires on the legacy `usdc_transactions_history` insert. Added a sol-side parallel `handle_sol_usdc_withdrawal` triggering on `sol_claimable_account_transfers`, resolving the sender via `sol_claimable_accounts`, filtering to USDC mints, looking up `memo_type` for the `withdrawal` vs. plain `transfer` distinction, and emitting the same shape + group_id as the legacy trigger (so `on conflict do nothing` dedupes while both pipelines run side-by-side; once Python is decommissioned only this one fires). Same parallel-trigger pattern as `handle_sol_purchase` / `handle_sol_reward_disbursement`.

## Backfill

`0206_backfill_sol_transfer_memo_types.sql` joins legacy `usdc_transactions_history` to `sol_claimable_account_transfers` / `sol_payments` and inserts memo markers for historical rows. Inserts only into `sol_transfer_memo_types` — `handle_sol_usdc_withdrawal` triggers on `sol_claimable_account_transfers`, not on the marker table, so no new notifications fire for backfilled rows.

## Test plan

- [x] `go test ./solana/indexer/... -count=1` — green (program: `TestParseTransferTypeMemo`, `TestFindTransferTypeMemo`, `TestTransactionTouchesJupiter`, `TestTransferTypeString` + existing claimable / payment_router / reward suite. token: `TestFindAudioVendorMemoType` with 7 cases covering all three vendor strings, unrecognized vendor name, non-vendor memo, empty tx, and multi-memo tx)
- [x] `go test ./api/ -count=1` — full API suite green, including: `TestVTokenTransactionsHistory_MemoTaggedTransfers` (withdrawal / prepare_withdrawal / internal_transfer with tx_metadata override for withdrawal), `TestVTokenTransactionsHistory_RecoverWithdrawal`, `TestVTokenTransactionsHistory_AudioVendorPurchases` (all three vendor types end-to-end), `TestHandleSolUsdcWithdrawalTrigger` (notification trigger over claimable transfer + memo combination), `TestHandleSolUsdcWithdrawalTrigger_SkipsSystemTypes`
- [x] `make test-schema` regenerates a clean dump including the new table, view changes, and notification trigger

🤖 Generated with [Claude Code](https://claude.com/claude-code)