### PR TITLE
Fix v_user_balances missing mixed-case linked wallets

### DIFF
--- a/api/v_user_balances_test.go
+++ b/api/v_user_balances_test.go
@@ -198,3 +198,30 @@ func TestVUserBalances_DeletedAssociatedWalletsExcluded(t *testing.T) {
 	r := queryVUserBalances(t, app, 1)
 	assert.Equal(t, "0", r.EthBalance, "deleted associated_wallets should not contribute")
 }
+
+// Mixed-case wallets in associated_wallets must still resolve against
+// eth_wallet_balances (which is canonical lowercase). This was a real bug on
+// prod where ~35% of the top-100 legacy balances diverged purely because the
+// view's IN-list comparison was case-sensitive. The LOWER() inside the
+// LATERAL keeps the eth_wallet_balances_pkey lookup intact.
+func TestVUserBalances_MixedCaseLinkedWallets(t *testing.T) {
+	app := emptyTestApp(t)
+	const mixedCaseLinked = "0xAbCdEf1234567890abCDef1234567890ABCdEf12"
+	fixtures := database.FixtureMap{
+		"users": []map[string]any{
+			{"user_id": 1, "handle": "u1", "wallet": vubUserPrimaryWallet},
+		},
+		"associated_wallets": []map[string]any{
+			// As-stored mixed case (legacy entry).
+			{"id": 1, "user_id": 1, "wallet": mixedCaseLinked, "chain": "eth", "blockhash": "h", "blocknumber": 101, "is_current": true, "is_delete": false},
+		},
+		"eth_wallet_balances": []map[string]any{
+			// Canonical lowercase (what the eth-indexer + seed migration write).
+			{"wallet": "0xabcdef1234567890abcdef1234567890abcdef12", "balance": "999"},
+		},
+	}
+	database.Seed(app.pool.Replicas[0], fixtures)
+
+	r := queryVUserBalances(t, app, 1)
+	assert.Equal(t, "999", r.EthBalance, "mixed-case associated_wallets entry must still match lowercase eth_wallet_balances")
+}

--- a/ddl/views/v_user_balances.sql
+++ b/ddl/views/v_user_balances.sql
@@ -7,10 +7,12 @@ SELECT
     -- chain=eth associated_wallets, summed server-side. eth_wallet_balances
     -- already includes ERC-20 balanceOf + staking + delegation (Multicall3 sum
     -- in eth/indexer/multicall.go), matching the legacy Python
-    -- cache_user_balance.py semantic. No LOWER() on the join key — the
-    -- eth-indexer normalizes via lowerHex() and users.wallet is already
-    -- lowercase, and LOWER() would force a seq scan instead of using
-    -- eth_wallet_balances_pkey.
+    -- cache_user_balance.py semantic. The IN-list values are LOWER()'d
+    -- because eth_wallet_balances stores wallets lowercased (eth-indexer
+    -- normalizes via lowerHex()) while associated_wallets historically
+    -- accepted mixed-case input. LOWER() is on the *values* being looked
+    -- up, not on ewb.wallet, so eth_wallet_balances_pkey still drives the
+    -- lookup — no seq scan.
     COALESCE(eth.total_balance, 0)::varchar AS eth_balance,
 
     -- wAUDIO total for the user — sol_user_balances already pre-aggregates
