### PR TITLE
chore: bump go-openaudio for entity-manager indexed logs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,8 +6,8 @@ require (
 	connectrpc.com/connect v1.18.1
 	github.com/AlecAivazis/survey/v2 v2.3.7
 	github.com/Doist/unfurlist v0.0.0-20250409100812-515f2735f8e5
-	github.com/OpenAudio/go-openaudio v1.3.1-0.20260529221831-4d1c9dfdfb52
-	github.com/OpenAudio/go-openaudio/pkg/etl v1.3.1-0.20260529221831-4d1c9dfdfb52
+	github.com/OpenAudio/go-openaudio v1.3.1-0.20260601200759-f6b56f1a737e
+	github.com/OpenAudio/go-openaudio/pkg/etl v1.3.1-0.20260601200759-f6b56f1a737e
 	github.com/aquasecurity/esquery v0.2.0
 	github.com/axiomhq/axiom-go v0.23.0
 	github.com/axiomhq/hyperloglog v0.2.5

--- a/go.sum
+++ b/go.sum
@@ -20,10 +20,10 @@ github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2 h1:+vx7roKuyA63n
 github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2/go.mod h1:HBCaDeC1lPdgDeDbhX8XFpy1jqjK0IBG8W5K+xYqA0w=
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5 h1:TngWCqHvy9oXAN6lEVMRuU21PR1EtLVZJmdB18Gu3Rw=
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5/go.mod h1:lmUJ/7eu/Q8D7ML55dXQrVaamCz2vxCfdQBasLZfHKk=
-github.com/OpenAudio/go-openaudio v1.3.1-0.20260529221831-4d1c9dfdfb52 h1:uT5PXDx/R398ufAYswcUjaavc4OuYIrhf4DhWFRKlaY=
-github.com/OpenAudio/go-openaudio v1.3.1-0.20260529221831-4d1c9dfdfb52/go.mod h1:wiFXmVbIUkN2D5lRshknaARCKhzbHtCBKRCZe6UOnVs=
-github.com/OpenAudio/go-openaudio/pkg/etl v1.3.1-0.20260529221831-4d1c9dfdfb52 h1:cwLCsQGeiJbLBa2tEK1fZrg4r+bmnv7ZuJ8PrWHlwPE=
-github.com/OpenAudio/go-openaudio/pkg/etl v1.3.1-0.20260529221831-4d1c9dfdfb52/go.mod h1:LZKiU9vBYzlZzn6oPRHHLPXteBtMKQPegNH9bX9JuH8=
+github.com/OpenAudio/go-openaudio v1.3.1-0.20260601200759-f6b56f1a737e h1:5BmK2SU1xjbVO2rVPT35VWGBLybcZe9JIx+EYzoEGiM=
+github.com/OpenAudio/go-openaudio v1.3.1-0.20260601200759-f6b56f1a737e/go.mod h1:wiFXmVbIUkN2D5lRshknaARCKhzbHtCBKRCZe6UOnVs=
+github.com/OpenAudio/go-openaudio/pkg/etl v1.3.1-0.20260601200759-f6b56f1a737e h1:woxembtT6moaH0oQeFnCxJRzTzSTVTsqbd+7H+yfCLE=
+github.com/OpenAudio/go-openaudio/pkg/etl v1.3.1-0.20260601200759-f6b56f1a737e/go.mod h1:LZKiU9vBYzlZzn6oPRHHLPXteBtMKQPegNH9bX9JuH8=
 github.com/StackExchange/wmi v1.2.1 h1:VIkavFPXSjcnS+O8yTq7NI32k0R5Aj+v39y29VYDOSA=
 github.com/StackExchange/wmi v1.2.1/go.mod h1:rcmrprowKIVzvc+NUiLncP2uuArMWLCbu9SBzvHz7e8=
 github.com/VictoriaMetrics/fastcache v1.12.2 h1:N0y9ASrJ0F6h0QaC3o6uJb3NIZ9VKLjCM7NQbSmF7WI=


### PR DESCRIPTION
## Summary
Bumps the `go-openaudio` and `go-openaudio/pkg/etl` dependencies from `4d1c9dfdfb52` to `f6b56f1a737e`, pulling in [go-openaudio#329](https://github.com/OpenAudio/go-openaudio/pull/329).

That change promotes the entity-manager success path in the ETL indexer from a **Debug** `"tx indexed"` line (invisible in prod, no entity fields) to an **Info** `"entity manager indexed"` line carrying `entity_type`, `action`, `entity_id`, `user_id`, and `block`. It mirrors the field set of the existing `"entity manager validation rejected"` and `"entity manager dispatch error"` logs, so a single grep on `hash`/`entity_id` shows the full lifecycle of every EM transaction.

This is the api-side bump needed to actually capture those logs in the running ETL indexer.

## Changes
- `go.mod` / `go.sum`: both go-openaudio modules → `v1.3.1-0.20260601200759-f6b56f1a737e`

## Test plan
- [x] `go mod tidy` stable (pins hold)
- [x] `go build ./...`
- [ ] After deploy, confirm `entity manager indexed` Info lines appear in the indexer logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)