### PR TITLE
feat(tracks): allow custom genres; cap at 100 chars

### DIFF
--- a/api/swagger/swagger-v1.yaml
+++ b/api/swagger/swagger-v1.yaml
@@ -14387,59 +14387,17 @@ components:
           $ref: "#/components/schemas/grant"
     genre:
       type: string
-      description: Music genre
-      enum:
-        - Electronic
-        - Rock
-        - Metal
-        - Alternative
-        - Hip-Hop/Rap
-        - Experimental
-        - Punk
-        - Folk
-        - Pop
-        - Ambient
-        - Soundtrack
-        - World
-        - Jazz
-        - Acoustic
-        - Funk
-        - R&B/Soul
-        - Devotional
-        - Classical
-        - Reggae
-        - Podcasts
-        - Country
-        - Spoken Word
-        - Comedy
-        - Blues
-        - Kids
-        - Audiobooks
-        - Latin
-        - Lo-Fi
-        - Hyperpop
-        - Dancehall
-        - Techno
-        - Trap
-        - House
-        - Tech House
-        - Deep House
-        - Disco
-        - Electro
-        - Jungle
-        - Progressive House
-        - Hardstyle
-        - Glitch Hop
-        - Trance
-        - Future Bass
-        - Future House
-        - Tropical House
-        - Downtempo
-        - Drum & Bass
-        - Dubstep
-        - Jersey Club
-        - Vaporwave
-        - Moombahton
+      maxLength: 100
+      description: |
+        Music genre. Any string up to 100 characters is accepted. Known/canonical
+        values (shown as autocomplete suggestions in clients): Electronic, Rock,
+        Metal, Alternative, Hip-Hop/Rap, Experimental, Punk, Folk, Pop, Ambient,
+        Soundtrack, World, Jazz, Acoustic, Funk, R&B/Soul, Devotional, Classical,
+        Reggae, Podcasts, Country, Spoken Word, Comedy, Blues, Kids, Audiobooks,
+        Latin, Lo-Fi, Hyperpop, Dancehall, Techno, Trap, House, Tech House,
+        Deep House, Disco, Electro, Jungle, Progressive House, Hardstyle,
+        Glitch Hop, Trance, Future Bass, Future House, Tropical House, Downtempo,
+        Drum & Bass, Dubstep, Jersey Club, Vaporwave, Moombahton.
     albums_response:
       required:
         - latest_chain_block

