### PR TITLE
feat(for-you): include collections in /users/{id}/feed/for-you

### DIFF
--- a/api/swagger/swagger-v1.yaml
+++ b/api/swagger/swagger-v1.yaml
@@ -9482,10 +9482,14 @@ paths:
       summary: Get For You feed for user
       description:
         Returns a personalized For You feed for the user identified in the
-        path. Twitter-style multi-source pipeline — candidate retrieval
-        (in-network, trending, underground) → linear ranking (recency
-        decay × engagement × social affinity, weighted by source) →
-        diversity (per-artist cap + consecutive-same-artist lookahead).
+        path. The response is a heterogenous list of tracks and
+        playlists/albums (`{type, timestamp, item}` envelope), mirroring
+        the chronological /v1/users/{id}/feed shape so clients can render
+        both in a single ranked list. Twitter-style multi-source pipeline
+        — candidate retrieval (in-network, trending, underground) →
+        linear ranking (recency decay × engagement × social affinity,
+        weighted by source) → diversity (shared per-artist cap across
+        tracks + collections + consecutive-same-artist lookahead).
       operationId: Get User For You Feed
       security:
         - {}
@@ -9519,8 +9523,9 @@ paths:
         - name: max_per_artist
           in: query
           description:
-            Maximum number of tracks per artist on a single page. Used by the
-            diversity pass to cap consecutive same-artist results.
+            Maximum number of items (tracks or playlists/albums combined)
+            per artist on a single page. Used by the diversity pass to cap
+            consecutive same-artist results.
           schema:
             type: integer
             default: 3
@@ -9537,7 +9542,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/tracks"
+                $ref: "#/components/schemas/user_feed_response"
         "400":
           description: Bad request
           content: {}

