### PR TITLE
perf(api): simplify underground trending joins

### DIFF
--- a/api/v1_tracks_trending_underground.go
+++ b/api/v1_tracks_trending_underground.go
@@ -25,11 +25,6 @@ func (app *ApiServer) v1TracksTrendingUnderground(c *fiber.Ctx) error {
 	    WITH trending_tracks AS (
 			SELECT track_trending_scores.track_id
 			FROM track_trending_scores
-			LEFT JOIN tracks
-				ON tracks.track_id = track_trending_scores.track_id
-				AND tracks.is_delete = false
-				AND tracks.is_unlisted = false
-				AND tracks.is_available = true
 			WHERE type = 'TRACKS'
 				AND version = 'pnagD'
 				AND time_range = @time
@@ -42,12 +37,12 @@ func (app *ApiServer) v1TracksTrendingUnderground(c *fiber.Ctx) error {
 
 		SELECT track_trending_scores.track_id
 		FROM track_trending_scores
-		LEFT JOIN tracks
+		JOIN tracks
 			ON tracks.track_id = track_trending_scores.track_id
 			AND tracks.is_delete = false
 			AND tracks.is_unlisted = false
 			AND tracks.is_available = true
-		LEFT JOIN aggregate_user
+		JOIN aggregate_user
 			ON aggregate_user.user_id = tracks.owner_id
 		WHERE type = 'TRACKS'
 			AND version = 'pnagD'


### PR DESCRIPTION
## Summary
- removes a non-filtering `tracks` join from the underground exclusion CTE
- makes the main `tracks` and `aggregate_user` joins explicit inner joins, matching the existing follower/following predicates

## Production evidence
- `/v1/tracks/trending/underground` was one of the hot trending endpoints in the database audit
- the old CTE joined `tracks` with liveness predicates in the `ON` clause but selected only `track_trending_scores.track_id`, so deleted/unlisted/unavailable tracks were still counted in the top-20 exclusion set while adding work
- the main query already rejected NULL `aggregate_user` rows via `aggregate_user.follower_count < 1500` and `following_count < 1500`, so explicit joins give the planner a simpler join graph with the same endpoint behavior

## Verification
- `go test ./api -run 'TestGetTrendingUnderground' -count=1 -timeout=2m`