### PR TITLE
chore(deps): bump go-openaudio ETL to playlist_contents key fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,8 +6,8 @@ require (
 	connectrpc.com/connect v1.18.1
 	github.com/AlecAivazis/survey/v2 v2.3.7
 	github.com/Doist/unfurlist v0.0.0-20250409100812-515f2735f8e5
-	github.com/OpenAudio/go-openaudio v1.3.1-0.20260528010155-6ea0f10200ac
-	github.com/OpenAudio/go-openaudio/pkg/etl v1.3.1-0.20260528010155-6ea0f10200ac
+	github.com/OpenAudio/go-openaudio v1.3.1-0.20260529194448-35ad422c0f27
+	github.com/OpenAudio/go-openaudio/pkg/etl v1.3.1-0.20260529194448-35ad422c0f27
 	github.com/aquasecurity/esquery v0.2.0
 	github.com/axiomhq/axiom-go v0.23.0
 	github.com/axiomhq/hyperloglog v0.2.5

--- a/go.sum
+++ b/go.sum
@@ -20,10 +20,10 @@ github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2 h1:+vx7roKuyA63n
 github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2/go.mod h1:HBCaDeC1lPdgDeDbhX8XFpy1jqjK0IBG8W5K+xYqA0w=
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5 h1:TngWCqHvy9oXAN6lEVMRuU21PR1EtLVZJmdB18Gu3Rw=
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5/go.mod h1:lmUJ/7eu/Q8D7ML55dXQrVaamCz2vxCfdQBasLZfHKk=
-github.com/OpenAudio/go-openaudio v1.3.1-0.20260528010155-6ea0f10200ac h1:esefVxyIIrvYEVh9ax8D5yTWB4Tf8ax4B4U8z1xsMSw=
-github.com/OpenAudio/go-openaudio v1.3.1-0.20260528010155-6ea0f10200ac/go.mod h1:wiFXmVbIUkN2D5lRshknaARCKhzbHtCBKRCZe6UOnVs=
-github.com/OpenAudio/go-openaudio/pkg/etl v1.3.1-0.20260528010155-6ea0f10200ac h1:aaR2TZXQ8tbjnLHV2ik+eY1FLhxp1CVd+82TLTHIz+o=
-github.com/OpenAudio/go-openaudio/pkg/etl v1.3.1-0.20260528010155-6ea0f10200ac/go.mod h1:LZKiU9vBYzlZzn6oPRHHLPXteBtMKQPegNH9bX9JuH8=
+github.com/OpenAudio/go-openaudio v1.3.1-0.20260529194448-35ad422c0f27 h1:h42jz04hL+3kxICalInzqppFPUvll0BpckPJp/ei86w=
+github.com/OpenAudio/go-openaudio v1.3.1-0.20260529194448-35ad422c0f27/go.mod h1:wiFXmVbIUkN2D5lRshknaARCKhzbHtCBKRCZe6UOnVs=
+github.com/OpenAudio/go-openaudio/pkg/etl v1.3.1-0.20260529194448-35ad422c0f27 h1:OC9CDVmc5EtEcXLLfTfkFXRMNjQLgeCV4+qDlWZzSVU=
+github.com/OpenAudio/go-openaudio/pkg/etl v1.3.1-0.20260529194448-35ad422c0f27/go.mod h1:LZKiU9vBYzlZzn6oPRHHLPXteBtMKQPegNH9bX9JuH8=
 github.com/StackExchange/wmi v1.2.1 h1:VIkavFPXSjcnS+O8yTq7NI32k0R5Aj+v39y29VYDOSA=
 github.com/StackExchange/wmi v1.2.1/go.mod h1:rcmrprowKIVzvc+NUiLncP2uuArMWLCbu9SBzvHz7e8=
 github.com/VictoriaMetrics/fastcache v1.12.2 h1:N0y9ASrJ0F6h0QaC3o6uJb3NIZ9VKLjCM7NQbSmF7WI=


### PR DESCRIPTION
## Summary

Bumps `go-openaudio` and `go-openaudio/pkg/etl` from `6ea0f10` → `35ad422`, picking up [go-openaudio#321](https://github.com/OpenAudio/go-openaudio/pull/321).

That PR fixes the ETL indexer's `playlist_contents` JSONB write path: pre-fix it persisted the SDK's `track_id` / `timestamp` / `metadata_timestamp` alias keys verbatim, but every reader on this side only understands the canonical `track` key —
- `api/v1_playlist_tracks` query — `(e.value->>'track')::int`
- the `handle_playlist` notification trigger — `(track_item->>'track')::int`
- the `dbv1` `get_playlists` play-count rollup — `(e.item->>'track')::int`

so affected playlists rendered **empty** even though the `playlist_tracks` junction table was correct. After this bump, new writes land in the canonical `{track, time, metadata_time}` shape.

## Backfill

Already-broken `is_current` rows (65 and climbing at time of writing) are **not** repaired by this PR — they're fixed by a one-shot SQL backfill run out-of-band. The backfill maps the same alias keys onto the canonical names and was dry-run-verified against prod (2194 entries in → 2194 out, zero drops).

> ⚠️ Deploy ordering: the backfill should run together with / after this bump deploys. If it ran while the old indexer were still live, new bad rows would keep landing.

## Test plan

- [x] `go build ./...` clean against the bumped deps
- [x] go-openaudio#321 ships the unit tests covering the canonicalization (alias keys, hashid strings, mixed shapes)
- [ ] Confirm core-indexer comes up clean post-deploy (`stern -n api core-indexer`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)