### PR TITLE
Optimize GetUsers relationship hydration

### DIFF
--- a/api/dbv1/get_users.sql.go
+++ b/api/dbv1/get_users.sql.go
@@ -15,6 +15,57 @@ import (
 )
 
 const getUsers = `-- name: GetUsers :many
+WITH input_users AS (
+  SELECT DISTINCT unnest($2::int[])::int AS user_id
+),
+current_user_followees AS (
+  SELECT followee_user_id
+  FROM follows
+  WHERE $1 > 0
+    AND follower_user_id = $1
+    AND is_delete = false
+),
+current_user_following_targets AS (
+  SELECT f.followee_user_id AS user_id
+  FROM follows f
+  JOIN input_users i ON i.user_id = f.followee_user_id
+  WHERE $1 > 0
+    AND f.follower_user_id = $1
+    AND f.is_delete = false
+  GROUP BY f.followee_user_id
+),
+current_user_subscribed_targets AS (
+  SELECT s.user_id
+  FROM subscriptions s
+  JOIN input_users i ON i.user_id = s.user_id
+  WHERE $1 > 0
+    AND s.subscriber_id = $1
+    AND s.is_delete = false
+  GROUP BY s.user_id
+),
+targets_following_current_user AS (
+  SELECT f.follower_user_id AS user_id
+  FROM follows f
+  JOIN input_users i ON i.user_id = f.follower_user_id
+  WHERE $1 > 0
+    AND f.followee_user_id = $1
+    AND f.is_delete = false
+  GROUP BY f.follower_user_id
+),
+current_user_followee_follow_counts AS (
+  SELECT target.user_id, count(*)::bigint AS count
+  FROM current_user_followees mf
+  JOIN LATERAL (
+    SELECT f.followee_user_id AS user_id
+    FROM follows f
+    WHERE f.follower_user_id = mf.followee_user_id
+      AND f.followee_user_id = ANY($2::int[])
+      AND f.followee_user_id != $1
+      AND f.is_delete = false
+    OFFSET 0
+  ) target ON TRUE
+  GROUP BY target.user_id
+)
 SELECT
   album_count,
   artist_pick_track_id,
@@ -106,57 +157,15 @@ SELECT
 
   -- "Of the people I follow, how many also follow this user?"
   --
-  -- Drive the loop from my followees (always small — a few thousand at
-  -- most) and probe whether each follows the target user. The previous
-  -- shape let Postgres pick a Merge Join that walked the full follower
-  -- list of the target — for popular target users that's millions of
-  -- rows. The LIMIT 1 OFFSET 0 inside the EXISTS is the same
-  -- optimization fence used by the feed query: it pins the planner to
-  -- nested-loop semantics so the plan never flips to merge join.
-  (
-    SELECT count(*)
-    FROM follows mf
-    WHERE $1 > 0
-      AND $1 != u.user_id -- don't compute when viewing own profile
-      AND mf.follower_user_id = $1
-      AND mf.is_delete = false
-      AND EXISTS (
-        SELECT 1 FROM (
-          SELECT 1 FROM follows f
-          WHERE f.follower_user_id = mf.followee_user_id
-            AND f.followee_user_id = u.user_id
-            AND f.is_delete = false
-          LIMIT 1 OFFSET 0
-        ) x
-      )
-  ) AS current_user_followee_follow_count,
-
-  (
-    SELECT count(*) > 0
-    FROM follows
-    WHERE $1 > 0
-      AND follower_user_id = $1
-      AND followee_user_id = u.user_id
-      AND is_delete = false
-  ) AS does_current_user_follow,
-
-  (
-    SELECT count(*) > 0
-    FROM subscriptions
-    WHERE $1 > 0
-      AND subscriber_id = $1
-      AND user_id = u.user_id
-      AND is_delete = false
-  ) AS does_current_user_subscribe,
-
-  (
-    SELECT count(*) > 0
-    FROM follows
-    WHERE $1 > 0
-      AND followee_user_id = $1
-      AND follower_user_id = u.user_id
-      AND is_delete = false
-  ) AS does_follow_current_user,
+  -- Compute viewer relationship state once for the whole @ids batch. The
+  -- previous correlated shape repeated the mutual-follow count for every
+  -- returned user, which multiplied the viewer followee scan by result size.
+  -- The CTE above drives from the viewer's followees once and probes the
+  -- target batch via the fanout index.
+  COALESCE(current_user_followee_follow_counts.count, 0)::bigint AS current_user_followee_follow_count,
+  (current_user_following_targets.user_id IS NOT NULL)::bool AS does_current_user_follow,
+  (current_user_subscribed_targets.user_id IS NOT NULL)::bool AS does_current_user_subscribe,
+  (targets_following_current_user.user_id IS NOT NULL)::bool AS does_follow_current_user,
 
   handle_lc,
   u.updated_at,
@@ -234,6 +243,14 @@ LEFT JOIN sol_claimable_accounts spl_user_bank
 LEFT JOIN sol_claimable_accounts usdc_user_bank
   ON usdc_user_bank.ethereum_address = u.wallet
   AND usdc_user_bank.mint = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v' -- USDC
+LEFT JOIN current_user_followee_follow_counts
+  ON current_user_followee_follow_counts.user_id = u.user_id
+LEFT JOIN current_user_following_targets
+  ON current_user_following_targets.user_id = u.user_id
+LEFT JOIN current_user_subscribed_targets
+  ON current_user_subscribed_targets.user_id = u.user_id
+LEFT JOIN targets_following_current_user
+  ON targets_following_current_user.user_id = u.user_id
 WHERE u.user_id = ANY($2::int[])
 ORDER BY u.user_id
 `

