### PR TITLE
perf(api): drive usdc purchase tracks from trending scores

### DIFF
--- a/api/v1_tracks_usdc_purchase.go
+++ b/api/v1_tracks_usdc_purchase.go
@@ -21,21 +21,20 @@ func (app *ApiServer) v1TracksUsdcPurchase(c *fiber.Ctx) error {
 	}
 
 	sql := `
-		WITH usdc_track_ids AS MATERIALIZED (
-			SELECT track_id
-			FROM tracks
-			WHERE
-				is_unlisted = false AND
-				is_available = true AND
-				is_delete = false AND
-				stream_conditions ? 'usdc_purchase'
-			)
-	    SELECT track_trending_scores.track_id
+		SELECT track_trending_scores.track_id
 		FROM track_trending_scores
-		JOIN usdc_track_ids ON track_trending_scores.track_id = usdc_track_ids.track_id
 		WHERE type = 'TRACKS'
 			AND version = 'pnagD'
 			AND time_range = @time
+			AND EXISTS (
+				SELECT 1
+				FROM tracks
+				WHERE tracks.track_id = track_trending_scores.track_id
+					AND tracks.is_unlisted = false
+					AND tracks.is_available = true
+					AND tracks.is_delete = false
+					AND tracks.stream_conditions ? 'usdc_purchase'
+			)
 		ORDER BY
 			track_trending_scores.score DESC,
 			track_trending_scores.track_id DESC


### PR DESCRIPTION
## Summary
- removes the materialized `usdc_track_ids` CTE from `/v1/tracks/usdc-purchase`
- filters ordered `track_trending_scores` rows with an `EXISTS` probe against `tracks`
- preserves the same eligibility predicates and `ORDER BY score DESC, track_id DESC` response order

## Production evidence
- the database audit found the current plan materializing eligible USDC tracks before sorting joined trending scores, with startup cost around 265k for a small page
- the rewritten shape lets PostgreSQL start from the ordered trending-score path and probe `tracks` by `track_id`, which the audit EXPLAIN showed reducing startup work by orders of magnitude for the equivalent ordered scan/probe plan
- this PR is code-only and independent of the separate trending-score index PR

## Verification
- `go test ./api -run 'TestGetUsdcPurchase|TestGetTrendingIds' -count=1 -timeout=2m`