### PR TITLE
chore(api): bump etl to persist dropped track/comment fields (#343)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,8 +6,8 @@ require (
 	connectrpc.com/connect v1.18.1
 	github.com/AlecAivazis/survey/v2 v2.3.7
 	github.com/Doist/unfurlist v0.0.0-20250409100812-515f2735f8e5
-	github.com/OpenAudio/go-openaudio v1.3.1-0.20260608204715-4cccb46f1332
-	github.com/OpenAudio/go-openaudio/pkg/etl v1.3.1-0.20260608204715-4cccb46f1332
+	github.com/OpenAudio/go-openaudio v1.3.1-0.20260609000702-c5fcacffbb79
+	github.com/OpenAudio/go-openaudio/pkg/etl v1.3.1-0.20260609000702-c5fcacffbb79
 	github.com/aquasecurity/esquery v0.2.0
 	github.com/axiomhq/axiom-go v0.23.0
 	github.com/axiomhq/hyperloglog v0.2.5

--- a/go.sum
+++ b/go.sum
@@ -20,10 +20,10 @@ github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2 h1:+vx7roKuyA63n
 github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2/go.mod h1:HBCaDeC1lPdgDeDbhX8XFpy1jqjK0IBG8W5K+xYqA0w=
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5 h1:TngWCqHvy9oXAN6lEVMRuU21PR1EtLVZJmdB18Gu3Rw=
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5/go.mod h1:lmUJ/7eu/Q8D7ML55dXQrVaamCz2vxCfdQBasLZfHKk=
-github.com/OpenAudio/go-openaudio v1.3.1-0.20260608204715-4cccb46f1332 h1:kzylGfPmjhK27EEIfa0OvaCQ5LIc86khH0HDf7Sj32E=
-github.com/OpenAudio/go-openaudio v1.3.1-0.20260608204715-4cccb46f1332/go.mod h1:wiFXmVbIUkN2D5lRshknaARCKhzbHtCBKRCZe6UOnVs=
-github.com/OpenAudio/go-openaudio/pkg/etl v1.3.1-0.20260608204715-4cccb46f1332 h1:tAA2Lky0ReU5PQfyUZeg0+jQj0ycbKJiLEQPvDgOrtw=
-github.com/OpenAudio/go-openaudio/pkg/etl v1.3.1-0.20260608204715-4cccb46f1332/go.mod h1:LZKiU9vBYzlZzn6oPRHHLPXteBtMKQPegNH9bX9JuH8=
+github.com/OpenAudio/go-openaudio v1.3.1-0.20260609000702-c5fcacffbb79 h1:eqTu4/JR74mPNa3JqlL2u5C8QZUzqzcIg88CuOHNgkY=
+github.com/OpenAudio/go-openaudio v1.3.1-0.20260609000702-c5fcacffbb79/go.mod h1:wiFXmVbIUkN2D5lRshknaARCKhzbHtCBKRCZe6UOnVs=
+github.com/OpenAudio/go-openaudio/pkg/etl v1.3.1-0.20260609000702-c5fcacffbb79 h1:0JRNoJtyEx0ngJr24LI4CPW4eTQm3lbfU6OmVGVDuFs=
+github.com/OpenAudio/go-openaudio/pkg/etl v1.3.1-0.20260609000702-c5fcacffbb79/go.mod h1:LZKiU9vBYzlZzn6oPRHHLPXteBtMKQPegNH9bX9JuH8=
 github.com/StackExchange/wmi v1.2.1 h1:VIkavFPXSjcnS+O8yTq7NI32k0R5Aj+v39y29VYDOSA=
 github.com/StackExchange/wmi v1.2.1/go.mod h1:rcmrprowKIVzvc+NUiLncP2uuArMWLCbu9SBzvHz7e8=
 github.com/VictoriaMetrics/fastcache v1.12.2 h1:N0y9ASrJ0F6h0QaC3o6uJb3NIZ9VKLjCM7NQbSmF7WI=


### PR DESCRIPTION
## Summary

Bumps `github.com/OpenAudio/go-openaudio` and `.../pkg/etl` from `4cccb46` (#920) to **`c5fcacf`** to consume go-openaudio **#343**.

That change fixes entity-manager handlers silently dropping columns that exist on the table and arrive in metadata (same class as the social-links fix, found by auditing all write handlers):
- **Track** create/update now persist `license`, `isrc`, `iswc`, `preview_start_seconds`, `comments_disabled`, `no_ai_use`, `cover_original_song_title`, `cover_original_artist`. Prod scale of the prior loss: 642,291 tracks have a `license`, 94,894 an `isrc`, 31,615 a custom `preview_start_seconds`.
- **Comment** update now preserves/updates `video_url` (a text-only edit no longer wipes an attached video).

`core-indexer` runs this vendored `audius/api` image, so this bump ships the fix.

## Changes
- `go.mod` / `go.sum`: both go-openaudio modules → `v1.3.1-0.20260609000702-c5fcacffbb79`

## Deploy note — no migration
This is **code-only**: every affected column already exists in migration `0002`/`0032`, so there's no new migration and no schema/rollout concern. Latest ETL migration stays `0032`.

## Test plan
- [x] `go mod tidy` — only go.mod/go.sum changed
- [x] `go build ./...` passes
- [x] resolved module contains the track field writes (`License` in track_row.go) and comment `video_url` COALESCE; latest migration unchanged (0032)
- [ ] Post-deploy: track license/isrc/preview-start and comment video edits persist (verify on a test account)

🤖 Generated with [Claude Code](https://claude.com/claude-code)