### PR TITLE
perf(db): drop duplicate reward disbursement index

### DIFF
--- a/ddl/migrations/0218_drop_duplicate_reward_disbursement_challenge_index.sql
+++ b/ddl/migrations/0218_drop_duplicate_reward_disbursement_challenge_index.sql
@@ -1,0 +1,5 @@
+-- sol_reward_disbursements_challenge_specifier_idx duplicates the checked-in
+-- sol_reward_disbursements_challenge_idx definition on (challenge_id, specifier).
+-- Keep the original index and remove the backfill-era duplicate.
+
+drop index concurrently if exists sol_reward_disbursements_challenge_specifier_idx;


### PR DESCRIPTION
## Summary
- drops `sol_reward_disbursements_challenge_specifier_idx` concurrently when present
- keeps `sol_reward_disbursements_challenge_idx`, which has the same `(challenge_id, specifier)` key

## Production evidence
- the database audit found `sol_reward_disbursements_challenge_specifier_idx` duplicating the checked-in `sol_reward_disbursements_challenge_idx`
- both indexes support the same challenge/specifier lookups, so keeping both adds write and vacuum overhead without improving read plans

## Verification
- migration review only; SQL is `DROP INDEX CONCURRENTLY IF EXISTS`
- no application code changed