### PR TITLE
chore: creatornode2 turndown — route uploads/storage to creatornode, RPC to rpc.audius.co

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -217,8 +217,7 @@ func init() {
 		fallthrough
 	case "production":
 		Cfg.OpenAudioURLs = []string{
-			"creatornode.audius.co",
-			"creatornode2.audius.co",
+			"rpc.audius.co",
 		}
 		if Cfg.DelegatePrivateKey == "" {
 			log.Fatalf("Missing required %s env var: delegatePrivateKey", env)
@@ -251,11 +250,11 @@ func init() {
 			"https://audius-content-13.cultur3stake.com",
 		}
 		Cfg.StoreAllNodes = []string{
-			"https://creatornode2.audius.co",
+			"https://creatornode.audius.co",
 		}
 		Cfg.UploadNodes = ProdUploadNodes
 		Cfg.Rewards = core_config.MakeRewards(core_config.ProdClaimAuthorities, core_config.ProdRewardExtensions)
-		Cfg.AudiusdURL = "creatornode.audius.co"
+		Cfg.AudiusdURL = "rpc.audius.co"
 		Cfg.ChainId = "audius-mainnet-alpha-beta"
 		Cfg.AudiusdChainID = core_config.ProdAcdcChainID
 		Cfg.AudiusdEntityManagerAddress = core_config.ProdAcdcAddress

--- a/config/nodes.go
+++ b/config/nodes.go
@@ -19,7 +19,7 @@ type Node struct {
 
 var (
 	ProdUploadNodes = []string{
-		"https://creatornode2.audius.co",
+		"https://creatornode.audius.co",
 	}
 	StageUploadNodes = []string{
 		"https://creatornode6.staging.audius.co",


### PR DESCRIPTION
## What
Remove all `creatornode2.audius.co` references from prod config as part of the node turndown, and dedicate RPC traffic to `rpc.audius.co`.

| Config | Before | After | Role |
|---|---|---|---|
| `ProdUploadNodes` (`config/nodes.go`) | creatornode2 | **creatornode** | client upload routing |
| `StoreAllNodes` (`config/config.go`) | creatornode2 | **creatornode** | rendezvous full-replica content/blob node (becoming archive) |
| `OpenAudioURLs` (`config/config.go`) | creatornode, creatornode2 | **rpc.audius.co** | API server OpenAudio RPC pool |
| `AudiusdURL` (`config/config.go`) | creatornode | **rpc.audius.co** | primary OpenAudio SDK — used by API server, **indexer**, and `rewards_cli` |

## Why
`creatornode2.audius.co` is being decommissioned. RPC reads are dedicated to the purpose-built `rpc.audius.co`; content/upload/store-all duties stay on `creatornode.audius.co`, which is staying up and becoming the archive / store-all node.

## Notes / blast radius
- `AudiusdURL` is the chain source the **indexer** builds the API DB from — this PR repoints that to `rpc.audius.co`. Confirmed healthy: `/health_check` 200, `core.live: true`, current height ~25.9M, same audiusd image.
- `OpenAudioURLs` is now a single endpoint (no failover pool) per decision to dedicate RPC to `rpc.audius.co`.
- `ArtistCoinRewardsStaticSenders` still lists `creatornode.audius.co` (kept — that node stays up).

## Verification
- `go build ./config/... ./api/... ./indexer/... ./cmd/rewards_cli/...` passes
- No `creatornode2` references remain in `config/`
- `rpc.audius.co` and `creatornode.audius.co` both confirmed healthy

🤖 Generated with [Claude Code](https://claude.com/claude-code)