### PR TITLE
fix(health-check): filter core_indexed_blocks MAX(height) by chain_id

### DIFF
--- a/api/health_check.go
+++ b/api/health_check.go
@@ -40,9 +40,22 @@ func (app *ApiServer) getCoreIndexerHealth(ctx context.Context) (*coreIndexerHea
 
 	// ETL tracks the highest indexed chain height in `core_indexed_blocks`.
 	// COALESCE handles the cold-start case before any blocks are indexed.
+	//
+	// The chain_id predicate is required for index usage. `core_indexed_blocks`
+	// has indexes (PK on (chain_id, height) and idx_chain_id_height), all
+	// leading with chain_id. Without the filter, MAX(height) degrades to a
+	// sequential scan over the whole table (~tens of millions of rows on
+	// prod) — at k8s probe cadence × bridge replicas that becomes enough
+	// load to saturate I/O and exhaust the connection pool. The filter
+	// makes it a sub-millisecond index seek.
+	//
+	// We reuse the Chainid from the just-fetched nodeInfo rather than
+	// plumbing a separate config field — same value ETL uses when it
+	// writes rows here, so the filter always matches the writer's intent.
 	var indexerLastBlockHeight int64
 	err = app.pool.QueryRow(ctx,
-		"SELECT COALESCE(MAX(height), 0) FROM core_indexed_blocks",
+		"SELECT COALESCE(MAX(height), 0) FROM core_indexed_blocks WHERE chain_id = $1",
+		nodeInfo.Msg.Chainid,
 	).Scan(&indexerLastBlockHeight)
 	if err != nil {
 		return nil, fiber.NewError(fiber.StatusInternalServerError, "Failed to get core indexer last block height")


### PR DESCRIPTION
## Summary

The bridge's `/health-check` endpoint runs this query on every request:

```sql
SELECT COALESCE(MAX(height), 0) FROM core_indexed_blocks
```

I introduced this query in #840 and **missed that `core_indexed_blocks`'s indexes all lead with `chain_id`**, so the query has no usable index and degrades to a **sequential scan over ~27M rows on prod**.

## Test plan

- [ ] `go build ./...` clean — done locally.
- [ ] Deploy. Watch `/health-check` p99 latency drop from seconds to milliseconds.
- [ ] `pg_stat_activity` should stop showing this query in long-running state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)