### PR TITLE
perf(api): align trending ids query with index order

### DIFF
--- a/api/v1_tracks_trending_ids.go
+++ b/api/v1_tracks_trending_ids.go
@@ -8,23 +8,18 @@ import (
 
 func (app *ApiServer) getTrendingIds(c *fiber.Ctx, timeRange string, genre string, limit int, offset int) ([]int32, error) {
 	sql := `
-		SELECT track_trending_scores.track_id
-		FROM track_trending_scores
-		LEFT JOIN tracks
-			ON tracks.track_id = track_trending_scores.track_id
-			AND tracks.is_delete = false
-			AND tracks.is_unlisted = false
-			AND tracks.is_available = true
-		WHERE type = 'TRACKS'
-			AND version = 'pnagD'
-			AND time_range = @time
-			AND (@genre = '' OR track_trending_scores.genre = @genre)
-		ORDER BY
-			score DESC,
-			track_id DESC
-		LIMIT @limit
-		OFFSET @offset
-		`
+			SELECT track_trending_scores.track_id
+			FROM track_trending_scores
+			WHERE type = 'TRACKS'
+				AND version = 'pnagD'
+				AND time_range = @time
+				AND (@genre = '' OR track_trending_scores.genre = @genre)
+			ORDER BY
+				score DESC,
+				track_id DESC
+			LIMIT @limit
+			OFFSET @offset
+			`
 
 	args := pgx.NamedArgs{}
 	args["limit"] = limit

--- a/ddl/migrations/0218_track_trending_scores_desc_tiebreak_idx.sql
+++ b/ddl/migrations/0218_track_trending_scores_desc_tiebreak_idx.sql
@@ -1,0 +1,6 @@
+-- Hot trending endpoints order by score desc, track_id desc. The existing
+-- ix_trending_scores index has track_id in ascending order, which leaves
+-- PostgreSQL doing an incremental sort for every request. Keep API tie-break
+-- behavior stable by adding an index whose order matches the query.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS ix_trending_scores_desc_tiebreak
+    ON track_trending_scores (type, version, time_range, score DESC, track_id DESC);


### PR DESCRIPTION
## Summary
- remove a LEFT JOIN from getTrendingIds that did not filter rows
- add a concurrent index matching the existing ORDER BY score DESC, track_id DESC tie-breaker
- keep API ordering behavior unchanged for score ties

## Production evidence
- EXPLAIN for the current query planned a nested-loop left join plus incremental sort with startup cost ~309
- removing the inert join and matching index order lets PostgreSQL satisfy the hot lookup from the ordered btree path
- targeted tests caught that track_id DESC is expected for ties, so this PR preserves that contract

## Verification
- go test ./api -run 'TestGetTrendingIds|TestGetTrendingUnderground' -count=1 -timeout=2m