### PR TITLE
perf(api): bound EngagementNotificationsJob debounce with a materialized CTE

### DIFF
--- a/jobs/create_engagement_notifications.go
+++ b/jobs/create_engagement_notifications.go
@@ -87,31 +87,10 @@ func (j *EngagementNotificationsJob) run(ctx context.Context) error {
 		j.mutex.Unlock()
 	}()
 
-	// completed_at < now - 1 week. Two-stage dedup, mirroring the original
-	// Python task (create_engagement_notifications.py), split into an explicit
-	// MATERIALIZED CTE so the two stages run in that order rather than being
-	// fused into one anti-join by the planner:
-	//
-	//   1. `candidates` CTE — the cheap, LIMIT-bounded selection. The exact
-	//      (group_id, specifier) anti-join is served by the uq_notification
-	//      unique index, so the LIMIT fills via index probes and the scan
-	//      terminates early. This mirrors Python's `Notification.id IS NULL`
-	//      filter (which the first port dropped in favor of ON CONFLICT alone)
-	//      plus its `.limit(BATCH_SIZE)`. AS MATERIALIZED is an optimization
-	//      fence: it forces Postgres to compute these <=500 rows first instead
-	//      of inlining the CTE and re-fusing both anti-joins. Without the fence,
-	//      the planner underestimates the overlap anti-join's selectivity,
-	//      materializes a full `notification` scan, and nested-loop-anti-joins
-	//      every undisbursed candidate across the multi-year window — a
-	//      ~22-billion-cost plan that ran for tens of minutes per tick.
-	//
-	//   2. user_ids overlap anti-join — the 1-hour debounce: suppress a second
-	//      claimable_reward for the same user within the hour before completion
-	//      (Python's per-row existing_notification check). Running it against
-	//      the materialized `candidates` bounds the anti-join's outer side to
-	//      the <=500 rows surviving stage 1 instead of the full multi-year
-	//      candidate set, which is what made the fused plan quadratic. The
-	//      ON CONFLICT below is kept only as a race safety net.
+	// AS MATERIALIZED is load-bearing: it fences the LIMIT-bounded candidate
+	// selection from the 1-hour debounce so the debounce runs against <=500
+	// rows, not the full multi-year window. Without it the planner fuses both
+	// anti-joins into a multi-minute scan.
 	res, err := j.pool.Exec(ctx, `
 		WITH candidates AS MATERIALIZED (
 			SELECT

--- a/jobs/create_engagement_notifications.go
+++ b/jobs/create_engagement_notifications.go
@@ -87,11 +87,57 @@ func (j *EngagementNotificationsJob) run(ctx context.Context) error {
 		j.mutex.Unlock()
 	}()
 
-	// completed_at < now - 1 week. The matching (group_id, specifier) dedup is
-	// handled by uq_notification via ON CONFLICT; the NOT EXISTS debounce
-	// suppresses a second claimable_reward for the same user within the hour
-	// before completion (Python's per-row existing_notification check).
+	// completed_at < now - 1 week. Two-stage dedup, mirroring the original
+	// Python task (create_engagement_notifications.py), split into an explicit
+	// MATERIALIZED CTE so the two stages run in that order rather than being
+	// fused into one anti-join by the planner:
+	//
+	//   1. `candidates` CTE — the cheap, LIMIT-bounded selection. The exact
+	//      (group_id, specifier) anti-join is served by the uq_notification
+	//      unique index, so the LIMIT fills via index probes and the scan
+	//      terminates early. This mirrors Python's `Notification.id IS NULL`
+	//      filter (which the first port dropped in favor of ON CONFLICT alone)
+	//      plus its `.limit(BATCH_SIZE)`. AS MATERIALIZED is an optimization
+	//      fence: it forces Postgres to compute these <=500 rows first instead
+	//      of inlining the CTE and re-fusing both anti-joins. Without the fence,
+	//      the planner underestimates the overlap anti-join's selectivity,
+	//      materializes a full `notification` scan, and nested-loop-anti-joins
+	//      every undisbursed candidate across the multi-year window — a
+	//      ~22-billion-cost plan that ran for tens of minutes per tick.
+	//
+	//   2. user_ids overlap anti-join — the 1-hour debounce: suppress a second
+	//      claimable_reward for the same user within the hour before completion
+	//      (Python's per-row existing_notification check). Running it against
+	//      the materialized `candidates` bounds the anti-join's outer side to
+	//      the <=500 rows surviving stage 1 instead of the full multi-year
+	//      candidate set, which is what made the fused plan quadratic. The
+	//      ON CONFLICT below is kept only as a race safety net.
 	res, err := j.pool.Exec(ctx, `
+		WITH candidates AS MATERIALIZED (
+			SELECT
+				uc.user_id,
+				uc.challenge_id,
+				uc.specifier,
+				uc.amount,
+				uc.completed_blocknumber,
+				uc.completed_at
+			FROM user_challenges uc
+			JOIN challenges c ON c.id = uc.challenge_id
+			LEFT JOIN challenge_disbursements cd
+				ON cd.challenge_id = uc.challenge_id AND cd.specifier = uc.specifier
+			WHERE uc.is_complete
+				AND uc.completed_at >= @start_datetime
+				AND uc.completed_at < @cooldown_cutoff
+				AND c.cooldown_days = 7
+				AND cd.specifier IS NULL
+				AND NOT EXISTS (
+					SELECT 1 FROM notification done
+					WHERE done.group_id =
+						'claimable_reward:' || uc.user_id::text || ':challenge:' || uc.challenge_id || ':specifier:' || uc.specifier
+						AND done.specifier = uc.specifier
+				)
+			LIMIT @batch_size
+		)
 		INSERT INTO notification (specifier, group_id, blocknumber, user_ids, type, data, timestamp)
 		SELECT
 			uc.specifier,
@@ -105,22 +151,13 @@ func (j *EngagementNotificationsJob) run(ctx context.Context) error {
 				'amount', uc.amount
 			),
 			uc.completed_at
-		FROM user_challenges uc
-		JOIN challenges c ON c.id = uc.challenge_id
-		LEFT JOIN challenge_disbursements cd
-			ON cd.challenge_id = uc.challenge_id AND cd.specifier = uc.specifier
-		WHERE uc.is_complete
-			AND uc.completed_at >= @start_datetime
-			AND uc.completed_at < @cooldown_cutoff
-			AND c.cooldown_days = 7
-			AND cd.specifier IS NULL
-			AND NOT EXISTS (
-				SELECT 1 FROM notification n
-				WHERE n.type = 'claimable_reward'
-					AND n.user_ids @> ARRAY[uc.user_id]
-					AND n.timestamp >= uc.completed_at - INTERVAL '1 hour'
-			)
-		LIMIT @batch_size
+		FROM candidates uc
+		WHERE NOT EXISTS (
+			SELECT 1 FROM notification n
+			WHERE n.type = 'claimable_reward'
+				AND n.user_ids @> ARRAY[uc.user_id]
+				AND n.timestamp >= uc.completed_at - INTERVAL '1 hour'
+		)
 		ON CONFLICT (group_id, specifier) DO NOTHING
 	`, pgx.NamedArgs{
 		"start_datetime":  engagementStartDatetime,


### PR DESCRIPTION
## Summary

The `claimable_reward` backfill query in `EngagementNotificationsJob` was running ~49 minutes per tick on prod, overrunning its 10-minute schedule ~5x and pinning a DB connection + CPU continuously.

**Root cause.** The Go port collapsed the original Python task's [two-stage dedup](https://github.com/AudiusProject/apps/blob/main/packages/discovery-provider/src/tasks/create_engagement_notifications.py) into a single statement with one correlated `NOT EXISTS`. The planner underestimated the `user_ids` overlap anti-join's selectivity, materialized a full `notification` scan, and nested-loop-anti-joined **every** undisbursed candidate across the ~2-year `completed_at >= '2024-06-06'` window — a ~22-billion-cost plan.

**Fix.** Restore Python's staging explicitly via a `WITH candidates AS MATERIALIZED (...)` CTE:
- **Stage 1** (`candidates`) selects the ≤500 rows via the `uq_notification` index — this mirrors Python's `Notification.id IS NULL` anti-join + `.limit(BATCH_SIZE)`, which the first port dropped in favor of `ON CONFLICT` alone.
- `AS MATERIALIZED` is an optimization fence: it forces those ≤500 rows to be computed **before** the 1-hour overlap debounce runs, instead of the planner re-fusing both anti-joins.
- **Stage 2** runs the debounce against only the materialized candidates.

No schema or behavior change — same rows inserted, same `ON CONFLICT` safety net.

## Measured on prod (read-only EXPLAIN / EXPLAIN ANALYZE of the SELECT equivalent)

| | Before | After |
|---|---|---|
| Planner cost | ~21.9 billion | ~18 million |
| Wall time | ~49 min | **~40 s** |

Stage 1 fills in ~1.7s via `Index Only Scan using uq_notification`; the ~38s tail is stage 2 scanning the claimable_reward notifications once for the 500 candidates.

## Follow-up (not in this PR)

Stage 2 still scans all `claimable_reward` rows because `ix_notification gin(user_ids)` is not type-selective. A partial GIN index `(user_ids) WHERE type = 'claimable_reward'` would turn the debounce into per-user probes (~sub-second), but that's a separate migration with its own index-build/locking considerations.

## Test plan

- [x] `go build ./jobs/...`
- [x] `go vet ./jobs/`
- [x] `go test ./jobs/ -run TestEngagementNotifications -count=1` (FullPipeline + Exclusions pass)
- [x] Verified improved plan via read-only `EXPLAIN` against the prod write primary

🤖 Generated with [Claude Code](https://claude.com/claude-code)