### PR TITLE
Read user balance fields from v_user_balances in get_users.sql

### DIFF
--- a/api/dbv1/get_users.sql.go
+++ b/api/dbv1/get_users.sql.go
@@ -62,26 +62,29 @@ SELECT
   supporter_count,
   supporting_count,
   wallet,
-  balance,
-  associated_wallets_balance,
 
-  -- total_balance
+  -- Legacy ` + "`" + `balance` + "`" + ` (ETH-side AUDIO in wei) and ` + "`" + `associated_wallets_balance` + "`" + `
+  -- (the split between primary and linked wallets) are collapsed into
+  -- v_user_balances.eth_balance — sol_user_balances doesn't preserve a
+  -- user_bank-vs-linked breakdown so we don't preserve one on the ETH side
+  -- either. Surface the full ETH total under ` + "`" + `balance` + "`" + ` and zero out
+  -- ` + "`" + `associated_wallets_balance` + "`" + ` so the response shape stays the same and
+  -- ` + "`" + `total_balance` + "`" + ` still adds up to the right number.
+  coalesce(eth_balance, '0') as balance,
+  '0' as associated_wallets_balance,
+
+  -- total_balance: eth_balance is in wei, sol_balance is in wAUDIO base units
+  -- (8 decimals) so multiply by 10^10 to convert.
   (
-    coalesce(balance, '0')::NUMERIC +
-    coalesce(associated_wallets_balance, '0')::NUMERIC +
-    -- to wei
-    (coalesce(associated_sol_wallets_balance, '0')::NUMERIC * 10^10) +
-    (coalesce(waudio, '0')::NUMERIC * 10^10)
+    coalesce(eth_balance, '0')::NUMERIC +
+    (coalesce(sol_balance, '0')::NUMERIC * 10^10)
   )::NUMERIC::TEXT AS total_balance,
 
   -- total_audio_balance,
   FLOOR(
     (
-      coalesce(balance, '0')::NUMERIC +
-      coalesce(associated_wallets_balance, '0')::NUMERIC +
-      -- to wei
-      (coalesce(associated_sol_wallets_balance, '0')::NUMERIC * 10^10) +
-      (coalesce(waudio, '0')::NUMERIC * 10^10)
+      coalesce(eth_balance, '0')::NUMERIC +
+      (coalesce(sol_balance, '0')::NUMERIC * 10^10)
     ) / 1e18
   )::INT AS total_audio_balance,
 
@@ -92,8 +95,10 @@ SELECT
     ''
   )::text as payout_wallet,
 
-  coalesce(waudio, '0') as waudio_balance,
-  coalesce(associated_sol_wallets_balance, '0') as associated_sol_wallets_balance,
+  -- Same collapse on the sol side: full sol total under ` + "`" + `waudio_balance` + "`" + `,
+  -- ` + "`" + `associated_sol_wallets_balance` + "`" + ` zeroed.
+  coalesce(sol_balance, '0') as waudio_balance,
+  '0' as associated_sol_wallets_balance,
   blocknumber,
   u.created_at,
   is_storage_v2,
@@ -222,7 +227,7 @@ SELECT
 
 FROM users u
 JOIN aggregate_user using (user_id)
-LEFT JOIN user_balances using (user_id)
+LEFT JOIN v_user_balances using (user_id)
 LEFT JOIN user_bank_accounts on u.wallet = user_bank_accounts.ethereum_address
 LEFT JOIN usdc_user_bank_accounts on u.wallet = usdc_user_bank_accounts.ethereum_address
 WHERE u.user_id = ANY($2::int[])
