### PR TITLE
fix(trending): use bare type strings in trending winners queries

### DIFF
--- a/api/testdata/trending_results_fixtures.go
+++ b/api/testdata/trending_results_fixtures.go
@@ -2,11 +2,11 @@ package testdata
 
 var TrendingResultsFixtures = []map[string]any{
 	// Week 2022-01-21 - tracks 300, 202, 200 (rank 1, 2, 3) - matches trending order
-	{"user_id": 3, "id": "300", "rank": 1, "type": "TrendingType.TRACKS", "version": "TrendingVersion.ML51L", "week": "2022-01-21"},
-	{"user_id": 2, "id": "202", "rank": 2, "type": "TrendingType.TRACKS", "version": "TrendingVersion.ML51L", "week": "2022-01-21"},
-	{"user_id": 2, "id": "200", "rank": 3, "type": "TrendingType.TRACKS", "version": "TrendingVersion.ML51L", "week": "2022-01-21"},
+	{"user_id": 3, "id": "300", "rank": 1, "type": "TRACKS", "version": "TrendingVersion.ML51L", "week": "2022-01-21"},
+	{"user_id": 2, "id": "202", "rank": 2, "type": "TRACKS", "version": "TrendingVersion.ML51L", "week": "2022-01-21"},
+	{"user_id": 2, "id": "200", "rank": 3, "type": "TRACKS", "version": "TrendingVersion.ML51L", "week": "2022-01-21"},
 	// Week 2022-01-21 - underground tracks 519, 520, 521 (rank 1, 2, 3)
-	{"user_id": 8, "id": "519", "rank": 1, "type": "TrendingType.UNDERGROUND_TRACKS", "version": "TrendingVersion.ML51L", "week": "2022-01-21"},
-	{"user_id": 11, "id": "520", "rank": 2, "type": "TrendingType.UNDERGROUND_TRACKS", "version": "TrendingVersion.ML51L", "week": "2022-01-21"},
-	{"user_id": 1, "id": "521", "rank": 3, "type": "TrendingType.UNDERGROUND_TRACKS", "version": "TrendingVersion.ML51L", "week": "2022-01-21"},
+	{"user_id": 8, "id": "519", "rank": 1, "type": "UNDERGROUND_TRACKS", "version": "TrendingVersion.ML51L", "week": "2022-01-21"},
+	{"user_id": 11, "id": "520", "rank": 2, "type": "UNDERGROUND_TRACKS", "version": "TrendingVersion.ML51L", "week": "2022-01-21"},
+	{"user_id": 1, "id": "521", "rank": 3, "type": "UNDERGROUND_TRACKS", "version": "TrendingVersion.ML51L", "week": "2022-01-21"},
 }

--- a/api/v1_tracks_trending_underground_winners.go
+++ b/api/v1_tracks_trending_underground_winners.go
@@ -43,7 +43,7 @@ func (app *ApiServer) v1TracksTrendingUndergroundWinners(c *fiber.Ctx) error {
 
 func (app *ApiServer) getTrendingUndergroundWinnersIds(c *fiber.Ctx, weekParam string) ([]int32, error) {
 	args := pgx.NamedArgs{
-		"type": "TrendingType.UNDERGROUND_TRACKS",
+		"type": "UNDERGROUND_TRACKS",
 	}
 
 	var weekFilter string

--- a/api/v1_tracks_trending_winners.go
+++ b/api/v1_tracks_trending_winners.go
@@ -43,7 +43,7 @@ func (app *ApiServer) v1TracksTrendingWinners(c *fiber.Ctx) error {
 
 func (app *ApiServer) getTrendingWinnersIds(c *fiber.Ctx, weekParam string) ([]int32, error) {
 	args := pgx.NamedArgs{
-		"type": "TrendingType.TRACKS",
+		"type": "TRACKS",
 	}
 
 	var weekFilter string


### PR DESCRIPTION
## Summary
The trending winners endpoints filtered `trending_results.type` using the
Python-style enum strings `TrendingType.TRACKS` and
`TrendingType.UNDERGROUND_TRACKS`, but the values actually stored in the
table are the bare `TRACKS` / `UNDERGROUND_TRACKS`. This swaps the query
filter values to the bare strings and updates the test fixtures to match.

## Changes
- `api/v1_tracks_trending_winners.go`: `TrendingType.TRACKS` → `TRACKS`
- `api/v1_tracks_trending_underground_winners.go`: `TrendingType.UNDERGROUND_TRACKS` → `UNDERGROUND_TRACKS`
- `api/testdata/trending_results_fixtures.go`: updated fixture `type` values to match

## Testing
`go test ./api/... -run 'TestGetTrendingWinnersTracks|TestGetTrendingUndergroundWinnersTracks' -v` — all 8 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)