### PR TITLE
chore(api): bump etl to rune-count limits + slug-collision index (#340)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,8 +6,8 @@ require (
 	connectrpc.com/connect v1.18.1
 	github.com/AlecAivazis/survey/v2 v2.3.7
 	github.com/Doist/unfurlist v0.0.0-20250409100812-515f2735f8e5
-	github.com/OpenAudio/go-openaudio v1.3.1-0.20260602061322-5d2e19ad9d78
-	github.com/OpenAudio/go-openaudio/pkg/etl v1.3.1-0.20260602061322-5d2e19ad9d78
+	github.com/OpenAudio/go-openaudio v1.3.1-0.20260608175930-7062cd90dff5
+	github.com/OpenAudio/go-openaudio/pkg/etl v1.3.1-0.20260608175930-7062cd90dff5
 	github.com/aquasecurity/esquery v0.2.0
 	github.com/axiomhq/axiom-go v0.23.0
 	github.com/axiomhq/hyperloglog v0.2.5

--- a/go.sum
+++ b/go.sum
@@ -20,10 +20,10 @@ github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2 h1:+vx7roKuyA63n
 github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2/go.mod h1:HBCaDeC1lPdgDeDbhX8XFpy1jqjK0IBG8W5K+xYqA0w=
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5 h1:TngWCqHvy9oXAN6lEVMRuU21PR1EtLVZJmdB18Gu3Rw=
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5/go.mod h1:lmUJ/7eu/Q8D7ML55dXQrVaamCz2vxCfdQBasLZfHKk=
-github.com/OpenAudio/go-openaudio v1.3.1-0.20260602061322-5d2e19ad9d78 h1:SyVtJId85zH8jse56Sz5VEdCeKx/MwtvV5d1lfaZTGo=
-github.com/OpenAudio/go-openaudio v1.3.1-0.20260602061322-5d2e19ad9d78/go.mod h1:wiFXmVbIUkN2D5lRshknaARCKhzbHtCBKRCZe6UOnVs=
-github.com/OpenAudio/go-openaudio/pkg/etl v1.3.1-0.20260602061322-5d2e19ad9d78 h1:DKb+F4ekHl4titj7MHVHqd3Qpp50nEDYsKci9IvgPxo=
-github.com/OpenAudio/go-openaudio/pkg/etl v1.3.1-0.20260602061322-5d2e19ad9d78/go.mod h1:LZKiU9vBYzlZzn6oPRHHLPXteBtMKQPegNH9bX9JuH8=
+github.com/OpenAudio/go-openaudio v1.3.1-0.20260608175930-7062cd90dff5 h1:cSnrd4WohhfCBZXt8zTOqY6nvrgyvNXpqdGXNuMvqVk=
+github.com/OpenAudio/go-openaudio v1.3.1-0.20260608175930-7062cd90dff5/go.mod h1:wiFXmVbIUkN2D5lRshknaARCKhzbHtCBKRCZe6UOnVs=
+github.com/OpenAudio/go-openaudio/pkg/etl v1.3.1-0.20260608175930-7062cd90dff5 h1:xJ8Lg2TisX/WmiDY4LqSwSmdh8KLYiLidnIWhUYbxcs=
+github.com/OpenAudio/go-openaudio/pkg/etl v1.3.1-0.20260608175930-7062cd90dff5/go.mod h1:LZKiU9vBYzlZzn6oPRHHLPXteBtMKQPegNH9bX9JuH8=
 github.com/StackExchange/wmi v1.2.1 h1:VIkavFPXSjcnS+O8yTq7NI32k0R5Aj+v39y29VYDOSA=
 github.com/StackExchange/wmi v1.2.1/go.mod h1:rcmrprowKIVzvc+NUiLncP2uuArMWLCbu9SBzvHz7e8=
 github.com/VictoriaMetrics/fastcache v1.12.2 h1:N0y9ASrJ0F6h0QaC3o6uJb3NIZ9VKLjCM7NQbSmF7WI=


### PR DESCRIPTION
## Summary

Bumps `github.com/OpenAudio/go-openaudio` and `.../pkg/etl` from `5d2e19a` (#901) to **`7062cd9`**. Because `7062cd9` is downstream of both fixes, this single bump ships **two** changes to `core-indexer`:

> **Supersedes #912** (the standalone slug bump). #912 can be closed — this bump includes everything in it plus #340.

## Changes
- `go.mod` / `go.sum`: both go-openaudio modules → `v1.3.1-0.20260608175930-7062cd90dff5`

## ⚠️ Deploy note (carried from #337) — pre-build the indexes CONCURRENTLY
This bump pulls migration `0031`, which builds two route indexes **non-concurrently** (single-transaction migration runner), taking an `ACCESS EXCLUSIVE` lock on `track_routes` (~2M rows / 493 MB) on indexer boot. To avoid stalling route writes on deploy, pre-build them in prod first — `IF NOT EXISTS` then makes the migration a no-op:

```sql
CREATE INDEX CONCURRENTLY IF NOT EXISTS track_routes_owner_title_slug_idx
  ON track_routes (owner_id, title_slug, collision_id);
CREATE INDEX CONCURRENTLY IF NOT EXISTS playlist_routes_owner_title_slug_idx
  ON playlist_routes (owner_id, title_slug, collision_id);
```

(The rune-count change in #340 is pure validation logic — no migration, no special rollout.)

## Test plan
- [x] `go mod tidy` — only go.mod/go.sum changed
- [x] `go build ./...` passes
- [x] resolved module contains the rune-count fix (`RuneCountInString` in validate.go) **and** migration `0031`
- [ ] Post-deploy: `g1ld3dd` (and other multi-byte-name users) can save profile updates / artist picks; 0031 applied or no-op; Track/Playlist max processing times drop

🤖 Generated with [Claude Code](https://claude.com/claude-code)