--- a/api/v1_users_feed_for_you.go
+++ b/api/v1_users_feed_for_you.go
@@ -1,6 +1,8 @@
 package api
 
 import (
+	"time"
+
 	"api.audius.co/api/dbv1"
 	"github.com/gofiber/fiber/v2"
 	"github.com/jackc/pgx/v5"
@@ -12,69 +14,85 @@ type GetUsersFeedForYouParams struct {
 	MaxPerArtist int `query:"max_per_artist" default:"3" validate:"min=1,max=10"`
 }
 
-// v1FeedForYou returns a personalized "For You" track feed for the user
-// identified in the path. Modeled on Twitter's open-sourced 2023
-// algorithm (the-algorithm-ml). The shape of the pipeline is
-// candidate-retrieval → ranking → filtering+diversity, the same
-// three-stage pattern Twitter uses on top of a learned "heavy ranker."
-// Audius doesn't yet have a trained ranker, so the heavy ranker is
-// approximated by a hand-tuned linear blend below; the candidate
-// retrieval / diversity passes carry over directly so a learned model
-// can drop in later.
+// v1FeedForYou returns a personalized "For You" feed for the user
+// identified in the path. The response is a heterogenous list of
+// tracks and playlists/albums (`{type, timestamp, item}` items),
+// mirroring the chronological /v1/users/{id}/feed shape so clients can
+// render both in a single ranked list.
 //
-// 1. CANDIDATE RETRIEVAL (UNION across three sources, each capped):
-//   - in_network  — tracks uploaded in the last 14 days by users I follow.
-//     Strongest "this is for me" signal. Capped at 200.
-//   - trending    — top week-trending from track_trending_scores.
-//     Mirrors GET /tracks/trending. Capped at 100.
-//   - underground — week-trending tracks whose owner has < 1500
-//     follower & following count (mirrors GET /tracks/trending/underground).
+// Modeled on Twitter's open-sourced 2023 algorithm (the-algorithm-ml).
+// The shape of the pipeline is candidate-retrieval → ranking →
+// filtering+diversity, the same three-stage pattern Twitter uses on top
+// of a learned "heavy ranker." Audius doesn't yet have a trained ranker,
+// so the heavy ranker is approximated by a hand-tuned linear blend
+// below; the candidate retrieval / diversity passes carry over directly
+// so a learned model can drop in later.
+//
+// 1. CANDIDATE RETRIEVAL — six sources, three per entity type, each
+//    capped:
+//   - cand_in_network_track       — tracks uploaded in the last 14 days
+//     by users I follow. Capped at 200.
+//   - cand_trending_track         — top week-trending tracks
+//     (track_trending_scores). Mirrors GET /tracks/trending. Capped at 100.
+//   - cand_underground_track      — week-trending tracks whose owner has
+//     < 1500 follower & following count
+//     (mirrors GET /tracks/trending/underground). Capped at 50.
+//   - cand_in_network_playlist    — playlists/albums created in the last
+//     14 days by users I follow. Capped at 50.
+//   - cand_trending_playlist      — top week-trending playlists/albums
+//     (playlist_trending_scores). Mirrors GET /playlists/trending.
 //     Capped at 50.
+//   - cand_underground_playlist   — week-trending playlists/albums whose
+//     owner has < 1500 follower & following count. Capped at 25.
 //
-// The original v1 of this endpoint also had a 4th `similar_artists`
-// source — a 1-hop saves-graph collaborative filter. It was removed
-// because the saves self-join produced a 301M-row merge for power users
-// on prod and the endpoint never reliably completed within Cloudflare's
-// upstream limit. The three-source pipeline below is the lean
-// replacement.
+// Per-source caps are smaller for playlists because they're heavier
+// objects to hydrate downstream and rarer in the index — flooding the
+// pool with them would crowd out tracks under the shared per-artist cap.
 //
-// 2. RANKING — three light signals combined linearly:
+// 2. RANKING — three light signals combined linearly, identical formula
+// across types:
 //
 //	recency_score    = exp(-ln(2) * age_hours / 48)
 //	                   // 48h half-life: 48h-old → 0.5, 96h → 0.25
 //	engagement_score = ln(1 + 3*saves + 2*reposts + 1*plays) / 12
-//	                   // saves > reposts > plays, log-compressed
-//	social_boost     = 1.0 + min(my_affinity_with_artist / 4, 1)
-//	                   // up to ~2x for artists I already engage with often
+//	                   // saves > reposts > plays, log-compressed.
+//	                   // plays = 0 for playlists (no native play counter).
+//	social_boost     = 1.0 + min(my_affinity_with_owner / 4, 1)
+//	                   // up to ~2x for owners I already engage with often.
+//	                   // Affinity is built from saves+reposts of both
+//	                   // tracks AND playlists, plus plays of tracks.
 //	source_weight    = {in_network: 1.20, trending: 1.00,
 //	                    underground: 0.95}
 //
 //	final_score = (0.55 * recency_score + 0.45 * engagement_score)
 //	              * social_boost * source_weight
 //
-// 3. FILTERS — applied once after the union to keep the candidate set cheap:
-//   - is_delete / is_unlisted / is_available / stem_of (track liveness)
-//   - users.is_deactivated / is_available (owner liveness — same shape
-//     as v1_events_remix_contests.go)
-//   - access_authorities: caller's wallet must be on the list, else
-//     ungated only (matches the v1_users_feed authed-wallet pattern)
-//   - already-saved by the path-param user (don't resurface)
-//   - the path-param user's own uploads
+// 3. FILTERS — applied once after the union to keep the candidate set
+// cheap:
+//   - Track liveness: is_delete / is_unlisted / is_available / stem_of
+//   - Playlist liveness: is_delete / is_private
+//   - Owner liveness: users.is_deactivated / is_available
+//   - access_authorities (tracks only): caller's wallet must be on the
+//     list, else ungated only (matches the v1_users_feed authed-wallet
+//     pattern). Playlists don't carry access_authorities.
+//   - already-saved by the path-param user (don't resurface, both
+//     track and playlist saves)
+//   - the path-param user's own uploads/playlists
 //
-// 4. DIVERSITY — author-cap of N tracks per owner via row_number()
-// (configurable via max_per_artist; default 3), then a Go-side greedy
-// pass that, when the next track shares an owner with the previously
-// emitted one, prefers the next non-same-owner candidate within a
-// 5-position lookahead. This is a "consecutive same-artist penalty"
-// without paying for a second ranker.
+// 4. DIVERSITY — shared owner-cap of N items per owner across BOTH
+// types via row_number() (configurable via max_per_artist; default 3),
+// then a Go-side greedy pass that, when the next item shares an owner
+// with the previously emitted one, prefers the next different-owner
+// candidate within a 5-position lookahead. "Consecutive same-artist
+// penalty" without paying for a second ranker.
 //
 // PERFORMANCE NOTES: follow_set, the affinity sub-selects, and the
 // affinity join itself are all bounded — old engagement is weak signal
 // of current taste and unbounded scans are what previously took the
 // endpoint over the Cloudflare upstream limit for power users
-// (see PRs #805 and #806). The trending source relies on a partial
-// index on track_trending_scores for the TRACKS/pnagD/week/null-genre
-// slice (see ddl/migrations/0198_*).
+// (see PRs #805 and #806). The trending sources rely on partial indexes
+// on track_trending_scores / playlist_trending_scores for the
+// pnagD/week/null-genre slice.
 //
 // PAGINATION is offset/limit applied on the diversity-ordered list, so
 // pages are stable as long as the underlying scores haven't shifted.
@@ -87,10 +105,11 @@ type GetUsersFeedForYouParams struct {
 // Query params:
 //   - limit          (default 25, max 100)
 //   - offset         (default 0,  max 200)
-//   - max_per_artist (default 3,  max 10) — author cap per page
+//   - max_per_artist (default 3,  max 10) — owner cap per page,
+//     shared across tracks + playlists.
 //   - user_id        (optional): the caller's id. Independent of the
 //     path id — used to populate has_current_user_reposted and similar
-//     viewer-relative fields on the returned tracks. Same role it plays
+//     viewer-relative fields on the returned items. Same role it plays
 //     on every other /v1/users/{id}/... endpoint. The auth middleware
 //     treats this as advisory rather than authoritative on this route.
 func (app *ApiServer) v1FeedForYou(c *fiber.Ctx) error {
@@ -111,7 +130,7 @@ func (app *ApiServer) v1FeedForYou(c *fiber.Ctx) error {
 	WITH
 	-- Cap to the 500 most-recently-followed users. A power user with
 	-- thousands of follows pulls a huge hash table here that then has to
-	-- join against every recent track upload to find in-network candidates,
+	-- join against every recent upload to find in-network candidates,
 	-- so the planner can stall. Recent follows are a better signal of
 	-- current taste anyway.
 	follow_set AS (
@@ -131,45 +150,97 @@ func (app *ApiServer) v1FeedForYou(c *fiber.Ctx) error {
 		  AND is_current = true
 		  AND is_delete = false
 	),
-	-- Per-artist engagement strength (saves + reposts + plays of any of
-	-- their tracks by me). Used for the social_boost multiplier.
+	my_saved_playlists AS (
+		SELECT save_item_id AS playlist_id
+		FROM saves
+		WHERE user_id = @userId
+		  AND save_type IN ('playlist', 'album')
+		  AND is_current = true
+		  AND is_delete = false
+	),
+	-- Per-owner engagement strength: saves+reposts of any of their
+	-- tracks/playlists by me, plus plays of their tracks. Used for the
+	-- social_boost multiplier.
 	--
 	-- Each sub-select is bounded by recency: a heavy listener can have
 	-- hundreds of thousands of play rows, and the unbounded union forces
-	-- a full scan of those rows on every request. The inner join against
-	-- tracks is further restricted to tracks created in the last 90 days
-	-- so old uploads can't pull this CTE wide. Old engagement is a weak
-	-- signal of current taste anyway.
+	-- a full scan on every request. The inner joins are further
+	-- restricted to entities created in the last 90 days so old uploads
+	-- can't pull this CTE wide. Old engagement is a weak signal of
+	-- current taste anyway.
 	my_artist_affinity AS (
-		SELECT t.owner_id AS artist_id,
+		SELECT owner_id AS artist_id,
 		       LN(1 + COUNT(*)) AS affinity
 		FROM (
-			(SELECT save_item_id AS track_id FROM saves
-			 WHERE user_id = @userId AND save_type = 'track'
-			   AND is_current = true AND is_delete = false
-			 ORDER BY created_at DESC
-			 LIMIT 200)
+			SELECT t.owner_id
+			FROM (
+				SELECT save_item_id AS track_id FROM saves
+				WHERE user_id = @userId AND save_type = 'track'
+				  AND is_current = true AND is_delete = false
+				ORDER BY created_at DESC
+				LIMIT 200
+			) s
+			JOIN tracks t ON t.track_id = s.track_id
+			            AND t.created_at >= NOW() - INTERVAL '90 days'
+
 			UNION ALL
-			(SELECT repost_item_id AS track_id FROM reposts
-			 WHERE user_id = @userId AND repost_type = 'track'
-			   AND is_current = true AND is_delete = false
-			 ORDER BY created_at DESC
-			 LIMIT 200)
+
+			SELECT t.owner_id
+			FROM (
+				SELECT repost_item_id AS track_id FROM reposts
+				WHERE user_id = @userId AND repost_type = 'track'
+				  AND is_current = true AND is_delete = false
+				ORDER BY created_at DESC
+				LIMIT 200
+			) r
+			JOIN tracks t ON t.track_id = r.track_id
+			            AND t.created_at >= NOW() - INTERVAL '90 days'
+
 			UNION ALL
-			(SELECT play_item_id AS track_id FROM plays
-			 WHERE user_id = @userId
-			 ORDER BY created_at DESC
-			 LIMIT 500)
+
+			SELECT t.owner_id
+			FROM (
+				SELECT play_item_id AS track_id FROM plays
+				WHERE user_id = @userId
+				ORDER BY created_at DESC
+				LIMIT 500
+			) p
+			JOIN tracks t ON t.track_id = p.track_id
+			            AND t.created_at >= NOW() - INTERVAL '90 days'
+
+			UNION ALL
+
+			SELECT pl.playlist_owner_id AS owner_id
+			FROM (
+				SELECT save_item_id AS playlist_id FROM saves
+				WHERE user_id = @userId AND save_type IN ('playlist', 'album')
+				  AND is_current = true AND is_delete = false
+				ORDER BY created_at DESC
+				LIMIT 200
+			) sp
+			JOIN playlists pl ON pl.playlist_id = sp.playlist_id
+			               AND pl.created_at >= NOW() - INTERVAL '90 days'
+
+			UNION ALL
+
+			SELECT pl.playlist_owner_id AS owner_id
+			FROM (
+				SELECT repost_item_id AS playlist_id FROM reposts
+				WHERE user_id = @userId AND repost_type IN ('playlist', 'album')
+				  AND is_current = true AND is_delete = false
+				ORDER BY created_at DESC
+				LIMIT 200
+			) rp
+			JOIN playlists pl ON pl.playlist_id = rp.playlist_id
+			               AND pl.created_at >= NOW() - INTERVAL '90 days'
 		) eng
-		JOIN tracks t ON t.track_id = eng.track_id
-		           AND t.created_at >= NOW() - INTERVAL '90 days'
-		GROUP BY t.owner_id
+		GROUP BY owner_id
 	),
-	-- Source 1: in-network (followed-creator) recent uploads.
-	-- Bounded so a power-user with thousands of follows doesn't pull a
-	-- multi-thousand-row pool we'd just throw away after ranking.
-	cand_in_network AS (
-		SELECT t.track_id, 'in_network'::text AS source
+	-- Source 1a: in-network (followed-creator) recent track uploads.
+	cand_in_network_track AS (
+		SELECT t.track_id AS entity_id,
+		       'track'::text AS entity_type,
+		       'in_network'::text AS source
 		FROM tracks t
 		JOIN follow_set f ON f.user_id = t.owner_id
 		WHERE t.is_current = true
@@ -181,9 +252,11 @@ func (app *ApiServer) v1FeedForYou(c *fiber.Ctx) error {
 		ORDER BY t.created_at DESC
 		LIMIT 200
 	),
-	-- Source 2: weekly trending.
-	cand_trending AS (
-		SELECT tts.track_id, 'trending'::text AS source
+	-- Source 2a: weekly trending tracks.
+	cand_trending_track AS (
+		SELECT tts.track_id AS entity_id,
+		       'track'::text AS entity_type,
+		       'trending'::text AS source
 		FROM track_trending_scores tts
 		JOIN tracks t ON t.track_id = tts.track_id
 		            AND t.is_current = true
@@ -197,9 +270,11 @@ func (app *ApiServer) v1FeedForYou(c *fiber.Ctx) error {
 		ORDER BY tts.score DESC, tts.track_id DESC
 		LIMIT 100
 	),
-	-- Source 3: underground trending (sub-1500 follower & following artists).
-	cand_underground AS (
-		SELECT tts.track_id, 'underground'::text AS source
+	-- Source 3a: underground trending tracks (sub-1500 follower & following artists).
+	cand_underground_track AS (
+		SELECT tts.track_id AS entity_id,
+		       'track'::text AS entity_type,
+		       'underground'::text AS source
 		FROM track_trending_scores tts
 		JOIN tracks t ON t.track_id = tts.track_id
 		            AND t.is_current = true
@@ -216,37 +291,96 @@ func (app *ApiServer) v1FeedForYou(c *fiber.Ctx) error {
 		ORDER BY tts.score DESC, tts.track_id DESC
 		LIMIT 50
 	),
-	-- One row per track_id. DISTINCT ON keeps the strongest (lowest-prio)
-	-- source so an in-network track that's also trending keeps the
-	-- in_network weight rather than the lower trending weight.
-	candidates AS (
-		SELECT DISTINCT ON (track_id) track_id, source
-		FROM (
-			SELECT track_id, source, 1 AS prio FROM cand_in_network
-			UNION ALL
-			SELECT track_id, source, 2 AS prio FROM cand_trending
-			UNION ALL
-			SELECT track_id, source, 3 AS prio FROM cand_underground
-		) u
-		ORDER BY track_id, prio
+	-- Source 1b: in-network recent playlist/album creations.
+	cand_in_network_playlist AS (
+		SELECT p.playlist_id AS entity_id,
+		       'playlist'::text AS entity_type,
+		       'in_network'::text AS source
+		FROM playlists p
+		JOIN follow_set f ON f.user_id = p.playlist_owner_id
+		WHERE p.is_current = true
+		  AND p.is_delete = false
+		  AND p.is_private = false
+		  AND p.created_at >= NOW() - INTERVAL '14 days'
+		ORDER BY p.created_at DESC
+		LIMIT 50
 	),
-	filtered AS (
+	-- Source 2b: weekly trending playlists/albums.
+	cand_trending_playlist AS (
+		SELECT pts.playlist_id AS entity_id,
+		       'playlist'::text AS entity_type,
+		       'trending'::text AS source
+		FROM playlist_trending_scores pts
+		JOIN playlists p ON p.playlist_id = pts.playlist_id
+		            AND p.is_current = true
+		            AND p.is_delete = false
+		            AND p.is_private = false
+		WHERE pts.type = 'PLAYLISTS'
+		  AND pts.version = 'pnagD'
+		  AND pts.time_range = 'week'
+		ORDER BY pts.score DESC, pts.playlist_id DESC
+		LIMIT 50
+	),
+	-- Source 3b: underground trending playlists/albums.
+	cand_underground_playlist AS (
+		SELECT pts.playlist_id AS entity_id,
+		       'playlist'::text AS entity_type,
+		       'underground'::text AS source
+		FROM playlist_trending_scores pts
+		JOIN playlists p ON p.playlist_id = pts.playlist_id
+		            AND p.is_current = true
+		            AND p.is_delete = false
+		            AND p.is_private = false
+		JOIN aggregate_user au ON au.user_id = p.playlist_owner_id
+		WHERE pts.type = 'PLAYLISTS'
+		  AND pts.version = 'pnagD'
+		  AND pts.time_range = 'week'
+		  AND au.follower_count < 1500
+		  AND au.following_count < 1500
+		ORDER BY pts.score DESC, pts.playlist_id DESC
+		LIMIT 25
+	),
+	-- One row per (entity_type, entity_id). DISTINCT ON keeps the
+	-- strongest (lowest-prio) source so an in-network item that's also
+	-- trending keeps the in_network weight rather than the lower
+	-- trending weight.
+	candidates AS (
+		SELECT DISTINCT ON (entity_type, entity_id)
+		       entity_type, entity_id, source
+		FROM (
+			SELECT entity_type, entity_id, source, 1 AS prio FROM cand_in_network_track
+			UNION ALL
+			SELECT entity_type, entity_id, source, 2 AS prio FROM cand_trending_track
+			UNION ALL
+			SELECT entity_type, entity_id, source, 3 AS prio FROM cand_underground_track
+			UNION ALL
+			SELECT entity_type, entity_id, source, 1 AS prio FROM cand_in_network_playlist
+			UNION ALL
+			SELECT entity_type, entity_id, source, 2 AS prio FROM cand_trending_playlist
+			UNION ALL
+			SELECT entity_type, entity_id, source, 3 AS prio FROM cand_underground_playlist
+		) u
+		ORDER BY entity_type, entity_id, prio
+	),
+	filtered_tracks AS (
 		SELECT
-			c.track_id,
-			c.source,
-			t.owner_id,
-			t.created_at,
+			'track'::text                AS entity_type,
+			c.entity_id                  AS entity_id,
+			t.owner_id                   AS owner_id,
+			t.created_at                 AS created_at,
+			c.source                     AS source,
 			COALESCE(at.save_count, 0)   AS save_count,
 			COALESCE(at.repost_count, 0) AS repost_count,
 			COALESCE(ap.count, 0)        AS play_count,
 			COALESCE(maa.affinity, 0)    AS affinity
 		FROM candidates c
-		JOIN tracks t ON t.track_id = c.track_id
+		JOIN tracks t ON t.track_id = c.entity_id
 		JOIN users  u ON u.user_id  = t.owner_id
-		LEFT JOIN aggregate_track at  ON at.track_id     = c.track_id
-		LEFT JOIN aggregate_plays ap  ON ap.play_item_id = c.track_id
+		LEFT JOIN aggregate_track at  ON at.track_id     = c.entity_id
+		LEFT JOIN aggregate_plays ap  ON ap.play_item_id = c.entity_id
 		LEFT JOIN my_artist_affinity maa ON maa.artist_id = t.owner_id
-		WHERE t.is_current   = true
+		WHERE c.entity_type = 'track'
+		  AND t.is_current   = true
 		  AND t.is_delete    = false
 		  AND t.is_unlisted  = false
 		  AND t.is_available = true
@@ -261,14 +395,53 @@ func (app *ApiServer) v1FeedForYou(c *fiber.Ctx) error {
 		               WHERE lower(aa) = lower(@authed_wallet)
 		           )))
 		  AND NOT EXISTS (
-		      SELECT 1 FROM my_saved_tracks ms WHERE ms.track_id = c.track_id
+		      SELECT 1 FROM my_saved_tracks ms WHERE ms.track_id = c.entity_id
 		  )
 		  AND t.owner_id <> @userId
 	),
+	filtered_playlists AS (
+		SELECT
+			'playlist'::text             AS entity_type,
+			c.entity_id                  AS entity_id,
+			p.playlist_owner_id          AS owner_id,
+			p.created_at                 AS created_at,
+			c.source                     AS source,
+			COALESCE(ap.save_count, 0)   AS save_count,
+			COALESCE(ap.repost_count, 0) AS repost_count,
+			0                            AS play_count,
+			COALESCE(maa.affinity, 0)    AS affinity
+		FROM candidates c
+		JOIN playlists p ON p.playlist_id = c.entity_id
+		JOIN users     u ON u.user_id     = p.playlist_owner_id
+		LEFT JOIN aggregate_playlist ap   ON ap.playlist_id = c.entity_id
+		LEFT JOIN my_artist_affinity maa  ON maa.artist_id  = p.playlist_owner_id
+		WHERE c.entity_type = 'playlist'
+		  AND p.is_current = true
+		  AND p.is_delete  = false
+		  AND p.is_private = false
+		  AND u.is_current     = true
+		  AND u.is_deactivated = false
+		  AND u.is_available   = true
+		  AND NOT EXISTS (
+		      SELECT 1 FROM my_saved_playlists ms WHERE ms.playlist_id = c.entity_id
+		  )
+		  AND p.playlist_owner_id <> @userId
+	),
+	filtered AS (
+		SELECT entity_type, entity_id, owner_id, created_at, source,
+		       save_count, repost_count, play_count, affinity
+		FROM filtered_tracks
+		UNION ALL
+		SELECT entity_type, entity_id, owner_id, created_at, source,
+		       save_count, repost_count, play_count, affinity
+		FROM filtered_playlists
+	),
 	scored AS (
 		SELECT
-			f.track_id,
+			f.entity_type,
+			f.entity_id,
 			f.owner_id,
+			f.created_at,
 			EXP(-LN(2) * GREATEST(EXTRACT(EPOCH FROM (NOW() - f.created_at)) / 3600.0, 0) / 48.0)
 				AS recency_score,
 			LN(1 + 3 * f.save_count + 2 * f.repost_count + f.play_count) / 12.0
@@ -284,22 +457,24 @@ func (app *ApiServer) v1FeedForYou(c *fiber.Ctx) error {
 	),
 	final_scored AS (
 		SELECT
-			track_id,
+			entity_type,
+			entity_id,
 			owner_id,
+			created_at,
 			(0.55 * recency_score + 0.45 * engagement_score)
 				* social_boost * source_weight AS score
 		FROM scored
 	),
 	capped AS (
-		SELECT track_id, owner_id, score,
-		       ROW_NUMBER() OVER (PARTITION BY owner_id ORDER BY score DESC, track_id DESC)
+		SELECT entity_type, entity_id, owner_id, created_at, score,
+		       ROW_NUMBER() OVER (PARTITION BY owner_id ORDER BY score DESC, entity_id DESC)
 		         AS rn_artist
 		FROM final_scored
 	)
-	SELECT track_id, owner_id
+	SELECT entity_type, entity_id, owner_id, created_at
 	FROM capped
 	WHERE rn_artist <= @maxPerArtist
-	ORDER BY score DESC, track_id DESC
+	ORDER BY score DESC, entity_id DESC
 	LIMIT @poolSize
 	`
 
@@ -314,8 +489,10 @@ func (app *ApiServer) v1FeedForYou(c *fiber.Ctx) error {
 	}
 
 	type ranked struct {
-		TrackID int32
-		OwnerID int32
+		EntityType string
+		EntityID   int32
+		OwnerID    int32
+		CreatedAt  time.Time
 	}
 	pool, err := pgx.CollectRows(rows, pgx.RowToStructByPos[ranked])
 	if err != nil {
@@ -323,9 +500,9 @@ func (app *ApiServer) v1FeedForYou(c *fiber.Ctx) error {
 	}
 
 	// Greedy diversity pass: keep the global rank order, but if the next
-	// track shares an owner with the one just emitted, prefer the next
-	// non-same-owner candidate within a small lookahead. Soft penalty on
-	// consecutive-same-artist runs without computing a second ranker.
+	// item shares an owner with the one just emitted, prefer the next
+	// different-owner candidate within a small lookahead. Soft penalty
+	// on consecutive-same-artist runs without computing a second ranker.
 	const lookahead = 5
 	ordered := make([]ranked, 0, len(pool))
 	used := make([]bool, len(pool))
@@ -362,33 +539,54 @@ func (app *ApiServer) v1FeedForYou(c *fiber.Ctx) error {
 	}
 	page := ordered[start:end]
 
-	trackIds := make([]int32, len(page))
-	for i, r := range page {
-		trackIds[i] = r.TrackID
+	trackIds := []int32{}
+	playlistIds := []int32{}
+	for _, r := range page {
+		if r.EntityType == "track" {
+			trackIds = append(trackIds, r.EntityID)
+		} else {
+			playlistIds = append(playlistIds, r.EntityID)
+		}
 	}
 
-	tracks, err := app.queries.Tracks(c.Context(), dbv1.TracksParams{
-		GetTracksParams: dbv1.GetTracksParams{
-			Ids:          trackIds,
-			MyID:         myId,
-			AuthedWallet: authedWallet,
-		},
+	loaded, err := app.queries.Parallel(c.Context(), dbv1.ParallelParams{
+		TrackIds:     trackIds,
+		PlaylistIds:  playlistIds,
+		MyID:         myId,
+		AuthedWallet: authedWallet,
 	})
 	if err != nil {
 		return err
 	}
 
-	// Tracks() returns rows in id order; re-emit in our ranked order.
-	byId := make(map[int32]dbv1.Track, len(tracks))
-	for _, t := range tracks {
-		byId[t.TrackID] = t
+	type FeedItem struct {
+		EntityType string    `json:"type"`
+		CreatedAt  time.Time `json:"timestamp"`
+		Item       any       `json:"item"`
 	}
-	sorted := make([]dbv1.Track, 0, len(trackIds))
-	for _, id := range trackIds {
-		if t, ok := byId[id]; ok {
-			sorted = append(sorted, t)
+
+	items := make([]FeedItem, 0, len(page))
+	for _, r := range page {
+		if r.EntityType == "track" {
+			if t, ok := loaded.TrackMap[r.EntityID]; ok {
+				items = append(items, FeedItem{
+					EntityType: "track",
+					CreatedAt:  r.CreatedAt,
+					Item:       t,
+				})
+			}
+		} else {
+			if p, ok := loaded.PlaylistMap[r.EntityID]; ok {
+				items = append(items, FeedItem{
+					EntityType: "playlist",
+					CreatedAt:  r.CreatedAt,
+					Item:       p,
+				})
+			}
 		}
 	}
 
-	return v1TracksResponse(c, sorted)
+	return c.JSON(fiber.Map{
+		"data": items,
+	})
 }

--- a/api/v1_users_feed_for_you_test.go
+++ b/api/v1_users_feed_for_you_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"encoding/json"
 	"fmt"
 	"testing"
 	"time"
@@ -12,13 +13,23 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// feedForYouFixtures builds a small graph that exercises the in-network
-// and trending candidate sources plus the standard filters.
+// feedForYouItem mirrors the heterogenous feed envelope on the wire:
+// {type, timestamp, item}. The item is left as raw JSON so tests can
+// pick out whichever entity-shape fields they need.
+type feedForYouItem struct {
+	Type      string          `json:"type"`
+	Timestamp time.Time       `json:"timestamp"`
+	Item      json.RawMessage `json:"item"`
+}
+
+// feedForYouFixtures builds a small graph that exercises the in-network,
+// trending, and underground candidate sources for BOTH tracks and
+// playlists, plus the standard filters.
 //
 //	user 1 = me (the viewer)
-//	user 2 = an artist I follow         -> in-network candidates
-//	user 3 = an artist I do NOT follow  -> trending candidate
-//	user 4 = an underground artist      -> underground candidate
+//	user 2 = an artist I follow         -> in-network track + playlist
+//	user 3 = an artist I do NOT follow  -> trending track + playlist
+//	user 4 = an underground artist      -> underground track + playlist
 //	user 7 = a deactivated artist       -> filter test
 //	user 8 = saved artist               -> already-saved filter
 func feedForYouFixtures() database.FixtureMap {
@@ -53,17 +64,38 @@ func feedForYouFixtures() database.FixtureMap {
 		{"track_id": 902, "owner_id": 2, "title": "deleted", "created_at": hoursAgo(2), "is_delete": true},
 	}
 
+	playlists := []map[string]any{
+		// In-network playlist: recent, by a user I follow.
+		{"playlist_id": 1101, "playlist_owner_id": 2, "playlist_name": "in-network playlist", "is_album": false, "is_private": false, "playlist_contents": "{}", "created_at": hoursAgo(3), "updated_at": hoursAgo(3)},
+		// Trending playlist by someone I don't follow.
+		{"playlist_id": 1201, "playlist_owner_id": 3, "playlist_name": "trending playlist", "is_album": false, "is_private": false, "playlist_contents": "{}", "created_at": hoursAgo(96), "updated_at": hoursAgo(96)},
+		// Underground playlist by sub-1500 follower artist.
+		{"playlist_id": 1301, "playlist_owner_id": 4, "playlist_name": "underground playlist", "is_album": false, "is_private": false, "playlist_contents": "{}", "created_at": hoursAgo(60), "updated_at": hoursAgo(60)},
+		// Already-saved playlist (should be filtered out).
+		{"playlist_id": 1801, "playlist_owner_id": 8, "playlist_name": "already saved playlist", "is_album": false, "is_private": false, "playlist_contents": "{}", "created_at": hoursAgo(120), "updated_at": hoursAgo(120)},
+		// Private playlist by a user I follow (should be filtered out).
+		{"playlist_id": 1102, "playlist_owner_id": 2, "playlist_name": "private playlist", "is_album": false, "is_private": true, "playlist_contents": "{}", "created_at": hoursAgo(3), "updated_at": hoursAgo(3)},
+		// Deleted playlist (should be filtered out).
+		{"playlist_id": 1103, "playlist_owner_id": 2, "playlist_name": "deleted playlist", "is_album": false, "is_private": false, "playlist_contents": "{}", "created_at": hoursAgo(3), "updated_at": hoursAgo(3), "is_delete": true},
+	}
+
 	follows := []map[string]any{
 		{"follower_user_id": 1, "followee_user_id": 2},
 	}
 
 	saves := []map[string]any{
 		{"user_id": 1, "save_item_id": 801, "save_type": "track"},
+		{"user_id": 1, "save_item_id": 1801, "save_type": "playlist"},
 	}
 
 	trackTrendingScores := []map[string]any{
 		{"track_id": 201, "score": 9_000_000_000, "time_range": "week"},
 		{"track_id": 301, "score": 5_000_000_000, "time_range": "week"},
+	}
+
+	playlistTrendingScores := []map[string]any{
+		{"playlist_id": 1201, "type": "PLAYLISTS", "version": "pnagD", "time_range": "week", "score": 9_000_000_000.0},
+		{"playlist_id": 1301, "type": "PLAYLISTS", "version": "pnagD", "time_range": "week", "score": 5_000_000_000.0},
 	}
 
 	aggregateTrack := []map[string]any{
@@ -73,14 +105,23 @@ func feedForYouFixtures() database.FixtureMap {
 		{"track_id": 301, "save_count": 30, "repost_count": 10},
 	}
 
+	aggregatePlaylist := []map[string]any{
+		{"playlist_id": 1101, "is_album": false, "save_count": 4, "repost_count": 1},
+		{"playlist_id": 1201, "is_album": false, "save_count": 80, "repost_count": 30},
+		{"playlist_id": 1301, "is_album": false, "save_count": 20, "repost_count": 5},
+	}
+
 	return database.FixtureMap{
-		"users":                 users,
-		"aggregate_user":        aggregateUser,
-		"tracks":                tracks,
-		"follows":               follows,
-		"saves":                 saves,
-		"track_trending_scores": trackTrendingScores,
-		"aggregate_track":       aggregateTrack,
+		"users":                    users,
+		"aggregate_user":           aggregateUser,
+		"tracks":                   tracks,
+		"playlists":                playlists,
+		"follows":                  follows,
+		"saves":                    saves,
+		"track_trending_scores":    trackTrendingScores,
+		"playlist_trending_scores": playlistTrendingScores,
+		"aggregate_track":          aggregateTrack,
+		"aggregate_playlist":       aggregatePlaylist,
 	}
 }
 
@@ -110,7 +151,7 @@ func TestV1FeedForYou_EmptyFeedForNewUser(t *testing.T) {
 	})
 
 	var response struct {
-		Data []dbv1.Track
+		Data []feedForYouItem
 	}
 	path := "/v1/users/" + trashid.MustEncodeHashID(42) + "/feed/for-you"
 	status, body := testGet(t, app, path, &response)
@@ -119,35 +160,148 @@ func TestV1FeedForYou_EmptyFeedForNewUser(t *testing.T) {
 }
 
 // TestV1FeedForYou_PaginationDoesNotRepeat asserts that two consecutive
-// pages of the diversity-ordered list don't overlap on track ids.
+// pages of the diversity-ordered list don't overlap on (type, id).
 func TestV1FeedForYou_PaginationDoesNotRepeat(t *testing.T) {
 	app := emptyTestApp(t)
 	app.skipAuthCheck = true
 	database.Seed(app.pool.Replicas[0], feedForYouFixtures())
 
-	page := func(limit, offset int) []int32 {
+	page := func(limit, offset int) []string {
 		var resp struct {
-			Data []dbv1.Track
+			Data []feedForYouItem
 		}
 		path := fmt.Sprintf("/v1/users/%s/feed/for-you?limit=%d&offset=%d",
 			trashid.MustEncodeHashID(1), limit, offset)
 		status, body := testGet(t, app, path, &resp)
 		require.Equal(t, 200, status, string(body))
-		ids := make([]int32, len(resp.Data))
-		for i, tr := range resp.Data {
-			ids[i] = tr.TrackID
+		keys := make([]string, len(resp.Data))
+		for i, it := range resp.Data {
+			// Pull the id out of the wrapped track/playlist payload.
+			var idHolder struct {
+				ID         string `json:"id"`
+				PlaylistID string `json:"playlist_id"`
+				TrackID    string `json:"track_id"`
+			}
+			_ = json.Unmarshal(it.Item, &idHolder)
+			id := idHolder.ID
+			if id == "" {
+				id = idHolder.PlaylistID
+			}
+			if id == "" {
+				id = idHolder.TrackID
+			}
+			keys[i] = fmt.Sprintf("%s:%s", it.Type, id)
 		}
-		return ids
+		return keys
 	}
 
 	first := page(2, 0)
 	second := page(2, 2)
 
-	seen := map[int32]bool{}
-	for _, id := range first {
-		seen[id] = true
+	seen := map[string]bool{}
+	for _, k := range first {
+		seen[k] = true
 	}
-	for _, id := range second {
-		assert.Falsef(t, seen[id], "track %d appeared on both pages", id)
+	for _, k := range second {
+		assert.Falsef(t, seen[k], "item %s appeared on both pages", k)
 	}
+}
+
+// TestV1FeedForYou_IncludesCollections asserts that with both tracks
+// and playlists available across all three candidate sources, the feed
+// surfaces a mix of types — not tracks-only.
+func TestV1FeedForYou_IncludesCollections(t *testing.T) {
+	app := emptyTestApp(t)
+	app.skipAuthCheck = true
+	database.Seed(app.pool.Replicas[0], feedForYouFixtures())
+
+	var resp struct {
+		Data []feedForYouItem
+	}
+	// Pull a wide page so all 3 in-network + 2 trending + 2 underground
+	// playlists have a chance to land alongside the tracks.
+	path := fmt.Sprintf("/v1/users/%s/feed/for-you?limit=20", trashid.MustEncodeHashID(1))
+	status, body := testGet(t, app, path, &resp)
+	require.Equal(t, 200, status, string(body))
+
+	var (
+		sawTrack    bool
+		sawPlaylist bool
+		ids         = map[string]bool{}
+	)
+	for _, it := range resp.Data {
+		switch it.Type {
+		case "track":
+			sawTrack = true
+		case "playlist":
+			sawPlaylist = true
+		}
+
+		// Filtered/already-saved entities should never show up.
+		var idHolder struct {
+			PlaylistID string `json:"playlist_id"`
+			TrackID    string `json:"track_id"`
+		}
+		_ = json.Unmarshal(it.Item, &idHolder)
+		key := fmt.Sprintf("%s:%s%s", it.Type, idHolder.PlaylistID, idHolder.TrackID)
+		ids[key] = true
+	}
+	assert.True(t, sawTrack, "expected at least one track in the for-you feed")
+	assert.True(t, sawPlaylist, "expected at least one playlist in the for-you feed")
+	assert.False(t, ids["playlist:"+trashid.MustEncodeHashID(1801)],
+		"already-saved playlist 1801 must not appear")
+	assert.False(t, ids["playlist:"+trashid.MustEncodeHashID(1102)],
+		"private playlist 1102 must not appear")
+	assert.False(t, ids["playlist:"+trashid.MustEncodeHashID(1103)],
+		"deleted playlist 1103 must not appear")
+	assert.False(t, ids["track:"+trashid.MustEncodeHashID(701)],
+		"deactivated-owner track 701 must not appear")
+}
+
+// TestV1FeedForYou_PerArtistCapIsShared asserts that max_per_artist
+// applies across both tracks and playlists for the same owner — the
+// diversity cap is shared, not per-type. User 2 (followed) has 2 tracks
+// and 1 in-network playlist; with max_per_artist=1 we should see at
+// most 1 item from user 2 on a page.
+func TestV1FeedForYou_PerArtistCapIsShared(t *testing.T) {
+	app := emptyTestApp(t)
+	app.skipAuthCheck = true
+	database.Seed(app.pool.Replicas[0], feedForYouFixtures())
+
+	var (
+		_   dbv1.Track    // keep import alive even if Track shape is unused below
+		_   dbv1.Playlist // ditto for Playlist
+		_   = time.Time{} //
+	)
+
+	var resp struct {
+		Data []feedForYouItem
+	}
+	path := fmt.Sprintf("/v1/users/%s/feed/for-you?limit=20&max_per_artist=1",
+		trashid.MustEncodeHashID(1))
+	status, body := testGet(t, app, path, &resp)
+	require.Equal(t, 200, status, string(body))
+
+	// Count entities authored by user 2. Track owner is `user_id`;
+	// playlist owner is `user.user_id` inside the wrapped user object on
+	// playlists. To stay schema-agnostic in this test we pull the owner
+	// hash id out of either `user.id` (playlist shape) or `user.id`
+	// (track shape) — both pin owner_id to the same nested user.
+	type idHolder struct {
+		User struct {
+			ID string `json:"id"`
+		} `json:"user"`
+	}
+	user2 := trashid.MustEncodeHashID(2)
+	var fromUser2 int
+	for _, it := range resp.Data {
+		var h idHolder
+		_ = json.Unmarshal(it.Item, &h)
+		if h.User.ID == user2 {
+			fromUser2++
+		}
+	}
+	assert.LessOrEqualf(t, fromUser2, 1,
+		"max_per_artist=1 should produce at most 1 item from user 2 across track+playlist, got %d",
+		fromUser2)
 }


### PR DESCRIPTION
## Summary

- Extends `GET /v1/users/{id}/feed/for-you` from a tracks-only feed to a heterogenous tracks+playlists/albums feed, mirroring the chronological `/v1/users/{id}/feed` envelope (`{data: [{type, timestamp, item}]}`).
- 3-source pipeline becomes 6: each of `in_network`, `trending`, `underground` now retrieves both tracks (via `track_trending_scores`) and playlists/albums (via `playlist_trending_scores`).
- Diversity cap (`max_per_artist`, default 3) is **shared** across types — one artist can't dominate a page with a mix of tracks and playlists.
- `my_artist_affinity` now folds in playlist saves+reposts so the social_boost reflects engagement across both content types.
- Per-source playlist caps are smaller (50/50/25 vs the existing 200/100/50 for tracks) — playlists are heavier to hydrate and a smaller chunk of the catalog.

## Why

The For You feed should reflect what the user actually publishes and engages with. Today the feed surfaces only tracks, but Audius creators ship playlists and albums too. The chronological feed already returns mixed content; this brings parity.

## Notes

- Response shape change is a **breaking** change for SDK consumers of `getUserForYouFeed` (was `Tracks`, now `UserFeedResponse`). Companion SDK regen + apps consumer update in audius-protocol#TBD.
- Pipeline structure unchanged — same recency × engagement × social-affinity × source-weight blend, same Twitter-style three-stage architecture so a learned ranker can drop in later.

## Test plan

- [x] `go test ./api/ -run TestV1FeedForYou` — 5/5 pass (existing 3 + new `TestV1FeedForYou_IncludesCollections` + `TestV1FeedForYou_PerArtistCapIsShared`)
- [x] `go test ./api/ -run "TestUsersFeed\$|TestFanClubFeed"` — no regressions in chronological feed or fan-club feed
- [ ] Spot-check the endpoint against a real prod-shape DB before deploy (in-network playlists from followed creators surface; private/deleted playlists are filtered)

🤖 Generated with [Claude Code](https://claude.com/claude-code)