### PR TITLE
fix(challenges): stamp completed_blocknumber on trending winners

### DIFF
--- a/jobs/challenges/trending.go
+++ b/jobs/challenges/trending.go
@@ -188,6 +188,20 @@ func (p *TrendingProcessor) Reconcile(ctx context.Context, tx pgx.Tx) error {
 		return nil
 	}
 
+	// The pedalboard disburser pages /challenges/undisbursed with a
+	// `completed_blocknumber > cursor` filter, so rows with a NULL
+	// completed_blocknumber are never swept by the batch job (only client-side
+	// claims, which pass cursor 0, pay out). Stamp the current indexed block so
+	// weekly winners are disbursable, as the legacy indexer did.
+	var completedBlock int64
+	if err := tx.QueryRow(ctx, `
+		SELECT GREATEST(
+			COALESCE((SELECT max(blocknumber) FROM tracks), 0),
+			COALESCE((SELECT max(blocknumber) FROM playlists), 0))
+	`).Scan(&completedBlock); err != nil {
+		return fmt.Errorf("trending completed_blocknumber: %w", err)
+	}
+
 	for idx, e := range entries {
 		rank := int32(idx + 1)
 		rewardAmount := p.amountForRank(rank)
@@ -206,6 +220,13 @@ func (p *TrendingProcessor) Reconcile(ctx context.Context, tx pgx.Tx) error {
 		); err != nil {
 			return fmt.Errorf("upsert trending user_challenge: %w", err)
 		}
+	}
+
+	if _, err := tx.Exec(ctx, `
+		UPDATE user_challenges SET completed_blocknumber = $1
+		WHERE challenge_id = $2 AND specifier LIKE $3 AND completed_blocknumber IS NULL
+	`, completedBlock, p.ID, weekDate.Format("2006-01-02")+":%"); err != nil {
+		return fmt.Errorf("stamp trending completed_blocknumber: %w", err)
 	}
 	return nil
 }

--- a/jobs/challenges/trending_test.go
+++ b/jobs/challenges/trending_test.go
@@ -72,6 +72,14 @@ func TestTrending_IdempotentSameWeek(t *testing.T) {
 		}
 	}
 
+	// Regression: completed_blocknumber must be stamped. A NULL value is
+	// invisible to the pedalboard disburser, which pages /challenges/undisbursed
+	// with a `completed_blocknumber > cursor` filter.
+	var nullBlocks int
+	require.NoError(t, pool.QueryRow(context.Background(),
+		"SELECT COUNT(*) FROM user_challenges WHERE challenge_id = 'tt' AND completed_blocknumber IS NULL").Scan(&nullBlocks))
+	assert.Equal(t, 0, nullBlocks, "trending winners must have completed_blocknumber set")
+
 	// Second run is a no-op (already paid this week).
 	runProcessor(t, pool, NewTrendingTrackProcessor())
 	var count2 int


### PR DESCRIPTION
## Summary

Weekly trending rewards (`tt` / `tut` / `tp`) stopped being disbursable by the **pedalboard `trending-challenge-rewards`** batch job after the Python→Go indexer migration. Root cause:

- The Go trending reconcile inserts `user_challenges` via `UpsertUserChallenge`, which **never sets `completed_blocknumber`** (the legacy Python indexer did).
- The pedalboard disburser pages `GET /v1/challenges/undisbursed?...&completed_blocknumber=${cursor}` with a **non-zero cursor**, and that endpoint filters `completed_blocknumber > cursor`. `NULL > cursor` is false, so every trending winner is invisible to the batch job.
- Only **client-side claims** (the app calls the endpoint with cursor `0`, which disables the filter) paid out — which is why a few winners each week got rewarded and the rest silently didn't.

## Fix

In `TrendingProcessor.Reconcile`, stamp `completed_blocknumber` with the current max indexed block (across `tracks` and `playlists`) at reconcile time, so weekly winners are swept by the batch disburser. One `UPDATE` over the rows just inserted for the week, inside the same tx.

Scoped to the trending reconcile rather than threading a block through the shared `UpsertUserChallenge` (16 call sites) — trending is the only path the pedalboard cursor depends on. Other challenge types can thread their per-event blocknumber in a follow-up if they're ever batch-disbursed.

## Testing

- `TestTrending_IdempotentSameWeek` gains a regression assertion: no trending winner may have a NULL `completed_blocknumber`.
- Verified by temporarily bypassing the Friday gate (test + processor) against the `test_jobs` DB — passes with the fix, fails the new assertion without it. Reverted the bypasses; `go build ./jobs/...` + `go vet` clean.

> Note: the trending tests are Friday-UTC gated, so CI only exercises this path on Fridays.

## Related ops

The already-affected `2026-06-05` `tt`/`tut` rows were backfilled manually (set `completed_blocknumber`) so the pedalboard `/disburse 2026-06-05` can pay them out. This PR prevents recurrence for all future weeks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)