### PR TITLE
fix(ddl): emit user_verified NOTIFY only on the verification transition

### DIFF
--- a/ddl/functions/notify_on_row.sql
+++ b/ddl/functions/notify_on_row.sql
@@ -8,6 +8,20 @@ begin
       PERFORM pg_notify(TG_TABLE_NAME, json_build_object('track_id', new.track_id, 'updated_at', new.updated_at, 'created_at', new.created_at, 'blocknumber', new.blocknumber)::text);
     when 'users' then
       PERFORM pg_notify(TG_TABLE_NAME, json_build_object('user_id', new.user_id, 'blocknumber', new.blocknumber)::text);
+      -- Dedicated verification-transition channel.
+      --
+      -- The Go ETL writes `users` in place (single is_current row per user; it
+      -- bumps blocknumber rather than appending a versioned row), so consumers
+      -- can no longer reconstruct the "previous" verification state from the
+      -- `users` table or from revert_blocks. But because the update is in place,
+      -- this AFTER trigger's OLD row holds the true pre-update state. Emit on a
+      -- separate channel only for the genuine false -> true transition (or a
+      -- brand-new row that arrives already verified) so downstream listeners
+      -- (e.g. the verified-notifications Slack bot) fire exactly once instead of
+      -- on every profile edit by an already-verified user.
+      if new.is_verified and (TG_OP = 'INSERT' or not coalesce(old.is_verified, false)) then
+        PERFORM pg_notify('user_verified', json_build_object('user_id', new.user_id, 'blocknumber', new.blocknumber)::text);
+      end if;
     when 'playlists' then
       PERFORM pg_notify(TG_TABLE_NAME, json_build_object('playlist_id', new.playlist_id)::text);
     else


### PR DESCRIPTION
## Problem

The `verified-notifications` Slack bot is re-posting "now verified!" for **already-verified** users every time they edit their profile (~8/day, all noise).

Root cause: the Go ETL writes `users` **in place** — one `is_current` row per user, bumping `blocknumber` rather than appending a versioned row. Verified on prod: `users` has **0** rows with `is_current=false` (~1 row/user). The bot's handler tried to reconstruct the user's *previous* verification state from the `users` table (`blocknumber < notify_blocknumber`), which now always returns `undefined`, so `prev === undefined && current.is_verified` fires on every update. (The prior approach read `revert_blocks`, which the ETL also doesn't populate — same failure, different source.)

## Fix

The `users` update is in place, so this AFTER trigger's `OLD` row holds the true pre-update state. Add a dedicated `user_verified` NOTIFY channel that fires **only** on the genuine `false -> true` transition (or a brand-new row that arrives already verified):

```sql
if new.is_verified and (TG_OP = 'INSERT' or not coalesce(old.is_verified, false)) then
  PERFORM pg_notify('user_verified', json_build_object('user_id', new.user_id, 'blocknumber', new.blocknumber)::text);
end if;
```

The existing `users` firehose channel is unchanged. A companion pedalboard PR switches the bot to listen on `user_verified` and drops the (now impossible) history lookup.

## Apply mechanism

`pg_migrate.sh` re-applies `ddl/functions/*.sql` via `CREATE OR REPLACE` when the file's md5 changes, so this reapplies automatically on the next migration run — no tracker edit needed.

## Note (intentionally out of scope)

An identical `notify_on_row.sql` exists in the discovery-provider (apps) repo. While Python's migrate job still runs against the same DB it could flap `on_new_row()` back to the old definition. Per cutover plan, that copy is **not** patched here (Python indexer is being decommissioned).

## Test plan
- [ ] After deploy, edit an already-verified user's profile → **no** `user_verified` NOTIFY, no Slack post.
- [ ] Verify a previously-unverified user → exactly one `user_verified` NOTIFY + one Slack post.
- [ ] New signup that arrives already verified → exactly one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)