### PR TITLE
perf(db): index playlist trending order

### DIFF
--- a/ddl/migrations/0218_playlist_trending_scores_ordered_idx.sql
+++ b/ddl/migrations/0218_playlist_trending_scores_ordered_idx.sql
@@ -1,0 +1,10 @@
+-- Hot playlist trending callers order by score DESC, playlist_id DESC after
+-- filtering on type/version/time_range. Put the ordering columns immediately
+-- after the equality predicates so PostgreSQL can satisfy the LIMIT without a
+-- parallel scan and sort.
+
+create index concurrently if not exists idx_playlist_trending_scores_ordered
+    on playlist_trending_scores (type, version, time_range, score desc, playlist_id desc);
+
+comment on index idx_playlist_trending_scores_ordered is
+    'Covers playlist trending endpoints ordered by score desc, playlist_id desc.';


### PR DESCRIPTION
## Summary
- adds a concurrent index on `playlist_trending_scores(type, version, time_range, score DESC, playlist_id DESC)`
- covers `/v1/playlists/trending` and For You playlist candidate sources without changing API behavior

## Production evidence
- the database audit found playlist trending plans doing a parallel scan and sort for the hot `ORDER BY score DESC, playlist_id DESC LIMIT ...` pattern
- the production-only `idx_playlist_trending_scores_filtered` puts `playlist_id` before `score`, which cannot satisfy the requested ordering
- callers filter by `type`, `version`, and `time_range`, then page by score/tie-breaker; this index follows that shape directly

## Verification
- migration review only; SQL is `CREATE INDEX CONCURRENTLY IF NOT EXISTS` plus an index comment
- no application code changed