--- a/api/dbv1/queries/get_users.sql
+++ b/api/dbv1/queries/get_users.sql
@@ -1,4 +1,55 @@
 -- name: GetUsers :many
+WITH input_users AS (
+  SELECT DISTINCT unnest(@ids::int[])::int AS user_id
+),
+current_user_followees AS (
+  SELECT followee_user_id
+  FROM follows
+  WHERE @my_id > 0
+    AND follower_user_id = @my_id
+    AND is_delete = false
+),
+current_user_following_targets AS (
+  SELECT f.followee_user_id AS user_id
+  FROM follows f
+  JOIN input_users i ON i.user_id = f.followee_user_id
+  WHERE @my_id > 0
+    AND f.follower_user_id = @my_id
+    AND f.is_delete = false
+  GROUP BY f.followee_user_id
+),
+current_user_subscribed_targets AS (
+  SELECT s.user_id
+  FROM subscriptions s
+  JOIN input_users i ON i.user_id = s.user_id
+  WHERE @my_id > 0
+    AND s.subscriber_id = @my_id
+    AND s.is_delete = false
+  GROUP BY s.user_id
+),
+targets_following_current_user AS (
+  SELECT f.follower_user_id AS user_id
+  FROM follows f
+  JOIN input_users i ON i.user_id = f.follower_user_id
+  WHERE @my_id > 0
+    AND f.followee_user_id = @my_id
+    AND f.is_delete = false
+  GROUP BY f.follower_user_id
+),
+current_user_followee_follow_counts AS (
+  SELECT target.user_id, count(*)::bigint AS count
+  FROM current_user_followees mf
+  JOIN LATERAL (
+    SELECT f.followee_user_id AS user_id
+    FROM follows f
+    WHERE f.follower_user_id = mf.followee_user_id
+      AND f.followee_user_id = ANY(@ids::int[])
+      AND f.followee_user_id != @my_id
+      AND f.is_delete = false
+    OFFSET 0
+  ) target ON TRUE
+  GROUP BY target.user_id
+)
 SELECT
   album_count,
   artist_pick_track_id,
@@ -90,57 +141,15 @@ SELECT
 
   -- "Of the people I follow, how many also follow this user?"
   --
