### PR TITLE
perf(db): drop unused balance history mint index

### DIFF
--- a/ddl/migrations/0218_drop_user_balance_history_user_mint_timestamp_idx.sql
+++ b/ddl/migrations/0218_drop_user_balance_history_user_mint_timestamp_idx.sql
@@ -1,0 +1,5 @@
+-- Production pg_stat_user_indexes showed this wide mint index at roughly 78 GB
+-- with zero scans. The API balance-history endpoint filters by user_id and
+-- timestamp only, which is covered by user_balance_history_user_timestamp_idx.
+
+drop index concurrently if exists user_balance_history_user_mint_timestamp_idx;


### PR DESCRIPTION
## Summary
- drops `user_balance_history_user_mint_timestamp_idx` concurrently
- keeps `user_balance_history_user_timestamp_idx`, which covers the API endpoint predicate

## Production evidence
- the database audit found `user_balance_history_user_mint_timestamp_idx` at roughly 78 GB with `idx_scan = 0`
- `api/v1_users_balance_history.go` filters by `user_id` and `timestamp`, not `mint`
- dropping the unused wider index removes write amplification, vacuum overhead, and cache pressure from a large table

## Verification
- migration review only; SQL is `DROP INDEX CONCURRENTLY IF EXISTS`
- no application code changed