### PR TITLE
fix(rewards): use LOWER(users.wallet) in v_challenge_disbursements join

### DIFF
--- a/ddl/migrations/0204_fix_challenge_disbursements_case_sensitivity.sql
+++ b/ddl/migrations/0204_fix_challenge_disbursements_case_sensitivity.sql
@@ -1,0 +1,42 @@
+-- Fix case-sensitivity bug in v_challenge_disbursements.
+--
+-- The Go Solana indexer stores recipient_eth_address as lowercase
+-- (strings.ToLower in reward_manager.go:45), but users.wallet is an
+-- EIP-55 checksummed address (mixed-case). The previous JOIN used a
+-- case-sensitive equality check, which meant the join always failed
+-- for any user whose wallet differs in case from the stored lowercase
+-- value — i.e., virtually every user.
+--
+-- Effect of the bug:
+--   - All disbursements in sol_reward_disbursements were invisible
+--     through v_challenge_disbursements.
+--   - The /v1/challenges/undisbursed endpoint (which LEFT JOINs against
+--     this view) treated every completed challenge as unpaid.
+--   - The trending-challenge-rewards bot retried all of them; Solana
+--     rejected with "specifier already used". Users received their
+--     rewards correctly on-chain, but the bot's Slack report showed
+--     null slots for everything.
+--
+-- Fix: normalise the wallet side of the join to lowercase before
+-- comparing, matching the format already stored in the indexer table.
+
+BEGIN;
+
+DROP VIEW IF EXISTS v_challenge_disbursements;
+CREATE VIEW v_challenge_disbursements AS
+    SELECT
+        rd.challenge_id,
+        rd.specifier,
+        rd.amount::text AS amount,
+        rd.signature,
+        rd.slot,
+        rd.created_at,
+        users.user_id
+    FROM sol_reward_disbursements rd
+    JOIN users
+        ON LOWER(users.wallet) = rd.recipient_eth_address
+       AND users.is_current = TRUE;
+
+COMMENT ON VIEW v_challenge_disbursements IS 'Compatibility view that exposes sol_reward_disbursements in the column shape the API routes used to read from challenge_disbursements. Resolves user_id via the indexer-populated recipient_eth_address (see migration 0172). Join uses LOWER(users.wallet) because the Go indexer stores recipient_eth_address as lowercase.';
+
+COMMIT;

--- a/ddl/views/v_challenge_disbursements.sql
+++ b/ddl/views/v_challenge_disbursements.sql
@@ -10,7 +10,7 @@ CREATE VIEW v_challenge_disbursements AS
         users.user_id
     FROM sol_reward_disbursements rd
     JOIN users
-        ON users.wallet = rd.recipient_eth_address
+        ON LOWER(users.wallet) = rd.recipient_eth_address
        AND users.is_current = TRUE;
 
 COMMENT ON VIEW v_challenge_disbursements IS 'Compatibility view that exposes sol_reward_disbursements in the column shape the API routes used to read from challenge_disbursements. Resolves user_id via the indexer-populated recipient_eth_address (see migration 0172).';


### PR DESCRIPTION
## Summary

The Go Solana indexer stores `recipient_eth_address` as lowercase (`strings.ToLower` in `reward_manager.go`), but `users.wallet` is EIP-55 checksummed (mixed-case). The previous case-sensitive equality in `v_challenge_disbursements` caused every join to fail, making all disbursements invisible through the view.

**Effect:** The `/v1/challenges/undisbursed` endpoint treated every completed challenge as unpaid. The trending-challenge-rewards bot retried all of them on every run; Solana correctly rejected duplicates (users did receive their AUDIO on-chain), but the Slack report showed null slots for all disbursements.

**Fix:** `LOWER(users.wallet) = rd.recipient_eth_address` in the view and a new migration (0204).

## Test plan
- [ ] Verify `v_challenge_disbursements` returns rows for recently disbursed challenges
- [ ] Verify `/v1/challenges/undisbursed` no longer returns already-paid challenges
- [ ] Run trending-challenge-rewards bot and confirm Slack report shows correct slots