### PR TITLE
fix(jobs): 0x-prefix delegate-auth signature for notifier requests

### DIFF
--- a/jobs/delegate_auth.go
+++ b/jobs/delegate_auth.go
@@ -90,6 +90,15 @@ func basicAuthNonce(delegatePrivateKey string, now time.Time) (string, error) {
 		sig[64] += 27
 	}
 
-	nonce := tsStr + ":" + hex.EncodeToString(sig)
+	// The signature hex MUST carry the "0x" prefix. apps builds the nonce as
+	// f"{timestamp}:{signature.hex()}" where signature is a web3.py HexBytes;
+	// under hexbytes 0.3.1 (apps' pinned version) HexBytes.hex() returns the
+	// string WITH a leading "0x". The notifier's verifier parses the sig
+	// assuming that prefix (it strips the first two chars). Without "0x" the
+	// whole 65-byte signature shifts by one byte: r/s are corrupted and the
+	// recovery byte is read from the wrong offset — yielding a value outside
+	// [0,3] and the notifier's "recovery param is more than two bits" 401.
+	// mediorum's basic_auth.go does the same `0x`-prefixing for this reason.
+	nonce := tsStr + ":0x" + hex.EncodeToString(sig)
 	return "Basic " + base64.StdEncoding.EncodeToString([]byte(nonce)), nil
 }

--- a/jobs/delegate_auth_test.go
+++ b/jobs/delegate_auth_test.go
@@ -30,8 +30,20 @@ func TestBasicAuthNonce_Shape(t *testing.T) {
 	parts := strings.SplitN(string(decoded), ":", 2)
 	require.Len(t, parts, 2)
 	assert.Equal(t, "1700000000000", parts[0])
-	// signature is 65 bytes = 130 hex chars
-	assert.Len(t, parts[1], 130)
+	// The signature must be "0x"-prefixed to match apps' nonce format
+	// (f"{ts}:{HexBytes.hex()}" with hexbytes 0.3.1, which prepends "0x").
+	// The notifier strips this prefix before decoding; without it the sig
+	// bytes shift and verification fails with "recovery param is more than
+	// two bits". 2 chars ("0x") + 65 bytes * 2 = 132.
+	assert.True(t, strings.HasPrefix(parts[1], "0x"),
+		"signature hex must carry 0x prefix, got %q", parts[1])
+	assert.Len(t, parts[1], 132)
+
+	// The recovery byte (last hex pair) must be 1b or 1c (27/28), matching
+	// web3.py's sign_message convention that apps and the notifier expect.
+	recoveryByte := parts[1][len(parts[1])-2:]
+	assert.Contains(t, []string{"1b", "1c"}, recoveryByte,
+		"recovery byte should be 27/28, got %q", recoveryByte)
 }
 
 func TestBasicAuthNonce_BadKey(t *testing.T) {


### PR DESCRIPTION
## Summary

`UpdateDelistStatusesJob` is failing against `notifier.audius.co` with:

```
notifier returned non-2xx: HTTP 401: basic auth: invalid signature:
Error: The recovery param is more than two bits
```

## Root cause

The signed Authorization nonce omitted the `0x` prefix on the signature hex.

apps builds the nonce as `f"{timestamp}:{signature.hex()}"` (see `discovery-provider/src/utils/auth_helpers.py`). `signature` is a web3.py `HexBytes`, and under apps' pinned **`hexbytes==0.3.1`**, `HexBytes.hex()` returns the string **with a leading `0x`** (the prefix was only dropped in hexbytes 1.0). So apps sends:

```
<ts>:0x<r:32><s:32><v:1>
```

The notifier's verifier was built against that format — it strips the leading two chars before hex-decoding the 65-byte signature.

Our Go mirror (`jobs/delegate_auth.go`) used `hex.EncodeToString(sig)` with **no prefix**, sending:

```
<ts>:<r:32><s:32><v:1>
```

The notifier stripped our first *real* signature byte instead of `0x`, shifting the whole r/s/v layout by one byte. The recovery byte got read from the wrong offset — typically a value outside the valid `[0,3]` range — which is exactly elliptic's `"recovery param is more than two bits"` assertion, returned as a 401.

## Fix

Prefix the signature hex with `0x`:

```go
nonce := tsStr + ":0x" + hex.EncodeToString(sig)
```

This matches apps' nonce byte-for-byte (and `pkg/mediorum/server/signature/basic_auth.go`, which already does `fmt.Sprintf("0x%s", ...)` for the same scheme). The `+27` recovery-byte normalization was already correct (apps uses web3.py → v=27/28) and is unchanged.

## Why the original test didn't catch it

The prior `TestBasicAuthNonce_Shape` checked the nonce *length* (130 hex chars) but not its *format*, and its own comment deferred cross-format verification to "integration testing." So a structurally-valid but wire-incompatible nonce passed. This PR tightens the test to assert:
- the `0x` prefix is present (length now 132),
- the recovery byte is `1b`/`1c` (27/28).

## Test plan

- [x] `go build ./jobs/...` clean
- [x] `go test ./jobs/ -run TestBasicAuthNonce` passes
- [ ] Deploy; confirm `UpdateDelistStatusesJob` logs success (no more 401s) against notifier.audius.co

🤖 Generated with [Claude Code](https://claude.com/claude-code)