### PR TITLE
chore(deps): bump go-openaudio ETL to halt-on-block-error (#323)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,8 +6,8 @@ require (
 	connectrpc.com/connect v1.18.1
 	github.com/AlecAivazis/survey/v2 v2.3.7
 	github.com/Doist/unfurlist v0.0.0-20250409100812-515f2735f8e5
-	github.com/OpenAudio/go-openaudio v1.3.1-0.20260529221831-4d1c9dfdfb52
-	github.com/OpenAudio/go-openaudio/pkg/etl v1.3.1-0.20260529221831-4d1c9dfdfb52
+	github.com/OpenAudio/go-openaudio v1.3.1-0.20260529230137-819100b28c94
+	github.com/OpenAudio/go-openaudio/pkg/etl v1.3.1-0.20260529230137-819100b28c94
 	github.com/aquasecurity/esquery v0.2.0
 	github.com/axiomhq/axiom-go v0.23.0
 	github.com/axiomhq/hyperloglog v0.2.5

--- a/go.sum
+++ b/go.sum
@@ -20,10 +20,10 @@ github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2 h1:+vx7roKuyA63n
 github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2/go.mod h1:HBCaDeC1lPdgDeDbhX8XFpy1jqjK0IBG8W5K+xYqA0w=
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5 h1:TngWCqHvy9oXAN6lEVMRuU21PR1EtLVZJmdB18Gu3Rw=
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5/go.mod h1:lmUJ/7eu/Q8D7ML55dXQrVaamCz2vxCfdQBasLZfHKk=
-github.com/OpenAudio/go-openaudio v1.3.1-0.20260529221831-4d1c9dfdfb52 h1:uT5PXDx/R398ufAYswcUjaavc4OuYIrhf4DhWFRKlaY=
-github.com/OpenAudio/go-openaudio v1.3.1-0.20260529221831-4d1c9dfdfb52/go.mod h1:wiFXmVbIUkN2D5lRshknaARCKhzbHtCBKRCZe6UOnVs=
-github.com/OpenAudio/go-openaudio/pkg/etl v1.3.1-0.20260529221831-4d1c9dfdfb52 h1:cwLCsQGeiJbLBa2tEK1fZrg4r+bmnv7ZuJ8PrWHlwPE=
-github.com/OpenAudio/go-openaudio/pkg/etl v1.3.1-0.20260529221831-4d1c9dfdfb52/go.mod h1:LZKiU9vBYzlZzn6oPRHHLPXteBtMKQPegNH9bX9JuH8=
+github.com/OpenAudio/go-openaudio v1.3.1-0.20260529230137-819100b28c94 h1:AvnhnKIqiCx500n8fjRZgZtD1ElUlZhu/bAItSjkWdo=
+github.com/OpenAudio/go-openaudio v1.3.1-0.20260529230137-819100b28c94/go.mod h1:wiFXmVbIUkN2D5lRshknaARCKhzbHtCBKRCZe6UOnVs=
+github.com/OpenAudio/go-openaudio/pkg/etl v1.3.1-0.20260529230137-819100b28c94 h1:hN9X6lwVuqVl2d61j4kRSEkBBa8yFogEhWdiLM1BbD4=
+github.com/OpenAudio/go-openaudio/pkg/etl v1.3.1-0.20260529230137-819100b28c94/go.mod h1:LZKiU9vBYzlZzn6oPRHHLPXteBtMKQPegNH9bX9JuH8=
 github.com/StackExchange/wmi v1.2.1 h1:VIkavFPXSjcnS+O8yTq7NI32k0R5Aj+v39y29VYDOSA=
 github.com/StackExchange/wmi v1.2.1/go.mod h1:rcmrprowKIVzvc+NUiLncP2uuArMWLCbu9SBzvHz7e8=
 github.com/VictoriaMetrics/fastcache v1.12.2 h1:N0y9ASrJ0F6h0QaC3o6uJb3NIZ9VKLjCM7NQbSmF7WI=


### PR DESCRIPTION
## Summary

Picks up [OpenAudio/go-openaudio#323](https://github.com/OpenAudio/go-openaudio/pull/323).

Before that change, a `processBlock` failure in `pkg/etl` was swallowed with `continue`, advancing past the failed block. `core_indexed_blocks` is keyed by `MAX(height)`, so the api's `health_check?max_core_indexer_block_diff=...` probes look healthy while the skipped block is silently lost forever — and the prefetcher works forward from the indexed tip so it never re-hands a skipped block. That's the **same pattern that produced the `ray52726` dropped-signup** we tracked down earlier this week (`blocks_number_key` collision on the per-block tx → `continue` → silent gap).

After this bump, `processBlock` failure causes `indexBlocks()` to return the error. The pod crash-restart path picks up from `MAX(core_indexed_blocks.height)`, the prefetcher re-hands the previously-failed block, and we retry it. Transient failures self-heal on one restart; persistent corruption crashloops loudly.

## Bump details

| | from | to |
|---|---|---|
| `github.com/OpenAudio/go-openaudio` | `v1.3.1-0.20260529221831-4d1c9dfdfb52` | `v1.3.1-0.20260529230137-819100b28c94` |
| `github.com/OpenAudio/go-openaudio/pkg/etl` | `v1.3.1-0.20260529221831-4d1c9dfdfb52` | `v1.3.1-0.20260529230137-819100b28c94` |

`gh api .../compare/4d1c9dfdfb52...819100b2` confirms this is **one commit only** — #323's merge, no drive-bys.

## Operational note

This trades "silent data loss" for "loud crashloop on persistent corruption." Worth confirming that pod-restart / unhealthy-pod alerting on `core-indexer` is wired so the loud failure doesn't *also* go unnoticed. If it isn't, that's a quick follow-up — but even without it this PR is strictly better than today.

## Test plan

- [x] `go build ./...`, `go vet ./...` clean.
- [x] `go mod tidy` clean (no transitive surprises).
- [x] `./indexer/...` tests pass (the existing user_pubkey + user_events hook tests exercise the pkg/etl integration path).
- [ ] After deploy, confirm `blocks_behind` stays at 0 (no behavior change on the happy path).
- [ ] Confirm operator alerts fire on a synthetic crashloop, if not already verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
