### PR TITLE
perf(db): drop unused interval play count indexes

### DIFF
--- a/ddl/migrations/0218_drop_unused_interval_play_count_indexes.sql
+++ b/ddl/migrations/0218_drop_unused_interval_play_count_indexes.sql
@@ -1,0 +1,6 @@
+-- Production pg_stat_user_indexes showed both count-only interval play indexes
+-- with zero scans. aggregate_interval_plays lookups in the API use track_id,
+-- which is covered by interval_play_track_id_idx.
+
+drop index concurrently if exists interval_play_week_count_idx;
+drop index concurrently if exists interval_play_month_count_idx;


### PR DESCRIPTION
## Summary
- drops `interval_play_week_count_idx` and `interval_play_month_count_idx` concurrently when present
- leaves `interval_play_track_id_idx`, which covers API joins by track

## Production evidence
- the database audit found both count-only aggregate interval play indexes with `idx_scan = 0`
- API reads join aggregate play data by `track_id`; the checked-in schema keeps `interval_play_track_id_idx` for that path
- dropping unused indexes reduces write amplification and autovacuum/index-maintenance work on aggregate play updates

## Verification
- migration review only; SQL is `DROP INDEX CONCURRENTLY IF EXISTS`
- no application code changed