### PR TITLE
fix(api): route prod uploads to creatornode2 only

### DIFF
--- a/config/nodes.go
+++ b/config/nodes.go
@@ -19,7 +19,6 @@ type Node struct {
 
 var (
 	ProdUploadNodes = []string{
-		"https://creatornode.audius.co",
 		"https://creatornode2.audius.co",
 	}
 	StageUploadNodes = []string{


### PR DESCRIPTION
## Summary
- Remove `creatornode.audius.co` from `ProdUploadNodes` so production uploads target only the stable `creatornode2.audius.co`.

## Why
Stabilizing upload routing after recent infra changes — pinning uploads to the healthy creator node.

## Test plan
- [ ] Confirm uploads succeed against creatornode2.audius.co after deploy
- [ ] Verify no uploads are routed to creatornode.audius.co

🤖 Generated with [Claude Code](https://claude.com/claude-code)