--- a/api/v1_track.go
+++ b/api/v1_track.go
@@ -116,7 +116,7 @@ type DDEXRightsController struct {
 type CreateTrackRequest struct {
 	TrackId                      *trashid.HashId            `json:"track_id,omitempty" validate:"omitempty,min=1"`
 	Title                        string                     `json:"title" validate:"required,min=1"`
-	Genre                        string                     `json:"genre" validate:"required,oneof='Electronic' 'Rock' 'Metal' 'Alternative' 'Hip-Hop/Rap' 'Experimental' 'Punk' 'Folk' 'Pop' 'Ambient' 'Soundtrack' 'World' 'Jazz' 'Acoustic' 'Funk' 'R&B/Soul' 'Devotional' 'Classical' 'Reggae' 'Podcasts' 'Country' 'Spoken Word' 'Comedy' 'Blues' 'Kids' 'Audiobooks' 'Latin' 'Lo-Fi' 'Hyperpop' 'Dancehall' 'Techno' 'Trap' 'House' 'Tech House' 'Deep House' 'Disco' 'Electro' 'Jungle' 'Progressive House' 'Hardstyle' 'Glitch Hop' 'Trance' 'Future Bass' 'Future House' 'Tropical House' 'Downtempo' 'Drum & Bass' 'Dubstep' 'Jersey Club' 'Vaporwave' 'Moombahton'"`
+	Genre                        string                     `json:"genre" validate:"required,min=1,max=100"`
 	Description                  *string                    `json:"description,omitempty" validate:"omitempty,max=1000"`
 	Mood                         *string                    `json:"mood,omitempty" validate:"omitempty,oneof='Peaceful' 'Romantic' 'Sentimental' 'Tender' 'Easygoing' 'Yearning' 'Sophisticated' 'Sensual' 'Cool' 'Gritty' 'Melancholy' 'Serious' 'Brooding' 'Fiery' 'Defiant' 'Aggressive' 'Rowdy' 'Excited' 'Energizing' 'Empowering' 'Stirring' 'Upbeat' 'Other'"`
 	Tags                         *string                    `json:"tags,omitempty"`
@@ -159,7 +159,7 @@ type CreateTrackRequest struct {
 type UpdateTrackRequest struct {
 	Title                        *string                    `json:"title,omitempty" validate:"omitempty,min=1"`
 	Description                  *string                    `json:"description,omitempty" validate:"omitempty,max=1000"`
-	Genre                        *string                    `json:"genre,omitempty" validate:"omitempty,oneof='Electronic' 'Rock' 'Metal' 'Alternative' 'Hip-Hop/Rap' 'Experimental' 'Punk' 'Folk' 'Pop' 'Ambient' 'Soundtrack' 'World' 'Jazz' 'Acoustic' 'Funk' 'R&B/Soul' 'Devotional' 'Classical' 'Reggae' 'Podcasts' 'Country' 'Spoken Word' 'Comedy' 'Blues' 'Kids' 'Audiobooks' 'Latin' 'Lo-Fi' 'Hyperpop' 'Dancehall' 'Techno' 'Trap' 'House' 'Tech House' 'Deep House' 'Disco' 'Electro' 'Jungle' 'Progressive House' 'Hardstyle' 'Glitch Hop' 'Trance' 'Future Bass' 'Future House' 'Tropical House' 'Downtempo' 'Drum & Bass' 'Dubstep' 'Jersey Club' 'Vaporwave' 'Moombahton'"`
+	Genre                        *string                    `json:"genre,omitempty" validate:"omitempty,min=1,max=100"`
 	Mood                         *string                    `json:"mood,omitempty" validate:"omitempty,oneof='Peaceful' 'Romantic' 'Sentimental' 'Tender' 'Easygoing' 'Yearning' 'Sophisticated' 'Sensual' 'Cool' 'Gritty' 'Melancholy' 'Serious' 'Brooding' 'Fiery' 'Defiant' 'Aggressive' 'Rowdy' 'Excited' 'Energizing' 'Empowering' 'Stirring' 'Upbeat' 'Other'"`
 	Tags                         *string                    `json:"tags,omitempty"`
 	License                      *string                    `json:"license,omitempty"`

--- a/indexer/constants.go
+++ b/indexer/constants.go
@@ -39,3 +39,12 @@ const (
 	Entity_DeveloperApp     = "DeveloperApp"
 	Entity_Event            = "Event"
 )
+
+// Track field constraints applied at EM-event indexing time. Track genres are
+// arbitrary user-supplied strings (not an enum); enforce only a length cap.
+// Mirrors discovery-provider's `CHARACTER_LIMIT_GENRE` so that when the Go
+// indexer takes over track-entity event consumption from the Python
+// discovery-provider, the rule stays consistent.
+const (
+	MaxTrackGenreLength = 100
+)


### PR DESCRIPTION
## Summary
- `api/v1_track.go`: dropped the `oneof='Electronic' 'Rock' ...` validators on `CreateTrackRequest.Genre` (required) and `UpdateTrackRequest.Genre` (omitempty); replaced with `min=1,max=100` and `max=100` respectively.
- `api/swagger/swagger-v1.yaml`: `genre` schema changed from string-enum to plain string with `maxLength: 100`. Canonical values moved into the description so generated docs/SDKs still surface them as autocomplete suggestions.

Pairs with [AudiusProject/apps#14419](https://github.com/AudiusProject/apps/pull/14419) — the SDK regen, indexer relaxation, and web UI live there. **Ship this first (or together)** so the Python indexer relaxation isn't gated on a Go API that still rejects custom genres at the validate-tag layer.

## Test plan
- [x] Existing test fixtures using `genre: "Electronic"` etc. still pass (no breakage from removing the enum constraint — those values are still valid strings).
- [ ] POST `/v1/tracks` with `genre: "Phonk"` succeeds.
- [ ] POST with `genre: ""` returns 400 (`min=1`).
- [ ] POST with a 101-char genre returns 400 (`max=100`).
- [ ] Generated swagger docs at `/v1/swagger.yaml` show the new schema with description containing the canonical values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)