### PR TITLE
perf(api): make FirstWeeklyComment challenge incremental

### DIFF
--- a/ddl/migrations/0216_comments_blocknumber_idx.sql
+++ b/ddl/migrations/0216_comments_blocknumber_idx.sql
@@ -1,0 +1,22 @@
+-- Btree index on comments(blocknumber) — required by the dirty-set scan that
+-- drives the incremental FirstWeeklyComment processor (challenge "c").
+--
+-- Each tick the processor runs:
+--   SELECT user_id, blocknumber FROM comments
+--    WHERE blocknumber > $1
+--    ORDER BY blocknumber ASC LIMIT $2
+--
+-- Without this index that query is a seq-scan of the whole comments table
+-- (~321k rows) every 30s tick. With it the scan is a small index range read
+-- keyed on the processor checkpoint — same pattern #875 established for
+-- follows/saves/reposts/tracks/playlists/users and #897 for user_events.
+--
+-- NOTE: intentionally NOT wrapped in BEGIN/COMMIT so CREATE INDEX
+-- CONCURRENTLY can run without holding an ACCESS EXCLUSIVE lock on comments.
+-- IF NOT EXISTS makes the migration idempotent.
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS comments_blocknumber_idx
+    ON public.comments USING btree (blocknumber);
+
+COMMENT ON INDEX comments_blocknumber_idx IS
+    'Range scans by blocknumber for the incremental FirstWeeklyComment challenge processor (c).';

--- a/ddl/migrations/0217_seed_first_weekly_comment_checkpoint.sql
+++ b/ddl/migrations/0217_seed_first_weekly_comment_checkpoint.sql
@@ -1,0 +1,25 @@
+-- Seed the incremental checkpoint for the FirstWeeklyComment processor.
+--
+-- Challenge "c" used to re-run a DISTINCT (user_id, ISO-year, ISO-week) scan
+-- over the entire comments table (~321k rows) and re-upsert a user_challenge
+-- row for every (user, week) pair across all history every tick — ~100s, the
+-- dominant cost of IndexChallengesJob. It now checkpoints comments.blocknumber
+-- and recomputes only the users whose comments changed since the checkpoint.
+-- See jobs/challenges/first_weekly_comment.go and jobs/challenges/incremental.go.
+--
+-- A fresh checkpoint defaults to 0, which would re-derive every (user, week)
+-- pair from the beginning the first time the job runs. We don't want that: the
+-- legacy Python stack already populated user_challenges and the upserts are
+-- idempotent, so a full historical re-derivation is pure redundant write load.
+-- Seed the checkpoint to the current max(comments.blocknumber) so the processor
+-- starts "from now" and only picks up new comments.
+--
+-- ON CONFLICT DO NOTHING keeps this idempotent and never rewinds a checkpoint the
+-- running job has already advanced. The max(blocknumber) probe is an index-only
+-- scan against comments_blocknumber_idx (migration 0216).
+--
+-- Checkpoint name must match commentCheckpoint in the processor.
+
+INSERT INTO indexing_checkpoints (tablename, last_checkpoint)
+SELECT 'challenges:c:last_blocknumber', COALESCE((SELECT max(blocknumber) FROM comments), 0)
+ON CONFLICT (tablename) DO NOTHING;

