### PR TITLE
Backfill eth_wallet_balances with all tracked wallets

### DIFF
--- a/ddl/migrations/0204_backfill_eth_wallet_balances_tracked.sql
+++ b/ddl/migrations/0204_backfill_eth_wallet_balances_tracked.sql
@@ -1,0 +1,39 @@
+BEGIN;
+SET LOCAL statement_timeout = 0;
+
+-- Seed eth_wallet_balances with every tracked Ethereum wallet at
+-- updated_at = epoch so the eth-indexer's stale-refresh sweep
+-- (eth/indexer/eth_indexer.go:selectStaleWallets, ORDER BY updated_at ASC)
+-- picks them up oldest-first and reads the real on-chain balance via
+-- Multicall3 (balanceOf + totalStakedFor + getTotalDelegatorStake).
+--
+-- Without this seed, long-time stakers / delegators who haven't moved AUDIO
+-- since the eth-indexer started watching are invisible to it — the sweep
+-- can only refresh rows that already exist in eth_wallet_balances, and the
+-- live Transfer subscription never sees them. Confirmed via diagnostics on
+-- the top 25 legacy balances: 9 users had multi-hundred-thousand-AUDIO gaps
+-- entirely from associated_wallets chain=eth wallets that had zero coverage.
+--
+-- Idempotent: ON CONFLICT DO NOTHING preserves any existing row's balance
+-- and updated_at, so re-running this migration is safe and so is a fresh
+-- run after rows have been refreshed.
+
+INSERT INTO eth_wallet_balances (wallet, balance, updated_at)
+SELECT wallet, 0, '1970-01-01'::timestamp
+FROM (
+    SELECT LOWER(wallet) AS wallet
+      FROM users
+     WHERE is_current = TRUE
+       AND wallet IS NOT NULL
+       AND wallet <> ''
+    UNION
+    SELECT LOWER(wallet) AS wallet
+      FROM associated_wallets
+     WHERE chain = 'eth'
+       AND is_delete = FALSE
+       AND wallet IS NOT NULL
+       AND wallet <> ''
+) t
+ON CONFLICT (wallet) DO NOTHING;
+
+COMMIT;


### PR DESCRIPTION
## Summary

Seeds every tracked Ethereum wallet into \`eth_wallet_balances\` with placeholder rows (\`balance=0, updated_at='1970-01-01'\`) so the eth-indexer's stale-refresh sweep can discover and refresh long-time stakers / delegators that the live \`Transfer\` subscription has never seen.

Pairs with [#861](https://github.com/AudiusProject/api/pull/861) (\`v_user_balances\` view): that PR deferred the \`get_users.sql\` reader swap because comparing the view against the legacy \`user_balances\` showed 9 of the top 25 balances missing — all from \`associated_wallets\` chain=eth entries with zero \`eth_wallet_balances\` coverage. Once this backfill drains, the swap can land.

## Why the gap exists

The eth-indexer subscribes to AUDIO \`Transfer\` events and only inserts into \`eth_wallet_balances\` when a tracked wallet shows up as a Transfer endpoint. The stale-refresh sweep (\`eth/indexer/eth_indexer.go:498\`) is \`ORDER BY updated_at ASC LIMIT K\` over \`eth_wallet_balances\` itself — it can re-read rows but can't discover new ones. So a user who staked years ago and hasn't moved AUDIO since is invisible to both code paths.

## What the migration does

\`\`\`sql
INSERT INTO eth_wallet_balances (wallet, balance, updated_at)
SELECT wallet, 0, '1970-01-01'::timestamp
FROM (
    SELECT LOWER(wallet) FROM users WHERE is_current AND wallet <> ''
    UNION
    SELECT LOWER(wallet) FROM associated_wallets
     WHERE chain = 'eth' AND NOT is_delete AND wallet <> ''
) t
ON CONFLICT (wallet) DO NOTHING;
\`\`\`

Idempotent — \`ON CONFLICT DO NOTHING\` preserves any row that already has a real balance, so re-running is a no-op.

## Operational plan

After this lands:

1. Bump \`ethStaleRefreshBatchSize\` and shrink \`ethStaleRefreshIntervalSecs\` on the running eth-indexer for the backfill duration. Suggested: \`batch_size=2000, interval=10s\` → ~4 hours for 3.15M wallets vs. the default ~22 days.
2. Watch the indexer logs for \`stale refresh: tick complete\` — sweep makes progress with no errors.
3. Spot-check with the side-by-side diff from the comments on #861: top 25 legacy balances should all converge to near-zero diffs.
4. Once coverage is verified, restore default env vars and merge the \`get_users.sql\` reader swap (separate follow-up).

No code changes in this PR — purely the data migration. The acceleration mechanism is operational (env-var bumps); a CLI subcommand was considered but adds ~80 lines for what \`kubectl edit configmap\` accomplishes.

## Test plan

- [x] Migration is straight INSERT...SELECT + ON CONFLICT — trivially correct
- [ ] CI green
- [ ] Stage: apply, bump env vars, verify rows being refreshed in indexer logs
- [ ] Stage: side-by-side diff over top 25 — all near-zero
- [ ] Prod: apply, observe sweep progress, watch \`fresh_eth_primary_block\` advance for the suspect users

🤖 Generated with [Claude Code](https://claude.com/claude-code)