### PR TITLE
perf(indexer): drop blocks is_current dependency

### DIFF
--- a/api/handle_sol_usdc_withdrawal_test.go
+++ b/api/handle_sol_usdc_withdrawal_test.go
@@ -29,8 +29,8 @@ func TestHandleSolUsdcWithdrawalTrigger(t *testing.T) {
 	// the memo marker must be present at trigger time. Mirrors the order the
 	// indexer uses in claimable_tokens.go.
 	_, err := app.writePool.Exec(ctx, `
-		INSERT INTO public.blocks (blockhash, parenthash, is_current, number)
-		VALUES ('block1', 'block0', true, 101)
+		INSERT INTO public.blocks (blockhash, parenthash, number)
+		VALUES ('block1', 'block0', 101)
 		ON CONFLICT DO NOTHING;`)
 	require.NoError(t, err)
 	database.SeedTable(app.writePool, "users", []map[string]any{
@@ -153,8 +153,8 @@ func TestHandleSolUsdcWithdrawalTrigger_SkipsSystemTypes(t *testing.T) {
 	userBank := "User1UsdcBank_skip_test_____________________"
 
 	_, err := app.writePool.Exec(ctx, `
-		INSERT INTO public.blocks (blockhash, parenthash, is_current, number)
-		VALUES ('block1', 'block0', true, 101)
+		INSERT INTO public.blocks (blockhash, parenthash, number)
+		VALUES ('block1', 'block0', 101)
 		ON CONFLICT DO NOTHING;`)
 	require.NoError(t, err)
 	database.SeedTable(app.writePool, "users", []map[string]any{

--- a/api/server_test.go
+++ b/api/server_test.go
@@ -68,12 +68,10 @@ func testAppWithFixtures(t *testing.T) *ApiServer {
 	INSERT INTO public.blocks (
 		blockhash,
 		parenthash,
-		is_current,
 		number
 	) VALUES (
 		'block1',   -- blockhash
 		'block0',   -- parenthash
-		true,
 		101
 	);
 	`)

--- a/database/seed.go
+++ b/database/seed.go
@@ -711,7 +711,6 @@ var (
 		"blocks": {
 			"blockhash":  nil,
 			"parenthash": nil,
-			"is_current": false,
 			"number":     nil,
 		},
 		"reward_codes": {
@@ -811,12 +810,10 @@ func Seed(pool *pgxpool.Pool, fixtures FixtureMap) {
 	INSERT INTO public.blocks (
 		blockhash,
 		parenthash,
-		is_current,
 		number
 	) VALUES (
 		'block1',   -- blockhash
 		'block0',   -- parenthash
-		true,
 		101
 	) ON CONFLICT DO NOTHING;
 	`)

--- a/ddl/migrations/0215_drop_blocks_is_current.sql
+++ b/ddl/migrations/0215_drop_blocks_is_current.sql
@@ -1,0 +1,21 @@
+-- Drop the legacy chain-tip marker from blocks.
+--
+-- The core indexer and API use blocks.number / core_indexed_blocks for block
+-- progress and confirmation checks. Maintaining blocks.is_current requires a
+-- per-entity-manager-block tip flip on a very large table, and the associated
+-- boolean indexes have become a disproportionate source of write work.
+--
+-- Deploy ordering:
+--   1. Deploy an ETL version whose resolveBlockNumber no longer reads, writes,
+--      or inserts blocks.is_current.
+--   2. Run this migration after the new binary is live everywhere.
+
+BEGIN;
+
+DROP INDEX IF EXISTS public.blocks_is_current_idx;
+DROP INDEX IF EXISTS public.is_current_blocks_idx;
+
+ALTER TABLE public.blocks
+    DROP COLUMN IF EXISTS is_current;
+
+COMMIT;

--- a/ddl/preflight/0001_initial_block.sql
+++ b/ddl/preflight/0001_initial_block.sql
@@ -1,10 +1,9 @@
 INSERT INTO "blocks"
-("blockhash", "parenthash", "number", "is_current")
+("blockhash", "parenthash", "number")
 VALUES
 (
     '0x0',
     NULL,
-    0,
-    TRUE
+    0
 )
 on conflict do nothing;

--- a/go.mod
+++ b/go.mod
@@ -6,8 +6,8 @@ require (
 	connectrpc.com/connect v1.18.1
 	github.com/AlecAivazis/survey/v2 v2.3.7
 	github.com/Doist/unfurlist v0.0.0-20250409100812-515f2735f8e5
-	github.com/OpenAudio/go-openaudio v1.3.1-0.20260601200759-f6b56f1a737e
-	github.com/OpenAudio/go-openaudio/pkg/etl v1.3.1-0.20260601200759-f6b56f1a737e
+	github.com/OpenAudio/go-openaudio v1.3.1-0.20260602021941-ea6c925d2455
+	github.com/OpenAudio/go-openaudio/pkg/etl v1.3.1-0.20260602021941-ea6c925d2455
 	github.com/aquasecurity/esquery v0.2.0
 	github.com/axiomhq/axiom-go v0.23.0
 	github.com/axiomhq/hyperloglog v0.2.5

--- a/go.sum
+++ b/go.sum
@@ -20,10 +20,10 @@ github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2 h1:+vx7roKuyA63n
 github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2/go.mod h1:HBCaDeC1lPdgDeDbhX8XFpy1jqjK0IBG8W5K+xYqA0w=
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5 h1:TngWCqHvy9oXAN6lEVMRuU21PR1EtLVZJmdB18Gu3Rw=
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5/go.mod h1:lmUJ/7eu/Q8D7ML55dXQrVaamCz2vxCfdQBasLZfHKk=
-github.com/OpenAudio/go-openaudio v1.3.1-0.20260601200759-f6b56f1a737e h1:5BmK2SU1xjbVO2rVPT35VWGBLybcZe9JIx+EYzoEGiM=
-github.com/OpenAudio/go-openaudio v1.3.1-0.20260601200759-f6b56f1a737e/go.mod h1:wiFXmVbIUkN2D5lRshknaARCKhzbHtCBKRCZe6UOnVs=
-github.com/OpenAudio/go-openaudio/pkg/etl v1.3.1-0.20260601200759-f6b56f1a737e h1:woxembtT6moaH0oQeFnCxJRzTzSTVTsqbd+7H+yfCLE=
-github.com/OpenAudio/go-openaudio/pkg/etl v1.3.1-0.20260601200759-f6b56f1a737e/go.mod h1:LZKiU9vBYzlZzn6oPRHHLPXteBtMKQPegNH9bX9JuH8=
+github.com/OpenAudio/go-openaudio v1.3.1-0.20260602021941-ea6c925d2455 h1:O/gjjTOPwlbXVwgdYqPMt6gsAq65p5wUl/qXudws6L0=
+github.com/OpenAudio/go-openaudio v1.3.1-0.20260602021941-ea6c925d2455/go.mod h1:wiFXmVbIUkN2D5lRshknaARCKhzbHtCBKRCZe6UOnVs=
+github.com/OpenAudio/go-openaudio/pkg/etl v1.3.1-0.20260602021941-ea6c925d2455 h1:yhAeLKeuIxLb8EKfXV1Y2xNO3V9vgkbKO/NFIqTzD08=
+github.com/OpenAudio/go-openaudio/pkg/etl v1.3.1-0.20260602021941-ea6c925d2455/go.mod h1:LZKiU9vBYzlZzn6oPRHHLPXteBtMKQPegNH9bX9JuH8=
 github.com/StackExchange/wmi v1.2.1 h1:VIkavFPXSjcnS+O8yTq7NI32k0R5Aj+v39y29VYDOSA=
 github.com/StackExchange/wmi v1.2.1/go.mod h1:rcmrprowKIVzvc+NUiLncP2uuArMWLCbu9SBzvHz7e8=
 github.com/VictoriaMetrics/fastcache v1.12.2 h1:N0y9ASrJ0F6h0QaC3o6uJb3NIZ9VKLjCM7NQbSmF7WI=

--- a/indexer/plays_hook.go
+++ b/indexer/plays_hook.go
@@ -48,11 +48,20 @@ import (
 func newPlaysHook(logger *zap.Logger) etl.PlaysHook {
 	hookLogger := logger.Named("PlaysHook")
 	return func(ctx context.Context, params *etl.PlaysParams) error {
+		start := time.Now()
 		if err := indexPlays(ctx, params); err != nil {
 			hookLogger.Warn("failed to index plays into plays table",
 				zap.String("tx_hash", params.TxHash),
 				zap.Int64("block_height", params.BlockHeight),
+				zap.Int("plays", len(params.Plays)),
+				zap.Duration("duration", time.Since(start)),
 				zap.Error(err))
+		} else if elapsed := time.Since(start); elapsed > time.Second {
+			hookLogger.Info("indexed plays into plays table",
+				zap.String("tx_hash", params.TxHash),
+				zap.Int64("block_height", params.BlockHeight),
+				zap.Int("plays", len(params.Plays)),
+				zap.Duration("duration", elapsed))
 		}
 		return nil
 	}

--- a/indexer/user_events_hook.go
+++ b/indexer/user_events_hook.go
@@ -3,6 +3,7 @@ package indexer
 import (
 	"context"
 	"errors"
+	"time"
 
 	em "github.com/OpenAudio/go-openaudio/pkg/etl/processors/entity_manager"
 	"github.com/jackc/pgx/v5"
@@ -31,10 +32,18 @@ import (
 func newUserEventsHook(logger *zap.Logger) em.PostHook {
 	hookLogger := logger.Named("UserEventsHook")
 	return func(ctx context.Context, params *em.Params) error {
+		start := time.Now()
 		if err := indexUserEvents(ctx, params); err != nil {
 			hookLogger.Warn("failed to index user_events",
 				zap.Int64("user_id", params.EntityID),
+				zap.Int64("blocknumber", params.BlockNumber),
+				zap.Duration("duration", time.Since(start)),
 				zap.Error(err))
+		} else if elapsed := time.Since(start); elapsed > time.Second {
+			hookLogger.Info("indexed user_events",
+				zap.Int64("user_id", params.EntityID),
+				zap.Int64("blocknumber", params.BlockNumber),
+				zap.Duration("duration", elapsed))
 		}
 		return nil
 	}

--- a/indexer/user_pubkey_hook.go
+++ b/indexer/user_pubkey_hook.go
@@ -3,6 +3,7 @@ package indexer
 import (
 	"context"
 	"encoding/base64"
+	"time"
 
 	"api.audius.co/config"
 	corev1 "github.com/OpenAudio/go-openaudio/pkg/api/core/v1"
@@ -50,6 +51,15 @@ func newUserPubkeyHook(cfg config.Config, logger *zap.Logger) em.PostHook {
 		if tx == nil {
 			return nil // defensive — proto should always be set on dispatch
 		}
+		start := time.Now()
+		defer func() {
+			if elapsed := time.Since(start); elapsed > time.Second {
+				hookLogger.Info("indexed user pubkey hook completed",
+					zap.Int64("user_id", params.EntityID),
+					zap.Int64("blocknumber", params.BlockNumber),
+					zap.Duration("duration", elapsed))
+			}
+		}()
 		return recoverAndStorePubkey(ctx, hookLogger, coreCfg, tx, params)
 	}
 }

--- a/jobs/challenges/processor_test.go
+++ b/jobs/challenges/processor_test.go
@@ -18,26 +18,18 @@ func withChallengesDB(t *testing.T) *pgxpool.Pool {
 	t.Cleanup(func() { pool.Close() })
 
 	ctx := context.Background()
-	// The latest pg_migrate preflight seeds a `0x0` block with
-	// is_current=true. database.Seed() also inserts a `block1` block
-	// with is_current=true, which collides on the blocks_is_current_idx
-	// unique partial index. Clear the preflight row so Seed() can
-	// install its expected fixture.
-	if _, err := pool.Exec(ctx, "DELETE FROM blocks WHERE blockhash = '0x0'"); err != nil {
-		t.Fatalf("clean preflight block: %v", err)
-	}
 
 	// Seed Phase 1+2+3 challenges catalog inline. We don't run the
 	// production migration here because the test_jobs template DB isn't
 	// routed through the ddl runner — keeping the seed local to the
 	// test makes intent clearer too.
 	rows := []struct {
-		id, typ, amount       string
-		active                bool
-		stepCount             *int32
-		startingBlock         int32
-		weeklyPool            int32
-		cooldownDays          *int32
+		id, typ, amount string
+		active          bool
+		stepCount       *int32
+		startingBlock   int32
+		weeklyPool      int32
+		cooldownDays    *int32
 	}{
 		{"p", "numeric", "1", true, i32p(7), 0, 25000, i32p(7)},
 		{"u", "numeric", "1", true, i32p(3), 25346436, 25000, i32p(7)},

--- a/jobs/create_engagement_notifications.go
+++ b/jobs/create_engagement_notifications.go
@@ -74,6 +74,7 @@ func (j *EngagementNotificationsJob) Run(ctx context.Context) {
 }
 
 func (j *EngagementNotificationsJob) run(ctx context.Context) error {
+	start := time.Now()
 	j.mutex.Lock()
 	if j.isRunning {
 		j.mutex.Unlock()
@@ -147,8 +148,8 @@ func (j *EngagementNotificationsJob) run(ctx context.Context) error {
 		return fmt.Errorf("insert claimable_reward notifications: %w", err)
 	}
 
-	if n := res.RowsAffected(); n > 0 {
-		j.logger.Info("Inserted claimable_reward notifications", zap.Int64("count", n))
-	}
+	j.logger.Info("Checked claimable_reward notifications",
+		zap.Int64("count", res.RowsAffected()),
+		zap.Duration("duration", time.Since(start)))
 	return nil
 }

--- a/jobs/create_listen_streak_reminder_notifications.go
+++ b/jobs/create_listen_streak_reminder_notifications.go
@@ -70,6 +70,7 @@ func (j *ListenStreakReminderJob) Run(ctx context.Context) {
 }
 
 func (j *ListenStreakReminderJob) run(ctx context.Context) error {
+	start := time.Now()
 	j.mutex.Lock()
 	if j.isRunning {
 		j.mutex.Unlock()
@@ -115,8 +116,8 @@ func (j *ListenStreakReminderJob) run(ctx context.Context) error {
 		return fmt.Errorf("insert listen_streak_reminder notifications: %w", err)
 	}
 
-	if n := res.RowsAffected(); n > 0 {
-		j.logger.Info("Inserted listen_streak_reminder notifications", zap.Int64("count", n))
-	}
+	j.logger.Info("Checked listen_streak_reminder notifications",
+		zap.Int64("count", res.RowsAffected()),
+		zap.Duration("duration", time.Since(start)))
 	return nil
 }

--- a/jobs/create_remix_contest_notifications.go
+++ b/jobs/create_remix_contest_notifications.go
@@ -72,6 +72,7 @@ func (j *RemixContestNotificationsJob) Run(ctx context.Context) {
 }
 
 func (j *RemixContestNotificationsJob) run(ctx context.Context) error {
+	start := time.Now()
 	j.mutex.Lock()
 	if j.isRunning {
 		j.mutex.Unlock()
@@ -100,18 +101,31 @@ func (j *RemixContestNotificationsJob) run(ctx context.Context) error {
 	}
 	var firstErr error
 	for _, s := range steps {
+		stepStart := time.Now()
 		n, err := s.fn(ctx, now)
 		if err != nil {
-			j.logger.Error("remix contest notification step failed", zap.String("step", s.name), zap.Error(err))
+			j.logger.Error("remix contest notification step failed",
+				zap.String("step", s.name),
+				zap.Duration("duration", time.Since(stepStart)),
+				zap.Error(err))
 			if firstErr == nil {
 				firstErr = err
 			}
 			continue
 		}
 		if n > 0 {
-			j.logger.Info("Inserted remix contest notifications", zap.String("step", s.name), zap.Int64("count", n))
+			j.logger.Info("Inserted remix contest notifications",
+				zap.String("step", s.name),
+				zap.Int64("count", n),
+				zap.Duration("duration", time.Since(stepStart)))
+		} else {
+			j.logger.Debug("No remix contest notifications inserted",
+				zap.String("step", s.name),
+				zap.Duration("duration", time.Since(stepStart)))
 		}
 	}
+	j.logger.Info("Checked remix contest notifications",
+		zap.Duration("duration", time.Since(start)))
 	return firstErr
 }
 

--- a/jobs/index_challenges.go
+++ b/jobs/index_challenges.go
@@ -108,12 +108,18 @@ func (j *IndexChallengesJob) run(ctx context.Context) error {
 	start := time.Now()
 	var anyErr error
 	for _, p := range j.processors {
+		processorStart := time.Now()
 		if err := j.runProcessor(ctx, p); err != nil {
 			j.logger.Error("processor failed",
 				zap.String("challenge_id", p.ChallengeID()),
+				zap.Duration("duration", time.Since(processorStart)),
 				zap.Error(err))
 			anyErr = err
 			// Continue — one bad processor shouldn't kill the rest.
+		} else {
+			j.logger.Info("challenge processor reconciled",
+				zap.String("challenge_id", p.ChallengeID()),
+				zap.Duration("duration", time.Since(processorStart)))
 		}
 	}
 	j.logger.Info("Reconciled challenges",

--- a/jobs/index_hourly_play_counts.go
+++ b/jobs/index_hourly_play_counts.go
@@ -70,6 +70,7 @@ func (j *HourlyPlayCountsJob) Run(ctx context.Context) {
 }
 
 func (j *HourlyPlayCountsJob) run(ctx context.Context) error {
+	start := time.Now()
 	j.mutex.Lock()
 	if j.isRunning {
 		j.mutex.Unlock()
@@ -94,7 +95,8 @@ func (j *HourlyPlayCountsJob) run(ctx context.Context) error {
 		return fmt.Errorf("read max(plays.id): %w", err)
 	}
 	if newMax == nil || *newMax == prev {
-		j.logger.Debug("No new plays since last run")
+		j.logger.Debug("No new plays since last run",
+			zap.Duration("duration", time.Since(start)))
 		return nil
 	}
 
@@ -126,7 +128,8 @@ func (j *HourlyPlayCountsJob) run(ctx context.Context) error {
 	j.logger.Info("Hourly play counts updated",
 		zap.Int64("prev_checkpoint", prev),
 		zap.Int64("new_checkpoint", *newMax),
-		zap.Int64("hours_touched", res.RowsAffected()))
+		zap.Int64("hours_touched", res.RowsAffected()),
+		zap.Duration("duration", time.Since(start)))
 	return nil
 }
 

--- a/jobs/index_user_listening_history.go
+++ b/jobs/index_user_listening_history.go
@@ -100,6 +100,7 @@ type listenEntry struct {
 }
 
 func (j *UserListeningHistoryJob) run(ctx context.Context) error {
+	start := time.Now()
 	j.mutex.Lock()
 	if j.isRunning {
 		j.mutex.Unlock()
@@ -144,6 +145,8 @@ func (j *UserListeningHistoryJob) run(ctx context.Context) error {
 	}
 
 	if len(newPlays) == 0 {
+		j.logger.Debug("No new plays for user listening history",
+			zap.Duration("duration", time.Since(start)))
 		return nil
 	}
 
@@ -219,7 +222,8 @@ func (j *UserListeningHistoryJob) run(ctx context.Context) error {
 	j.logger.Info("Indexed user listening history",
 		zap.Int("plays_processed", len(newPlays)),
 		zap.Int("users_touched", updated),
-		zap.Int64("new_checkpoint", maxID))
+		zap.Int64("new_checkpoint", maxID),
+		zap.Duration("duration", time.Since(start)))
 	return nil
 }
 

--- a/jobs/prune_plays.go
+++ b/jobs/prune_plays.go
@@ -91,6 +91,7 @@ func (j *PrunePlaysJob) Run(ctx context.Context) {
 }
 
 func (j *PrunePlaysJob) run(ctx context.Context) error {
+	start := time.Now()
 	j.mutex.Lock()
 	if j.isRunning {
 		j.mutex.Unlock()
@@ -129,7 +130,13 @@ func (j *PrunePlaysJob) run(ctx context.Context) error {
 		j.logger.Info("Pruned plays",
 			zap.Int64("deleted", deleted),
 			zap.Time("cutoff", cutoff),
-			zap.Int("batch_size", j.batchSize))
+			zap.Int("batch_size", j.batchSize),
+			zap.Duration("duration", time.Since(start)))
+	} else {
+		j.logger.Debug("No plays pruned",
+			zap.Time("cutoff", cutoff),
+			zap.Int("batch_size", j.batchSize),
+			zap.Duration("duration", time.Since(start)))
 	}
 	return nil
 }

--- a/solana/indexer/program/purchase_revalidator_test.go
+++ b/solana/indexer/program/purchase_revalidator_test.go
@@ -182,13 +182,9 @@ func seedRevalidatorFixtures(
 
 func insertBlock(t *testing.T, pool *pgxpool.Pool, number int) {
 	t.Helper()
-	// is_current is left false to avoid colliding with the auto-inserted block
-	// 101 that database.Seed adds (a partial unique index allows only one row
-	// with is_current=true). validatePurchase reads MAX(number), not by
-	// is_current, so this is fine for these tests.
 	_, err := pool.Exec(t.Context(), `
-		INSERT INTO blocks (blockhash, parenthash, is_current, number)
-		VALUES ('test-block-' || $1::integer::text, NULL, false, $1::integer)
+		INSERT INTO blocks (blockhash, parenthash, number)
+		VALUES ('test-block-' || $1::integer::text, NULL, $1::integer)
 		ON CONFLICT DO NOTHING
 	`, number)
 	require.NoError(t, err)
@@ -256,4 +252,3 @@ func pollUntil(t *testing.T, timeout, interval time.Duration, cond func() bool, 
 	}
 	t.Fatalf("condition not met within %s: %s", timeout, msg)
 }
-

--- a/sql/01_schema.sql
+++ b/sql/01_schema.sql
@@ -7705,7 +7705,6 @@ CREATE TABLE public.audius_data_txs (
 CREATE TABLE public.blocks (
     blockhash character varying NOT NULL,
     parenthash character varying,
-    is_current boolean,
     number integer
 );
 
@@ -12415,13 +12414,6 @@ COMMENT ON INDEX public.artist_coins_user_id_idx IS 'Used for getting coins mint
 
 
 --
--- Name: blocks_is_current_idx; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE UNIQUE INDEX blocks_is_current_idx ON public.blocks USING btree (is_current) WHERE (is_current IS TRUE);
-
-
---
 -- Name: challenge_disbursements_user_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -12979,13 +12971,6 @@ CREATE INDEX interval_play_track_id_idx ON public.aggregate_interval_plays USING
 --
 
 CREATE INDEX interval_play_week_count_idx ON public.aggregate_interval_plays USING btree (week_listen_counts);
-
-
---
--- Name: is_current_blocks_idx; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX is_current_blocks_idx ON public.blocks USING btree (is_current);
 
 
 --
@@ -14692,5 +14677,3 @@ ALTER TABLE ONLY public.users
 --
 -- PostgreSQL database dump complete
 --
-
-


### PR DESCRIPTION
## Summary
- update `go-openaudio` and `go-openaudio/pkg/etl` to the merged upstream commit `ea6c925`
- remove `blocks.is_current` from API schema, seed/preflight SQL, and test fixtures
- add migration 0215 to drop `blocks.is_current` plus related indexes
- add slow-path instrumentation for indexer hooks and periodic jobs

## Why
The ETL hot path no longer reads or writes `blocks.is_current`, so the API can drop the column and the bloated partial indexes that were causing high-variance `UPDATE blocks SET is_current ...` latency.

## Rollout
This should deploy after the merged go-openaudio change is available to the API build. Do not run the migration before API is consuming the updated ETL dependency.

## Tests
- `go test ./database ./jobs/challenges ./solana/indexer/program`
- `go test ./api ./indexer ./jobs`
