### PR TITLE
chore(api): bump etl to include slug-collision route index (#337)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,8 +6,8 @@ require (
 	connectrpc.com/connect v1.18.1
 	github.com/AlecAivazis/survey/v2 v2.3.7
 	github.com/Doist/unfurlist v0.0.0-20250409100812-515f2735f8e5
-	github.com/OpenAudio/go-openaudio v1.3.1-0.20260602061322-5d2e19ad9d78
-	github.com/OpenAudio/go-openaudio/pkg/etl v1.3.1-0.20260602061322-5d2e19ad9d78
+	github.com/OpenAudio/go-openaudio v1.3.1-0.20260604005215-43606e8d8e5a
+	github.com/OpenAudio/go-openaudio/pkg/etl v1.3.1-0.20260604005215-43606e8d8e5a
 	github.com/aquasecurity/esquery v0.2.0
 	github.com/axiomhq/axiom-go v0.23.0
 	github.com/axiomhq/hyperloglog v0.2.5

--- a/go.sum
+++ b/go.sum
@@ -20,10 +20,10 @@ github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2 h1:+vx7roKuyA63n
 github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2/go.mod h1:HBCaDeC1lPdgDeDbhX8XFpy1jqjK0IBG8W5K+xYqA0w=
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5 h1:TngWCqHvy9oXAN6lEVMRuU21PR1EtLVZJmdB18Gu3Rw=
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5/go.mod h1:lmUJ/7eu/Q8D7ML55dXQrVaamCz2vxCfdQBasLZfHKk=
-github.com/OpenAudio/go-openaudio v1.3.1-0.20260602061322-5d2e19ad9d78 h1:SyVtJId85zH8jse56Sz5VEdCeKx/MwtvV5d1lfaZTGo=
-github.com/OpenAudio/go-openaudio v1.3.1-0.20260602061322-5d2e19ad9d78/go.mod h1:wiFXmVbIUkN2D5lRshknaARCKhzbHtCBKRCZe6UOnVs=
-github.com/OpenAudio/go-openaudio/pkg/etl v1.3.1-0.20260602061322-5d2e19ad9d78 h1:DKb+F4ekHl4titj7MHVHqd3Qpp50nEDYsKci9IvgPxo=
-github.com/OpenAudio/go-openaudio/pkg/etl v1.3.1-0.20260602061322-5d2e19ad9d78/go.mod h1:LZKiU9vBYzlZzn6oPRHHLPXteBtMKQPegNH9bX9JuH8=
+github.com/OpenAudio/go-openaudio v1.3.1-0.20260604005215-43606e8d8e5a h1:cU6o/VTe+USqBOR4IKb1mCRkFDDww7KL1xaQ1eGzSHY=
+github.com/OpenAudio/go-openaudio v1.3.1-0.20260604005215-43606e8d8e5a/go.mod h1:wiFXmVbIUkN2D5lRshknaARCKhzbHtCBKRCZe6UOnVs=
+github.com/OpenAudio/go-openaudio/pkg/etl v1.3.1-0.20260604005215-43606e8d8e5a h1:ghuTw2GGHP9oInTBlE27iegrQ1ZYmQl57tlZqrvdrGQ=
+github.com/OpenAudio/go-openaudio/pkg/etl v1.3.1-0.20260604005215-43606e8d8e5a/go.mod h1:LZKiU9vBYzlZzn6oPRHHLPXteBtMKQPegNH9bX9JuH8=
 github.com/StackExchange/wmi v1.2.1 h1:VIkavFPXSjcnS+O8yTq7NI32k0R5Aj+v39y29VYDOSA=
 github.com/StackExchange/wmi v1.2.1/go.mod h1:rcmrprowKIVzvc+NUiLncP2uuArMWLCbu9SBzvHz7e8=
 github.com/VictoriaMetrics/fastcache v1.12.2 h1:N0y9ASrJ0F6h0QaC3o6uJb3NIZ9VKLjCM7NQbSmF7WI=


### PR DESCRIPTION
## Summary

Bumps `github.com/OpenAudio/go-openaudio` and `.../pkg/etl` from `5d2e19a` (#901) to **`43606e8`** to consume go-openaudio **#337**.

That change adds ETL migration `0031`, which indexes `track_routes` and `playlist_routes` on `(owner_id, title_slug, collision_id)`. Slug-collision resolution runs `SELECT MAX(collision_id) … WHERE owner_id AND title_slug` on every track/playlist create + rename; today that's a full per-owner route scan (prod EXPLAIN: ~16k-row bitmap heap scan on every upload for a prolific owner), which is the multi-second Track (7.8s) / Playlist (44s) tail in `core-indexer`. The new index makes it an index-only lookup.

`core-indexer` runs this vendored `audius/api` image, so this bump is required to ship #337 to prod.

## Changes
- `go.mod` / `go.sum`: both go-openaudio modules → `v1.3.1-0.20260604005215-43606e8d8e5a`

## ⚠️ Deploy note — pre-build the indexes CONCURRENTLY first
Migration 0031 builds the indexes **non-concurrently** (single-transaction migration runner), taking an `ACCESS EXCLUSIVE` lock on `track_routes` (~2M rows / 493 MB) on indexer boot. To avoid stalling route writes on deploy, pre-build them in prod first — `IF NOT EXISTS` then makes the migration a no-op (same pattern used to recover the 0030 indexes):

```sql
CREATE INDEX CONCURRENTLY IF NOT EXISTS track_routes_owner_title_slug_idx
  ON track_routes (owner_id, title_slug, collision_id);
CREATE INDEX CONCURRENTLY IF NOT EXISTS playlist_routes_owner_title_slug_idx
  ON playlist_routes (owner_id, title_slug, collision_id);
```

## Test plan
- [x] `go mod tidy` — only go.mod/go.sum changed
- [x] `go build ./...` passes
- [x] migration `0031` present in the resolved module
- [ ] Post-deploy: 0031 applied (or no-op if pre-built), and Track/Playlist max processing times drop in the indexer log analysis

🤖 Generated with [Claude Code](https://claude.com/claude-code)