### PR TITLE
perf(db): index for you trending tie order

### DIFF
--- a/ddl/migrations/0218_track_trending_scores_for_you_desc_tiebreak_idx.sql
+++ b/ddl/migrations/0218_track_trending_scores_for_you_desc_tiebreak_idx.sql
@@ -1,0 +1,13 @@
+-- The For You feed orders weekly track candidates by score DESC, track_id DESC.
+-- The older partial index uses track_id ascending, leaving PostgreSQL to do an
+-- incremental sort after the index scan. Match the API order exactly.
+
+create index concurrently if not exists idx_track_trending_scores_for_you_desc_tiebreak
+    on track_trending_scores (score desc, track_id desc)
+    where type = 'TRACKS'
+      and version = 'pnagD'
+      and time_range = 'week'
+      and (genre is null or genre = '');
+
+comment on index idx_track_trending_scores_for_you_desc_tiebreak is
+    'Partial index matching For You feed weekly track candidate ordering by score desc, track_id desc.';


### PR DESCRIPTION
## Summary
- adds a concurrent partial index for the For You weekly track candidate slice
- matches the endpoint order exactly: `score DESC, track_id DESC`
- leaves the existing partial index in place so this can roll back independently

## Production evidence
- the database audit found the For You weekly trending/underground candidate plan using the existing partial index but still doing an incremental sort for tie ordering
- `api/v1_users_feed_for_you.go` orders both `cand_trending_track` and `cand_underground_track` by `tts.score DESC, tts.track_id DESC`
- the existing `idx_track_trending_scores_for_you` index is `(score DESC, track_id)` and cannot satisfy that tie direction directly

## Verification
- migration review only; SQL is `CREATE INDEX CONCURRENTLY IF NOT EXISTS` plus an index comment
- no application code changed