### PR TITLE
fix(api): key challenge disbursement reads by specifier, not recipient

### DIFF
--- a/api/dbv1/get_undisbursed_challenges.sql.go
+++ b/api/dbv1/get_undisbursed_challenges.sql.go
@@ -20,7 +20,7 @@ SELECT
     user_challenges.amount
 FROM user_challenges
 JOIN users ON users.user_id = user_challenges.user_id
-LEFT JOIN v_challenge_disbursements AS challenge_disbursements
+LEFT JOIN sol_reward_disbursements AS challenge_disbursements
     ON challenge_disbursements.challenge_id = user_challenges.challenge_id
     AND challenge_disbursements.specifier = user_challenges.specifier
 WHERE
@@ -45,6 +45,10 @@ type GetUndisbursedChallengesRow struct {
 	Amount      int32       `json:"amount"`
 }
 
+// Match raw disbursement rows by (challenge_id, specifier): a reward is disbursed
+// once per specifier on-chain regardless of recipient, and reading
+// sol_reward_disbursements directly avoids v_challenge_disbursements dropping
+// disbursements whose recipient wallet does not resolve to a current user.
 func (q *Queries) GetUndisbursedChallenges(ctx context.Context, arg GetUndisbursedChallengesParams) ([]GetUndisbursedChallengesRow, error) {
 	rows, err := q.db.Query(ctx, getUndisbursedChallenges, arg.UserID, arg.ChallengeID, arg.Specifier)
 	if err != nil {

--- a/api/dbv1/get_undisbursed_challenges.sql.go
+++ b/api/dbv1/get_undisbursed_challenges.sql.go
@@ -45,10 +45,8 @@ type GetUndisbursedChallengesRow struct {
 	Amount      int32       `json:"amount"`
 }
 
-// Match raw disbursement rows by (challenge_id, specifier): a reward is disbursed
-// once per specifier on-chain regardless of recipient, and reading
-// sol_reward_disbursements directly avoids v_challenge_disbursements dropping
-// disbursements whose recipient wallet does not resolve to a current user.
+// Anti-join the raw table by (challenge_id, specifier); the v_challenge_disbursements
+// view drops disbursements whose recipient wallet doesn't resolve to a user.
 func (q *Queries) GetUndisbursedChallenges(ctx context.Context, arg GetUndisbursedChallengesParams) ([]GetUndisbursedChallengesRow, error) {
 	rows, err := q.db.Query(ctx, getUndisbursedChallenges, arg.UserID, arg.ChallengeID, arg.Specifier)
 	if err != nil {

--- a/api/dbv1/queries/get_undisbursed_challenges.sql
+++ b/api/dbv1/queries/get_undisbursed_challenges.sql
@@ -7,10 +7,8 @@ SELECT
     user_challenges.amount
 FROM user_challenges
 JOIN users ON users.user_id = user_challenges.user_id
--- Match raw disbursement rows by (challenge_id, specifier): a reward is disbursed
--- once per specifier on-chain regardless of recipient, and reading
--- sol_reward_disbursements directly avoids v_challenge_disbursements dropping
--- disbursements whose recipient wallet does not resolve to a current user.
+-- Anti-join the raw table by (challenge_id, specifier); the v_challenge_disbursements
+-- view drops disbursements whose recipient wallet doesn't resolve to a user.
 LEFT JOIN sol_reward_disbursements AS challenge_disbursements
     ON challenge_disbursements.challenge_id = user_challenges.challenge_id
     AND challenge_disbursements.specifier = user_challenges.specifier

--- a/api/dbv1/queries/get_undisbursed_challenges.sql
+++ b/api/dbv1/queries/get_undisbursed_challenges.sql
@@ -7,7 +7,11 @@ SELECT
     user_challenges.amount
 FROM user_challenges
 JOIN users ON users.user_id = user_challenges.user_id
-LEFT JOIN v_challenge_disbursements AS challenge_disbursements
+-- Match raw disbursement rows by (challenge_id, specifier): a reward is disbursed
+-- once per specifier on-chain regardless of recipient, and reading
+-- sol_reward_disbursements directly avoids v_challenge_disbursements dropping
+-- disbursements whose recipient wallet does not resolve to a current user.
+LEFT JOIN sol_reward_disbursements AS challenge_disbursements
     ON challenge_disbursements.challenge_id = user_challenges.challenge_id
     AND challenge_disbursements.specifier = user_challenges.specifier
 WHERE

--- a/api/v1_challenges_disbursements.go
+++ b/api/v1_challenges_disbursements.go
@@ -51,7 +51,7 @@ func (app *ApiServer) v1ChallengesDisbursements(c *fiber.Ctx) error {
 	case "specifier":
 		sortMethod = "cd.specifier"
 	case "user_id":
-		sortMethod = "cd.user_id"
+		sortMethod = "u.user_id"
 	}
 
 	whereClause := ""
@@ -63,25 +63,33 @@ func (app *ApiServer) v1ChallengesDisbursements(c *fiber.Ctx) error {
 		filters = append(filters, "cd.specifier ILIKE '%' || @specifierQuery || '%'")
 	}
 	if params.ChallengeUserID != 0 {
-		filters = append(filters, "cd.user_id = @challengeUserId")
+		filters = append(filters, "u.user_id = @challengeUserId")
 	}
 
 	if len(filters) > 0 {
 		whereClause = "WHERE " + strings.Join(filters, " AND ")
 	}
 
+	// Resolve the recipient user_id from the on-chain recipient_eth_address.
+	// The Go indexer stores recipient_eth_address lowercased, while users.wallet
+	// is an EIP-55 checksummed (mixed-case) address, so normalise before joining
+	// (see migration 0204). This inlines the former v_challenge_disbursements view,
+	// now that this is its only consumer.
 	sql := `
 	SELECT
 		cd.challenge_id,
-		cd.user_id,
+		u.user_id,
 		cd.specifier,
-		cd.amount,
+		cd.amount::text AS amount,
 		cd.created_at,
 		cd.signature,
 		cd.slot
-	FROM v_challenge_disbursements cd
+	FROM sol_reward_disbursements cd
+	JOIN users u
+		ON LOWER(u.wallet) = cd.recipient_eth_address
+		AND u.is_current = true
 	` + whereClause + `
-	ORDER BY ` + sortMethod + ` ` + sortDir + `, cd.user_id ASC
+	ORDER BY ` + sortMethod + ` ` + sortDir + `, u.user_id ASC
 	LIMIT @limit
 	OFFSET @offset;
 	`

--- a/api/v1_challenges_disbursements.go
+++ b/api/v1_challenges_disbursements.go
@@ -70,11 +70,9 @@ func (app *ApiServer) v1ChallengesDisbursements(c *fiber.Ctx) error {
 		whereClause = "WHERE " + strings.Join(filters, " AND ")
 	}
 
-	// Resolve the recipient user_id from the on-chain recipient_eth_address.
-	// The Go indexer stores recipient_eth_address lowercased, while users.wallet
-	// is an EIP-55 checksummed (mixed-case) address, so normalise before joining
-	// (see migration 0204). This inlines the former v_challenge_disbursements view,
-	// now that this is its only consumer.
+	// Inlines the former v_challenge_disbursements view to resolve recipient user_id.
+	// recipient_eth_address is stored lowercase but users.wallet is checksummed, so
+	// join on LOWER(users.wallet) (see migration 0204).
 	sql := `
 	SELECT
 		cd.challenge_id,

--- a/api/v1_challenges_info.go
+++ b/api/v1_challenges_info.go
@@ -59,10 +59,8 @@ func (app *ApiServer) v1ChallengesInfo(c *fiber.Ctx) error {
 		CASE
 			WHEN c.weekly_pool IS NULL THEN NULL
 			ELSE c.weekly_pool - COALESCE(
-				-- Read sol_reward_disbursements directly: the weekly pool spent is the
-				-- sum of all disbursements for the challenge, independent of recipient.
-				-- v_challenge_disbursements would drop any whose recipient wallet does
-				-- not resolve to a current user, overstating the remaining pool.
+				-- Sum from the raw table, not the view, which would drop
+				-- unresolved-recipient disbursements and overstate the remaining pool.
 				(SELECT SUM(cd.amount) / 100000000
 				 FROM sol_reward_disbursements cd
 				 WHERE cd.challenge_id = c.id

--- a/api/v1_challenges_info.go
+++ b/api/v1_challenges_info.go
@@ -59,8 +59,12 @@ func (app *ApiServer) v1ChallengesInfo(c *fiber.Ctx) error {
 		CASE
 			WHEN c.weekly_pool IS NULL THEN NULL
 			ELSE c.weekly_pool - COALESCE(
-				(SELECT SUM(cd.amount::bigint) / 100000000
-				 FROM v_challenge_disbursements cd
+				-- Read sol_reward_disbursements directly: the weekly pool spent is the
+				-- sum of all disbursements for the challenge, independent of recipient.
+				-- v_challenge_disbursements would drop any whose recipient wallet does
+				-- not resolve to a current user, overstating the remaining pool.
+				(SELECT SUM(cd.amount) / 100000000
+				 FROM sol_reward_disbursements cd
 				 WHERE cd.challenge_id = c.id
 				   AND cd.created_at > @weeklyPoolWindowStart),
 				0

--- a/api/v1_challenges_undisbursed.go
+++ b/api/v1_challenges_undisbursed.go
@@ -62,11 +62,9 @@ func (app *ApiServer) v1ChallengesUndisbursed(c *fiber.Ctx) error {
 	FROM user_challenges
 	JOIN challenges ON challenges.id = user_challenges.challenge_id
 	JOIN users ON users.user_id = user_challenges.user_id
-	-- A reward is disbursed once per (challenge_id, specifier) on-chain, regardless
-	-- of recipient. Match on the raw sol_reward_disbursements rows by specifier so a
-	-- reward that was already paid is never offered for claim, even if its recipient
-	-- wallet does not resolve to a current user (which v_challenge_disbursements would
-	-- drop, wrongly surfacing it as claimable).
+	-- Anti-join raw sol_reward_disbursements by (challenge_id, specifier), not the
+	-- v_challenge_disbursements view: a paid specifier must never be offered for claim,
+	-- and the view drops disbursements whose recipient wallet doesn't resolve to a user.
 	LEFT JOIN sol_reward_disbursements AS challenge_disbursements ON
 		challenge_disbursements.challenge_id = user_challenges.challenge_id
 		AND challenge_disbursements.specifier = user_challenges.specifier

--- a/api/v1_challenges_undisbursed.go
+++ b/api/v1_challenges_undisbursed.go
@@ -62,7 +62,12 @@ func (app *ApiServer) v1ChallengesUndisbursed(c *fiber.Ctx) error {
 	FROM user_challenges
 	JOIN challenges ON challenges.id = user_challenges.challenge_id
 	JOIN users ON users.user_id = user_challenges.user_id
-	LEFT JOIN v_challenge_disbursements AS challenge_disbursements ON
+	-- A reward is disbursed once per (challenge_id, specifier) on-chain, regardless
+	-- of recipient. Match on the raw sol_reward_disbursements rows by specifier so a
+	-- reward that was already paid is never offered for claim, even if its recipient
+	-- wallet does not resolve to a current user (which v_challenge_disbursements would
+	-- drop, wrongly surfacing it as claimable).
+	LEFT JOIN sol_reward_disbursements AS challenge_disbursements ON
 		challenge_disbursements.challenge_id = user_challenges.challenge_id
 		AND challenge_disbursements.specifier = user_challenges.specifier
 	WHERE challenge_disbursements.challenge_id IS NULL

--- a/api/v1_coins_post_redeem.go
+++ b/api/v1_coins_post_redeem.go
@@ -164,10 +164,8 @@ func (app *ApiServer) v1CoinsPostRedeem(c *fiber.Ctx) error {
 		redeemCode = coinTicker
 		// Check for challenge disbursement for the given code/userId
 		var count int
-		// Read sol_reward_disbursements directly: this is an existence check by
-		// (challenge_id, specifier) and must count a prior redemption even if its
-		// recipient wallet does not resolve to a current user (which
-		// v_challenge_disbursements would drop, allowing a double redemption).
+		// Existence check against the raw table, not the view: a prior redemption must
+		// block a second one even if its recipient wallet doesn't resolve to a user.
 		err := app.writePool.QueryRow(c.Context(), `SELECT count(*) FROM sol_reward_disbursements WHERE challenge_id = @code AND specifier = @specifier LIMIT 1;`, pgx.NamedArgs{
 			"code":      redeemCode,
 			"specifier": specifier,

--- a/api/v1_coins_post_redeem.go
+++ b/api/v1_coins_post_redeem.go
@@ -164,7 +164,11 @@ func (app *ApiServer) v1CoinsPostRedeem(c *fiber.Ctx) error {
 		redeemCode = coinTicker
 		// Check for challenge disbursement for the given code/userId
 		var count int
-		err := app.writePool.QueryRow(c.Context(), `SELECT count(*) FROM v_challenge_disbursements WHERE challenge_id = @code AND specifier = @specifier LIMIT 1;`, pgx.NamedArgs{
+		// Read sol_reward_disbursements directly: this is an existence check by
+		// (challenge_id, specifier) and must count a prior redemption even if its
+		// recipient wallet does not resolve to a current user (which
+		// v_challenge_disbursements would drop, allowing a double redemption).
+		err := app.writePool.QueryRow(c.Context(), `SELECT count(*) FROM sol_reward_disbursements WHERE challenge_id = @code AND specifier = @specifier LIMIT 1;`, pgx.NamedArgs{
 			"code":      redeemCode,
 			"specifier": specifier,
 		}).Scan(&count)

--- a/api/v1_users_challenges.go
+++ b/api/v1_users_challenges.go
@@ -46,13 +46,8 @@ func (app *ApiServer) v1UsersChallenges(c *fiber.Ctx) error {
 		FROM challenges
 		LEFT JOIN user_challenges_filtered ON challenges.id = user_challenges_filtered.challenge_id
 		CROSS JOIN user_row
-		-- A reward is disbursed exactly once per (challenge_id, specifier) on-chain,
-		-- regardless of which wallet/user received it. Match disbursements by
-		-- specifier (not by user_id) so a reward that has already been paid out is
-		-- never surfaced as still-claimable, even when it was attributed to a
-		-- different user than user_challenges records. Read sol_reward_disbursements
-		-- directly rather than v_challenge_disbursements so disbursements whose
-		-- recipient wallet does not resolve to a current user are still counted.
+		-- Match by (challenge_id, specifier), not user: a specifier is disbursed once
+		-- on-chain, so a paid reward is never shown claimable even if paid to another user.
 		LEFT JOIN sol_reward_disbursements AS reward_disbursements
 			ON user_challenges_filtered.challenge_id = reward_disbursements.challenge_id
 			AND user_challenges_filtered.specifier = reward_disbursements.specifier

--- a/api/v1_users_challenges.go
+++ b/api/v1_users_challenges.go
@@ -24,11 +24,6 @@ func (app *ApiServer) v1UsersChallenges(c *fiber.Ctx) error {
 		SELECT * FROM user_challenges JOIN user_row USING (user_id)
 	),
 
-	-- Pre-filter to their disbursements
-	challenge_disbursements_filtered AS (
-		SELECT * FROM v_challenge_disbursements JOIN user_row USING (user_id)
-	),
-
 	-- Start with the list of all active challenges, and then
 	-- apply the user's user challenges and disbursements.
 	-- verified-only challenges if not verified
@@ -39,21 +34,28 @@ func (app *ApiServer) v1UsersChallenges(c *fiber.Ctx) error {
 			COALESCE(user_challenges_filtered.specifier, '') AS specifier,
 			COALESCE(user_challenges_filtered.is_complete, false) AS is_complete,
 			challenges.active AS is_active,
-			(challenge_disbursements_filtered.slot IS NOT NULL) AS is_disbursed,
+			(reward_disbursements.slot IS NOT NULL) AS is_disbursed,
 			COALESCE(user_challenges_filtered.current_step_count, 0) AS current_step_count,
 			challenges.step_count AS max_steps,
 			challenges.type AS challenge_type,
 			COALESCE(challenges.amount::BIGINT, 0) AS amount,
 			COALESCE(user_challenges_filtered.amount, 0) AS user_amount,
-			COALESCE(challenge_disbursements_filtered.amount, '0')::BIGINT / 100000000 AS disbursed_amount,
+			COALESCE(reward_disbursements.amount, 0) / 100000000 AS disbursed_amount,
 			COALESCE(challenges.cooldown_days, 0) AS cooldown_days,
 			user_challenges_filtered.created_at
 		FROM challenges
 		LEFT JOIN user_challenges_filtered ON challenges.id = user_challenges_filtered.challenge_id
 		CROSS JOIN user_row
-		LEFT JOIN challenge_disbursements_filtered
-			ON user_challenges_filtered.challenge_id = challenge_disbursements_filtered.challenge_id
-			AND user_challenges_filtered.specifier = challenge_disbursements_filtered.specifier
+		-- A reward is disbursed exactly once per (challenge_id, specifier) on-chain,
+		-- regardless of which wallet/user received it. Match disbursements by
+		-- specifier (not by user_id) so a reward that has already been paid out is
+		-- never surfaced as still-claimable, even when it was attributed to a
+		-- different user than user_challenges records. Read sol_reward_disbursements
+		-- directly rather than v_challenge_disbursements so disbursements whose
+		-- recipient wallet does not resolve to a current user are still counted.
+		LEFT JOIN sol_reward_disbursements AS reward_disbursements
+			ON user_challenges_filtered.challenge_id = reward_disbursements.challenge_id
+			AND user_challenges_filtered.specifier = reward_disbursements.specifier
 		WHERE challenges.active
 			AND NOT (challenges.id IN ('rv', 's') AND NOT user_row.is_verified)
 			AND NOT (challenges.id IN ('r') AND user_row.is_verified)

--- a/api/v1_users_challenges_test.go
+++ b/api/v1_users_challenges_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -49,5 +50,37 @@ func TestUserChallenges(t *testing.T) {
 		"data.0.amount":             "1",
 		"data.0.current_step_count": "0",
 		"data.0.is_complete":        false,
+	})
+}
+
+// A reward that has been disbursed for a (challenge_id, specifier) must show as
+// disbursed to the user who completed that specifier, even when the on-chain
+// recipient wallet resolves to a different user. Disbursements are deduped by
+// (challenge_id, specifier) on-chain, so a paid specifier can never be claimed
+// again — surfacing it as still-claimable produces a stuck reward that errors
+// on claim.
+func TestUserChallengesDisbursedToDifferentUser(t *testing.T) {
+	app := testAppWithFixtures(t)
+	ctx := context.Background()
+
+	// User 402 (L50xn) completed boolean challenge "f" with specifier "fff".
+	// Record an on-chain disbursement for that specifier whose recipient wallet
+	// belongs to a different user (user 1, rayjacobson).
+	_, err := app.pool.Exec(ctx, `
+		INSERT INTO sol_reward_disbursements
+			(signature, instruction_index, amount, slot, user_bank, challenge_id, specifier, recipient_eth_address)
+		VALUES
+			('sig-fff', 0, 100000000, 1, 'user-bank-x', 'f', 'fff', '0x7d273271690538cf855e5b3002a0dd8c154bb060')
+	`)
+	assert.NoError(t, err)
+
+	status, body := testGet(t, app, "/v1/users/L50xn/challenges")
+	assert.Equal(t, 200, status)
+	// Challenges are ordered by challenge_id, so "f" follows the rolled-up "e".
+	jsonAssert(t, body, map[string]any{
+		"data.1.challenge_id":     "f",
+		"data.1.is_complete":      true,
+		"data.1.is_disbursed":     true,
+		"data.1.disbursed_amount": float64(1),
 	})
 }


### PR DESCRIPTION
## Problem

`v_challenge_disbursements` exposes `sol_reward_disbursements` in the legacy `challenge_disbursements` shape and resolves `user_id` by **INNER JOIN**ing `users` on the recipient wallet. Any disbursement whose recipient doesn't resolve to a current user (wallet migrations, deactivated users, case mismatches) is silently dropped from the view.

Most callers only ask the identity-independent question *"has this `(challenge_id, specifier)` been disbursed?"* — and a reward is disbursed exactly once per `(challenge_id, specifier)` on-chain, regardless of recipient. For those callers, a dropped row makes a **paid** reward look **unpaid**:

- **`/users/{id}/challenges`** — showed `is_complete=true, is_disbursed=false`, so the client offered an already-paid reward as claimable; the claim then failed ("No rewards to claim" / on-chain "specifier already used"). This was the original bug.
- **`/challenges/undisbursed`** (HTTP handler **and** the sqlc query used by the claim path) — same: a dropped disbursement makes a paid specifier claimable, and the claim fails on-chain. This is the exact failure mode migration `0204` documents.
- **`/challenges/info`** — `weekly_pool_remaining` overstated by any dropped disbursement.
- **coins redeem** — the double-redeem guard counts 0 and allows a second redemption.

## Fix

All specifier/challenge-keyed callers now read `sol_reward_disbursements` directly by `(challenge_id, specifier)`, aligning them with how the reward manager dedupes disbursements on-chain. `is_disbursed` on `/users/{id}/challenges` is now keyed by specifier rather than the querying user.

The one caller that genuinely needs the recipient `user_id` — **`/challenges/disbursements`** (admin listing) — inlines the `users` join, using `LOWER(users.wallet) = recipient_eth_address` per migration `0204` (the stale `ddl/views` file had the pre-`0204` case-sensitive join and, because `views/` applies after `migrations/`, was silently reverting the fix — so the deployed view was the broken one; inlining fixes that too).

The view is now unused but **retained in this PR** so the binary can deploy before the view is dropped. The drop is a stacked follow-up: **#873**.

## Why reads, not a data migration

`user_challenges` is indexer-derived; a manual reattribution would be reverted on reindex and doesn't address the read inconsistency. Keying reads by specifier is self-healing for past and future occurrences. (Attribution in `user_challenges` is intentionally left unchanged.)

## Tests

- New `TestUserChallengesDisbursedToDifferentUser`: a disbursement attributed (by wallet) to a different user now reports `is_disbursed=true` for the completer.
- Existing `TestGetChallengeDisbursements` covers the inlined join across all sorts/filters incl. `challenge_user_id`.
- Full `./api` + `./api/dbv1` suites pass.

## Rollout
1. Merge + deploy this (reads no longer touch the view; view still present).
2. Then merge #873 to drop the view.

🤖 Generated with [Claude Code](https://claude.com/claude-code)