@@ -33,9 +35,9 @@ LEFT JOIN LATERAL (
            MAX(ewb.updated_at) AS updated_at
       FROM eth_wallet_balances ewb
      WHERE ewb.wallet IN (
-        SELECT u.wallet
+        SELECT LOWER(u.wallet)
         UNION ALL
-        SELECT aw.wallet
+        SELECT LOWER(aw.wallet)
           FROM associated_wallets aw
          WHERE aw.user_id = u.user_id
            AND aw.chain = 'eth'

--- a/sql/01_schema.sql
+++ b/sql/01_schema.sql
@@ -9865,9 +9865,9 @@ CREATE VIEW public.v_user_balances AS
      LEFT JOIN LATERAL ( SELECT sum(ewb.balance) AS total_balance,
             max(ewb.updated_at) AS updated_at
            FROM public.eth_wallet_balances ewb
-          WHERE (ewb.wallet IN ( SELECT u.wallet
+          WHERE (ewb.wallet IN ( SELECT lower((u.wallet)::text) AS lower
                 UNION ALL
-                 SELECT aw.wallet
+                 SELECT lower((aw.wallet)::text) AS lower
                    FROM public.associated_wallets aw
                   WHERE ((aw.user_id = u.user_id) AND (aw.chain = 'eth'::public.wallet_chain) AND (aw.is_current = true) AND (aw.is_delete = false))))) eth ON (true))
   WHERE (u.is_current = true);

--- a/sql/03_migration_tracker.sql
+++ b/sql/03_migration_tracker.sql
@@ -150,7 +150,7 @@ views/v_token_transactions_history.sql	fd753db4177640b9cfed9ef6b6359d7d	2026-05-
 views/v_usdc_purchases.sql	322a527e132aed647c39b70d63aa6b51	2026-05-27 00:22:39.061667+00
 preflight/0001_initial_block.sql	1e59cca66b2208eda67a87ac0d09b67d	2026-05-27 00:22:39.249328+00
 migrations/0204_backfill_eth_wallet_balances_tracked.sql	d8b752794c42edb94f0d43633e14208c	2026-05-28 00:56:10.178339+00
-views/v_user_balances.sql	afe7026956272a1044f985515294e895	2026-05-28 00:56:10.657022+00
+views/v_user_balances.sql	ff6db739c1a77101021d4629647a44df	2026-05-28 17:28:07.629633+00
 \.
 
 


### PR DESCRIPTION
## Summary

Diagnostic over the top 100 legacy balances on prod (after [#864](https://github.com/AudiusProject/api/pull/864)'s seed migration + sweep ran) showed ~35 users with multi-hundred-thousand-AUDIO gaps verdicted as "missing eth_wallet_balances for N of N linked wallets". The seed and sweep are fine — the view's IN-list lookup was just case-sensitive.

\`associated_wallets.wallet\` historically accepted mixed-case input from clients (before the eth-indexer started canonicalizing), while \`eth_wallet_balances.wallet\` is always lowercase (\`lowerHex()\` in the indexer + \`SELECT LOWER(wallet)\` in the 0204 seed migration). So an \`associated_wallets\` row like \`0xAbC…\` never matched its corresponding \`0xabc…\` row in \`eth_wallet_balances\`.

## Fix

\`LOWER()\` the values inside the IN-list — keeps \`ewb.wallet\` raw on the left side so \`eth_wallet_balances_pkey\` still drives the lookup:

\`\`\`sql
WHERE ewb.wallet IN (
    SELECT LOWER(u.wallet)
    UNION ALL
    SELECT LOWER(aw.wallet)
      FROM associated_wallets aw
     WHERE aw.user_id = u.user_id
       AND aw.chain = 'eth'
       AND aw.is_current = TRUE
       AND aw.is_delete = FALSE
)
\`\`\`

Different from the original \`LOWER(ewb.wallet) = LOWER(u.wallet)\` mistake that caused the CPU spike in [#856](https://github.com/AudiusProject/api/pull/856) — here \`LOWER\` is on the *values* being looked up, not on the indexed column. EXPLAIN cost is unchanged (37 units, same Index Scan paths).

\`\`\`
Index Scan using users_pkey on users u  (cost=0.14..8.16)
Index Scan using sol_user_balances_mint_user_id_idx on sol_user_balances sub  (cost=0.15..8.17)
Index Scan using unique_user_wallet_chain on associated_wallets aw  (cost=0.15..8.20)
Index Scan using eth_wallet_balances_pkey on eth_wallet_balances ewb  (cost=0.15..6.17)
\`\`\`

## Follow-up

This is a hotfix at the read site. A separate PR will canonicalize \`associated_wallets.wallet\` to lowercase in-place + add a \`BEFORE INSERT/UPDATE\` trigger (or generated column) to prevent future mixed-case inserts. Once that lands, every consumer of \`associated_wallets.wallet\` is safe by construction and the \`LOWER()\` here becomes a defensive no-op — leaving it in costs nothing and prevents regression.

The eth-indexer's \`filterTracked\` already \`LOWER\`s both sides of its lookup, so it's been working correctly throughout — the bug was scoped to the view.

## Test plan

- [x] \`go test ./api/ -run TestVUserBalances -count=1\` — 8 tests green, including the new \`TestVUserBalances_MixedCaseLinkedWallets\` that pins the bug shape (associated_wallets stored as \`0xAbCdEf…\`, eth_wallet_balances stored as \`0xabcdef…\`, must return the correct balance)
- [x] \`make test-schema\` regenerates cleanly
- [x] EXPLAIN confirms PK index lookup still drives the join
- [ ] Re-run the prod diagnostic query — the "missing eth_wallet_balances for N of N linked wallets" bucket should drop to ~0

🤖 Generated with [Claude Code](https://claude.com/claude-code)