### PR TITLE
chore(api): bump etl to persist user social links (#341)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,8 +6,8 @@ require (
 	connectrpc.com/connect v1.18.1
 	github.com/AlecAivazis/survey/v2 v2.3.7
 	github.com/Doist/unfurlist v0.0.0-20250409100812-515f2735f8e5
-	github.com/OpenAudio/go-openaudio v1.3.1-0.20260608175930-7062cd90dff5
-	github.com/OpenAudio/go-openaudio/pkg/etl v1.3.1-0.20260608175930-7062cd90dff5
+	github.com/OpenAudio/go-openaudio v1.3.1-0.20260608204715-4cccb46f1332
+	github.com/OpenAudio/go-openaudio/pkg/etl v1.3.1-0.20260608204715-4cccb46f1332
 	github.com/aquasecurity/esquery v0.2.0
 	github.com/axiomhq/axiom-go v0.23.0
 	github.com/axiomhq/hyperloglog v0.2.5

--- a/go.sum
+++ b/go.sum
@@ -20,10 +20,10 @@ github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2 h1:+vx7roKuyA63n
 github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2/go.mod h1:HBCaDeC1lPdgDeDbhX8XFpy1jqjK0IBG8W5K+xYqA0w=
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5 h1:TngWCqHvy9oXAN6lEVMRuU21PR1EtLVZJmdB18Gu3Rw=
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5/go.mod h1:lmUJ/7eu/Q8D7ML55dXQrVaamCz2vxCfdQBasLZfHKk=
-github.com/OpenAudio/go-openaudio v1.3.1-0.20260608175930-7062cd90dff5 h1:cSnrd4WohhfCBZXt8zTOqY6nvrgyvNXpqdGXNuMvqVk=
-github.com/OpenAudio/go-openaudio v1.3.1-0.20260608175930-7062cd90dff5/go.mod h1:wiFXmVbIUkN2D5lRshknaARCKhzbHtCBKRCZe6UOnVs=
-github.com/OpenAudio/go-openaudio/pkg/etl v1.3.1-0.20260608175930-7062cd90dff5 h1:xJ8Lg2TisX/WmiDY4LqSwSmdh8KLYiLidnIWhUYbxcs=
-github.com/OpenAudio/go-openaudio/pkg/etl v1.3.1-0.20260608175930-7062cd90dff5/go.mod h1:LZKiU9vBYzlZzn6oPRHHLPXteBtMKQPegNH9bX9JuH8=
+github.com/OpenAudio/go-openaudio v1.3.1-0.20260608204715-4cccb46f1332 h1:kzylGfPmjhK27EEIfa0OvaCQ5LIc86khH0HDf7Sj32E=
+github.com/OpenAudio/go-openaudio v1.3.1-0.20260608204715-4cccb46f1332/go.mod h1:wiFXmVbIUkN2D5lRshknaARCKhzbHtCBKRCZe6UOnVs=
+github.com/OpenAudio/go-openaudio/pkg/etl v1.3.1-0.20260608204715-4cccb46f1332 h1:tAA2Lky0ReU5PQfyUZeg0+jQj0ycbKJiLEQPvDgOrtw=
+github.com/OpenAudio/go-openaudio/pkg/etl v1.3.1-0.20260608204715-4cccb46f1332/go.mod h1:LZKiU9vBYzlZzn6oPRHHLPXteBtMKQPegNH9bX9JuH8=
 github.com/StackExchange/wmi v1.2.1 h1:VIkavFPXSjcnS+O8yTq7NI32k0R5Aj+v39y29VYDOSA=
 github.com/StackExchange/wmi v1.2.1/go.mod h1:rcmrprowKIVzvc+NUiLncP2uuArMWLCbu9SBzvHz7e8=
 github.com/VictoriaMetrics/fastcache v1.12.2 h1:N0y9ASrJ0F6h0QaC3o6uJb3NIZ9VKLjCM7NQbSmF7WI=


### PR DESCRIPTION
## Summary

Bumps `github.com/OpenAudio/go-openaudio` and `.../pkg/etl` from `7062cd9` (#919) to **`4cccb46`** to consume go-openaudio **#341**.

That change fixes the User Create/Update handlers silently dropping `instagram_handle`, `twitter_handle`, `tiktok_handle`, `website`, and `donation` — so users editing their profile could not add or change social links. Reported by `audius.co/allatonce` and `audius.co/peaceluis`. Production data: 167k+ users have an *unverified* Instagram handle, confirming these are normal profile fields, not verification-only.

`core-indexer` runs this vendored `audius/api` image, so this bump is required to ship the fix.

## Changes
- `go.mod` / `go.sum`: both go-openaudio modules → `v1.3.1-0.20260608204715-4cccb46f1332`

## Deploy note — migration 0032 (low risk)
This bump pulls ETL migration `0032`, which adds the `website` + `donation` columns with `IF NOT EXISTS`. In prod these columns already exist (inherited legacy schema), so 0032 is a **no-op there** — no lock concern (unlike the 0031 index build). No special rollout needed.

## Test plan
- [x] `go mod tidy` — only go.mod/go.sum changed
- [x] `go build ./...` passes
- [x] resolved module contains the social-field writes (`instagram_handle` in user_update.go) and migration `0032`
- [ ] Post-deploy: `allatonce` / `peaceluis` can save IG handle + website; `verified_with_*` unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)