--- a/jobs/challenges/first_weekly_comment.go
+++ b/jobs/challenges/first_weekly_comment.go
@@ -17,9 +17,27 @@ import (
 // Idempotency is by specifier — re-scanning the same week never adds
 // duplicate rows. Each subsequent week the user posts, a new specifier
 // (and thus a new row) is minted.
+//
+// Incremental: the old design re-ran a DISTINCT (user, ISO-week) scan over the
+// entire comments table and re-upserted every (user, week) pair across all
+// history every tick — ~100s against prod. We instead checkpoint
+// comments.blocknumber and recompute only the users whose comments changed
+// since the checkpoint. See incremental.go.
 type FirstWeeklyCommentProcessor struct{}
 
 func (p *FirstWeeklyCommentProcessor) ChallengeID() string { return "c" }
+
+const commentCheckpoint = "challenges:c:last_blocknumber"
+
+// commentDirtySQL returns (user_id, blocknumber) for comments created, updated,
+// or deleted since the checkpoint. comments is updated in place so blocknumber
+// moves on every mutation.
+const commentDirtySQL = `
+	SELECT user_id, blocknumber FROM comments
+	WHERE blocknumber > $1
+	ORDER BY blocknumber ASC
+	LIMIT $2
+`
 
 func (p *FirstWeeklyCommentProcessor) Reconcile(ctx context.Context, tx pgx.Tx) error {
 	c, ok, err := LoadChallenge(ctx, tx, p.ChallengeID())
@@ -31,8 +49,16 @@ func (p *FirstWeeklyCommentProcessor) Reconcile(ctx context.Context, tx pgx.Tx) 
 	}
 	amount := c.AmountInt()
 
-	// One row per (user, isoyear, isoweek). EXTRACT(ISOYEAR / WEEK) gives
-	// the ISO-8601 week numbers Python's date.isocalendar() returns.
+	return reconcileIncrementalUsers(ctx, tx, commentCheckpoint, commentDirtySQL,
+		func(ctx context.Context, tx pgx.Tx, userIDs []int64) error {
+			return p.recompute(ctx, tx, userIDs, amount)
+		})
+}
+
+func (p *FirstWeeklyCommentProcessor) recompute(ctx context.Context, tx pgx.Tx, userIDs []int64, amount int32) error {
+	// One row per (user, isoyear, isoweek) for just the affected users.
+	// EXTRACT(ISOYEAR / WEEK) gives the ISO-8601 week numbers Python's
+	// date.isocalendar() returns.
 	rows, err := tx.Query(ctx, `
 		SELECT DISTINCT user_id,
 		       EXTRACT(ISOYEAR FROM created_at)::int AS iso_year,
@@ -40,7 +66,8 @@ func (p *FirstWeeklyCommentProcessor) Reconcile(ctx context.Context, tx pgx.Tx) 
 		FROM comments
 		WHERE is_delete = false
 		  AND is_visible = true
-	`)
+		  AND user_id = ANY($1)
+	`, userIDs)
 	if err != nil {
 		return fmt.Errorf("scan comments: %w", err)
 	}

--- a/jobs/challenges/first_weekly_comment_test.go
+++ b/jobs/challenges/first_weekly_comment_test.go
@@ -25,10 +25,12 @@ func TestFirstWeeklyComment_OneRowPerUserPerWeek(t *testing.T) {
 		"blocks": {{"blockhash": "blk_fwc", "number": 1}},
 		"users":  {{"user_id": 700, "wallet": "0x700"}, {"user_id": 800, "wallet": "0x800"}},
 		"tracks": {{"track_id": 7000, "owner_id": 800, "title": "T", "blocknumber": 1}},
+		// blocknumber must be > 0 so the incremental dirty scan picks these up
+		// (tests don't run migrations, so the checkpoint stays at 0).
 		"comments": {
-			{"comment_id": 1, "user_id": 700, "entity_id": 7000, "entity_type": "Track", "text": "a", "created_at": wk1A, "blockhash": "x", "txhash": "tx1"},
-			{"comment_id": 2, "user_id": 700, "entity_id": 7000, "entity_type": "Track", "text": "b", "created_at": wk1B, "blockhash": "x", "txhash": "tx2"},
-			{"comment_id": 3, "user_id": 700, "entity_id": 7000, "entity_type": "Track", "text": "c", "created_at": wk5, "blockhash": "x", "txhash": "tx3"},
+			{"comment_id": 1, "user_id": 700, "entity_id": 7000, "entity_type": "Track", "text": "a", "created_at": wk1A, "blockhash": "x", "txhash": "tx1", "blocknumber": 1},
+			{"comment_id": 2, "user_id": 700, "entity_id": 7000, "entity_type": "Track", "text": "b", "created_at": wk1B, "blockhash": "x", "txhash": "tx2", "blocknumber": 1},
+			{"comment_id": 3, "user_id": 700, "entity_id": 7000, "entity_type": "Track", "text": "c", "created_at": wk5, "blockhash": "x", "txhash": "tx3", "blocknumber": 1},
 		},
 	})
 


### PR DESCRIPTION
## Summary

`FirstWeeklyComment` (challenge `c`) was the dominant cost of `IndexChallengesJob` — ~100s per 30s tick in prod (whole loop ~120-133s, surfaced by the per-processor timing added in #897). Every tick it rescanned the **entire** `comments` table (~321k rows), re-derived `DISTINCT (user_id, ISO-year, ISO-week)` across all history, and re-upserted a `user_challenge` row for every (user, week) pair.

This converts it to the same checkpoint + dirty-set pattern already used by `TrackUpload` (#875) and `PlayCountMilestones` (#896): checkpoint `comments.blocknumber` (monotonic, bumped on every insert/update/delete) and recompute only the users whose comments changed since the checkpoint. The existing `EXTRACT(ISOYEAR)/EXTRACT(WEEK)` logic and `is_delete=false AND is_visible=true` filter are preserved exactly for parity; the per-user recompute just adds `AND user_id = ANY($1)`.

This is the last big full-rescan challenge processor. `ProfileVerified` (`v`, ~4-17s) and `Tastemaker` (`t`, ~8-9s) are secondary and out of scope.

## Changes

- `jobs/challenges/first_weekly_comment.go` — `Reconcile` now `LoadChallenge` → `reconcileIncrementalUsers(commentCheckpoint, commentDirtySQL, recompute)`, mirroring `track_upload.go`. New const `commentCheckpoint = "challenges:c:last_blocknumber"`.
- `ddl/migrations/0216_comments_blocknumber_idx.sql` — `CREATE INDEX CONCURRENTLY` on `comments(blocknumber)`. Unlike the other source tables, `comments` had no blocknumber index, so the dirty scan would otherwise be a 321k-row seq scan each tick. Mirrors #897's `user_events` index migration (0209).
- `ddl/migrations/0217_seed_first_weekly_comment_checkpoint.sql` — seeds `challenges:c:last_blocknumber` to `max(comments.blocknumber)` so prod starts "from now" instead of re-deriving all history. Mirrors 0215 (`ON CONFLICT DO NOTHING`).
- `first_weekly_comment_test.go` — seeded comments now carry a `blocknumber`; tests don't run migrations, so the checkpoint stays 0 and the dirty scan picks up all fixtures. Existing assertions unchanged.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./jobs/...`
- [x] `go test ./jobs/challenges/` (incl. `TestFirstWeeklyComment_OneRowPerUserPerWeek`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)