### PR TITLE
chore(api): bump etl to include subscription upsert fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,8 +6,8 @@ require (
 	connectrpc.com/connect v1.18.1
 	github.com/AlecAivazis/survey/v2 v2.3.7
 	github.com/Doist/unfurlist v0.0.0-20250409100812-515f2735f8e5
-	github.com/OpenAudio/go-openaudio v1.3.1-0.20260602052835-dca79f030639
-	github.com/OpenAudio/go-openaudio/pkg/etl v1.3.1-0.20260602052835-dca79f030639
+	github.com/OpenAudio/go-openaudio v1.3.1-0.20260602061322-5d2e19ad9d78
+	github.com/OpenAudio/go-openaudio/pkg/etl v1.3.1-0.20260602061322-5d2e19ad9d78
 	github.com/aquasecurity/esquery v0.2.0
 	github.com/axiomhq/axiom-go v0.23.0
 	github.com/axiomhq/hyperloglog v0.2.5

--- a/go.sum
+++ b/go.sum
@@ -20,10 +20,10 @@ github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2 h1:+vx7roKuyA63n
 github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2/go.mod h1:HBCaDeC1lPdgDeDbhX8XFpy1jqjK0IBG8W5K+xYqA0w=
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5 h1:TngWCqHvy9oXAN6lEVMRuU21PR1EtLVZJmdB18Gu3Rw=
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5/go.mod h1:lmUJ/7eu/Q8D7ML55dXQrVaamCz2vxCfdQBasLZfHKk=
-github.com/OpenAudio/go-openaudio v1.3.1-0.20260602052835-dca79f030639 h1:vhhEm9AW1KKfZiR1+pXdLwbWKaEa6MBNTRv8xvWsd9c=
-github.com/OpenAudio/go-openaudio v1.3.1-0.20260602052835-dca79f030639/go.mod h1:wiFXmVbIUkN2D5lRshknaARCKhzbHtCBKRCZe6UOnVs=
-github.com/OpenAudio/go-openaudio/pkg/etl v1.3.1-0.20260602052835-dca79f030639 h1:lWFDHYYA4lXQbt8bbRlJf9vVRyw/ZCrNFzkugbq+oVc=
-github.com/OpenAudio/go-openaudio/pkg/etl v1.3.1-0.20260602052835-dca79f030639/go.mod h1:LZKiU9vBYzlZzn6oPRHHLPXteBtMKQPegNH9bX9JuH8=
+github.com/OpenAudio/go-openaudio v1.3.1-0.20260602061322-5d2e19ad9d78 h1:SyVtJId85zH8jse56Sz5VEdCeKx/MwtvV5d1lfaZTGo=
+github.com/OpenAudio/go-openaudio v1.3.1-0.20260602061322-5d2e19ad9d78/go.mod h1:wiFXmVbIUkN2D5lRshknaARCKhzbHtCBKRCZe6UOnVs=
+github.com/OpenAudio/go-openaudio/pkg/etl v1.3.1-0.20260602061322-5d2e19ad9d78 h1:DKb+F4ekHl4titj7MHVHqd3Qpp50nEDYsKci9IvgPxo=
+github.com/OpenAudio/go-openaudio/pkg/etl v1.3.1-0.20260602061322-5d2e19ad9d78/go.mod h1:LZKiU9vBYzlZzn6oPRHHLPXteBtMKQPegNH9bX9JuH8=
 github.com/StackExchange/wmi v1.2.1 h1:VIkavFPXSjcnS+O8yTq7NI32k0R5Aj+v39y29VYDOSA=
 github.com/StackExchange/wmi v1.2.1/go.mod h1:rcmrprowKIVzvc+NUiLncP2uuArMWLCbu9SBzvHz7e8=
 github.com/VictoriaMetrics/fastcache v1.12.2 h1:N0y9ASrJ0F6h0QaC3o6uJb3NIZ9VKLjCM7NQbSmF7WI=


### PR DESCRIPTION
## Summary

Bumps the vendored `go-openaudio` / `pkg/etl` pseudo-version to `5d2e19a` to deploy **go-openaudio #335**.

- #335 converts the explicit Subscribe/Unsubscribe handler (`social_subscription.go`) to a single-statement `ON CONFLICT (subscriber_id, user_id) WHERE is_current = true` upsert, matching the Follow auto-subscribe path. This closes the two-writer gap that allowed duplicate `is_current` subscription rows to accumulate (the data that broke the `0030` arbiter-index migration earlier today).
- The bump also rolls in #333 (release_date defaults to `created_at`), which sits between the currently vendored commit (#334) and #335.

Merging this builds the `audius/api` image and rolls `core-indexer`, putting the subscription upsert live.

## Test plan

- [x] `go mod tidy` + `go build ./...` clean
- [x] Confirmed the `ON CONFLICT` upsert is present in the vendored `social_subscription.go`
- [ ] After merge: watch `core-indexer` roll, confirm clean migration boot (already at version 30) and subscribe/unsubscribe indexing without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)