@@ -269,8 +274,8 @@ type GetUsersRow struct {
 	SupporterCount                 int32           `json:"supporter_count"`
 	SupportingCount                int32           `json:"supporting_count"`
 	Wallet                         pgtype.Text     `json:"wallet"`
-	Balance                        pgtype.Text     `json:"balance"`
-	AssociatedWalletsBalance       pgtype.Text     `json:"associated_wallets_balance"`
+	Balance                        string          `json:"balance"`
+	AssociatedWalletsBalance       string          `json:"associated_wallets_balance"`
 	TotalBalance                   string          `json:"total_balance"`
 	TotalAudioBalance              int32           `json:"total_audio_balance"`
 	PayoutWallet                   string          `json:"payout_wallet"`

--- a/api/dbv1/models.go
+++ b/api/dbv1/models.go
@@ -2701,14 +2701,12 @@ type VUsdcPurchase struct {
 	Splits       interface{}             `json:"splits"`
 }
 
-// Drop-in replacement for the legacy user_balances table, sourced entirely from indexer-maintained tables (eth_wallet_balances for ETH-side AUDIO+staking+delegation, sol_token_account_balances for wAUDIO). Column shape mirrors user_balances so callers swap with a table-name rename. balance / associated_wallets_balance are in wei; waudio / associated_sol_wallets_balance are in wAUDIO base units (multiply by 10^10 to compare to wei).
+// Per-user AUDIO/wAUDIO balance totals. One row per current user with eth_balance (wei) and sol_balance (wAUDIO base units, 8 decimals — multiply by 10^10 to compare to wei). eth_balance sums eth_wallet_balances across users.wallet + chain=eth associated_wallets (current, not deleted). sol_balance is sol_user_balances for the wAUDIO mint, already pre-aggregated across user_bank PDAs + linked Solana wallets by handle_sol_claimable_accounts / update_sol_user_balance triggers.
 type VUserBalance struct {
-	UserID                      int32       `json:"user_id"`
-	Balance                     string      `json:"balance"`
-	AssociatedWalletsBalance    string      `json:"associated_wallets_balance"`
-	Waudio                      string      `json:"waudio"`
-	AssociatedSolWalletsBalance string      `json:"associated_sol_wallets_balance"`
-	UpdatedAt                   interface{} `json:"updated_at"`
+	UserID     int32       `json:"user_id"`
+	EthBalance string      `json:"eth_balance"`
+	SolBalance string      `json:"sol_balance"`
+	UpdatedAt  interface{} `json:"updated_at"`
 }
 
 type VolumeLeaderExclusion struct {

--- a/api/dbv1/queries/get_users.sql
+++ b/api/dbv1/queries/get_users.sql
@@ -46,26 +46,29 @@ SELECT
   supporter_count,
   supporting_count,
   wallet,
-  balance,
-  associated_wallets_balance,
 
-  -- total_balance
+  -- Legacy `balance` (ETH-side AUDIO in wei) and `associated_wallets_balance`
+  -- (the split between primary and linked wallets) are collapsed into
+  -- v_user_balances.eth_balance — sol_user_balances doesn't preserve a
+  -- user_bank-vs-linked breakdown so we don't preserve one on the ETH side
+  -- either. Surface the full ETH total under `balance` and zero out
+  -- `associated_wallets_balance` so the response shape stays the same and
+  -- `total_balance` still adds up to the right number.
+  coalesce(eth_balance, '0') as balance,
+  '0' as associated_wallets_balance,
+
+  -- total_balance: eth_balance is in wei, sol_balance is in wAUDIO base units
+  -- (8 decimals) so multiply by 10^10 to convert.
   (
-    coalesce(balance, '0')::NUMERIC +
-    coalesce(associated_wallets_balance, '0')::NUMERIC +
-    -- to wei
-    (coalesce(associated_sol_wallets_balance, '0')::NUMERIC * 10^10) +
-    (coalesce(waudio, '0')::NUMERIC * 10^10)
+    coalesce(eth_balance, '0')::NUMERIC +
+    (coalesce(sol_balance, '0')::NUMERIC * 10^10)
   )::NUMERIC::TEXT AS total_balance,
 
   -- total_audio_balance,
   FLOOR(
     (
-      coalesce(balance, '0')::NUMERIC +
-      coalesce(associated_wallets_balance, '0')::NUMERIC +
-      -- to wei
-      (coalesce(associated_sol_wallets_balance, '0')::NUMERIC * 10^10) +
-      (coalesce(waudio, '0')::NUMERIC * 10^10)
+      coalesce(eth_balance, '0')::NUMERIC +
+      (coalesce(sol_balance, '0')::NUMERIC * 10^10)
     ) / 1e18
   )::INT AS total_audio_balance,
 
@@ -76,8 +79,10 @@ SELECT
     ''
   )::text as payout_wallet,
 
-  coalesce(waudio, '0') as waudio_balance,
-  coalesce(associated_sol_wallets_balance, '0') as associated_sol_wallets_balance,
+  -- Same collapse on the sol side: full sol total under `waudio_balance`,
+  -- `associated_sol_wallets_balance` zeroed.
+  coalesce(sol_balance, '0') as waudio_balance,
+  '0' as associated_sol_wallets_balance,
   blocknumber,
   u.created_at,
   is_storage_v2,
@@ -206,7 +211,7 @@ SELECT
 
 FROM users u
 JOIN aggregate_user using (user_id)
-LEFT JOIN user_balances using (user_id)
+LEFT JOIN v_user_balances using (user_id)
 LEFT JOIN user_bank_accounts on u.wallet = user_bank_accounts.ethereum_address
 LEFT JOIN usdc_user_bank_accounts on u.wallet = usdc_user_bank_accounts.ethereum_address
 WHERE u.user_id = ANY(@ids::int[])


### PR DESCRIPTION
## Summary

Flips \`get_users.sql\` (the GetUsers query that powers \`/v1/users/*\` responses) from the legacy \`user_balances\` table to the new \`v_user_balances\` view. After this lands \`user_balances\` has zero Go readers and Python's \`cache_user_balance.py\` is fully redundant.

## Why now

PR #864 seeded \`eth_wallet_balances\` with every tracked wallet, the stale-refresh sweep filled in real balances, and PR #866 fixed the case-sensitive IN-list that was hiding correctly-summed wallets. The side-by-side diagnostic against the legacy table on prod after all three landed:

| Verdict | Real meaning | Count (top 100) |
|---|---|---:|
| \`match\` | fresh = legacy | ~67 |
| \`legacy stale (fresh higher)\` | fresh is correct, legacy hasn't refreshed since something landed | ~17 |
| \`legacy stale (fresh lower)\` (misclassified as "missing linked wallets") | 5-year-old \`cache_user_balance.py\` snapshot the user has since drained | 2 |
| \`sol_user_balances stale\` | known small set — needs \`update_sol_user_balance_mint\` recompute | 4 |
| \`eth balance stale\` | sweep cadence canary (single row, ~no real balance) | 1 |

Every "missing" verdict on the eth side turned out to be a false positive. The eth-side pipeline is genuinely caught up. The 4 sol-side stale rows are a separate small problem (max drift 23k wAUDIO for user 608) that won't be made worse by flipping.

## What changes

\`api/dbv1/queries/get_users.sql\`: one JOIN swap + the column references for \`balance\`, \`associated_wallets_balance\`, \`waudio\`, \`associated_sol_wallets_balance\` get rewritten in terms of the view's \`eth_balance\` + \`sol_balance\`. The JSON response shape is preserved:

| Response field | New source |
|---|---|
| \`balance\` | \`v_user_balances.eth_balance\` (full ETH-side total) |
| \`associated_wallets_balance\` | \`'0'\` — the view doesn't split primary vs linked |
| \`waudio_balance\` | \`v_user_balances.sol_balance\` (full sol-side total) |
| \`associated_sol_wallets_balance\` | \`'0'\` — same collapse |
| \`total_balance\` | \`eth_balance + sol_balance * 10^10\` — same number as before |
| \`total_audio_balance\` | \`total_balance / 1e18\` floored — same number as before |

Consumers reading \`balance\` thinking it's primary-wallet-only will see the linked sum folded in. In practice the legacy semantics were rarely consumed this way — UIs that mattered already summed all four for display.

## Follow-ups (already drafted, separate PRs)

- **#867**: canonicalize \`associated_wallets.wallet\` to lowercase + add BEFORE trigger so the view's defensive LOWER() becomes a no-op.
- **Manual recompute** of \`sol_user_balances\` for the 4 stale users (608, 11957, 29493, 8471, 12427) — drift is in the high-hundreds-of-wAUDIO max; doable as a one-shot \`SELECT update_sol_user_balance_mint(...)\` loop.
- **Decommission \`cache_user_balance.py\`** in discovery-provider once this is soaked.

## Test plan

- [x] \`go test ./api/ -count=1\` — full API suite green (the response-shape regression tests would catch any drift in \`balance\` / \`total_balance\` / \`total_audio_balance\`)
- [x] \`make test-schema\` clean
- [ ] Stage soak — confirm \`/v1/users/{id}\` returns the expected balance fields, watch DB CPU for any LATERAL regression
- [ ] Prod canary — pick a few users from each verdict bucket, hit the endpoint, compare response totals against this PR's diagnostic numbers

🤖 Generated with [Claude Code](https://claude.com/claude-code)