-  -- Drive the loop from my followees (always small — a few thousand at
-  -- most) and probe whether each follows the target user. The previous
-  -- shape let Postgres pick a Merge Join that walked the full follower
-  -- list of the target — for popular target users that's millions of
-  -- rows. The LIMIT 1 OFFSET 0 inside the EXISTS is the same
-  -- optimization fence used by the feed query: it pins the planner to
-  -- nested-loop semantics so the plan never flips to merge join.
-  (
-    SELECT count(*)
-    FROM follows mf
-    WHERE @my_id > 0
-      AND @my_id != u.user_id -- don't compute when viewing own profile
-      AND mf.follower_user_id = @my_id
-      AND mf.is_delete = false
-      AND EXISTS (
-        SELECT 1 FROM (
-          SELECT 1 FROM follows f
-          WHERE f.follower_user_id = mf.followee_user_id
-            AND f.followee_user_id = u.user_id
-            AND f.is_delete = false
-          LIMIT 1 OFFSET 0
-        ) x
-      )
-  ) AS current_user_followee_follow_count,
-
-  (
-    SELECT count(*) > 0
-    FROM follows
-    WHERE @my_id > 0
-      AND follower_user_id = @my_id
-      AND followee_user_id = u.user_id
-      AND is_delete = false
-  ) AS does_current_user_follow,
-
-  (
-    SELECT count(*) > 0
-    FROM subscriptions
-    WHERE @my_id > 0
-      AND subscriber_id = @my_id
-      AND user_id = u.user_id
-      AND is_delete = false
-  ) AS does_current_user_subscribe,
-
-  (
-    SELECT count(*) > 0
-    FROM follows
-    WHERE @my_id > 0
-      AND followee_user_id = @my_id
-      AND follower_user_id = u.user_id
-      AND is_delete = false
-  ) AS does_follow_current_user,
+  -- Compute viewer relationship state once for the whole @ids batch. The
+  -- previous correlated shape repeated the mutual-follow count for every
+  -- returned user, which multiplied the viewer followee scan by result size.
+  -- The CTE above drives from the viewer's followees once and probes the
+  -- target batch via the fanout index.
+  COALESCE(current_user_followee_follow_counts.count, 0)::bigint AS current_user_followee_follow_count,
+  (current_user_following_targets.user_id IS NOT NULL)::bool AS does_current_user_follow,
+  (current_user_subscribed_targets.user_id IS NOT NULL)::bool AS does_current_user_subscribe,
+  (targets_following_current_user.user_id IS NOT NULL)::bool AS does_follow_current_user,
 
   handle_lc,
   u.updated_at,
@@ -221,6 +230,14 @@ LEFT JOIN sol_claimable_accounts spl_user_bank
 LEFT JOIN sol_claimable_accounts usdc_user_bank
   ON usdc_user_bank.ethereum_address = u.wallet
   AND usdc_user_bank.mint = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v' -- USDC
+LEFT JOIN current_user_followee_follow_counts
+  ON current_user_followee_follow_counts.user_id = u.user_id
+LEFT JOIN current_user_following_targets
+  ON current_user_following_targets.user_id = u.user_id
+LEFT JOIN current_user_subscribed_targets
+  ON current_user_subscribed_targets.user_id = u.user_id
+LEFT JOIN targets_following_current_user
+  ON targets_following_current_user.user_id = u.user_id
 WHERE u.user_id = ANY(@ids::int[])
 ORDER BY u.user_id
 ;


### PR DESCRIPTION
## Summary
- batch GetUsers viewer relationship state across the requested user id list
- replace per-row correlated follow/subscription checks with CTEs joined once per hydrated user
- regenerate sqlc output

## Production validation
Read-only prod checks only (`SELECT`/`EXPLAIN ANALYZE`). No data modifications.

Stress sample: viewer `38358` (about 329k following) hydrating 30 high-follower users.
- Current query: ~45.4s execution time; mutual-follow subplan ran once per output row and performed about 10.2M inner index probes.
- New query: ~13.1s execution time on the same sample.

Unauthenticated sample (`my_id = 0`) with the same 30 ids:
- Current query: ~26ms execution time.
- New query: ~26ms execution time.

Result consistency checks used `EXCEPT ALL` over `to_jsonb(row)` for old vs new query and returned zero diffs for:
- `my_id = 38358`
- `my_id = 0`
- `my_id = 325624`

## Tests
- `go test ./api -run 'TestGetUsers|TestGetUsersHandle|TestGetUser'`
- `go test ./api/dbv1`
