### PR TITLE
chore(challenges): stop minting trending playlist (tp) rewards

### DIFF
--- a/jobs/index_challenges.go
+++ b/jobs/index_challenges.go
@@ -51,7 +51,6 @@ func NewIndexChallengesJob(cfg config.Config, pool database.DbPool) *IndexChalle
 			challenges.NewPlayCountMilestonesProcessor(),
 			challenges.NewTrendingTrackProcessor(),
 			challenges.NewTrendingUndergroundProcessor(),
-			challenges.NewTrendingPlaylistProcessor(),
 			// Phase 2
 			&challenges.FirstWeeklyCommentProcessor{},
 			&challenges.CommentPinProcessor{},


### PR DESCRIPTION
## Summary

Removes `NewTrendingPlaylistProcessor()` from the `IndexChallengesJob` processor list, so the weekly reconcile stops generating trending-playlist (`tp`) rewards.

## Why

Trending playlists was retired on the frontend, but the Go challenge indexer never stopped minting it. On the same weekly Friday reconcile as `tt`/`tut`, the `tp` processor was still writing `trending_results` for `PLAYLISTS` and minting claimable `tp` `user_challenges` (100 OA each, 10k weekly pool).

Confirmed live in prod: `tp` was `active=t`, most recent mint `tp 2026-06-05:9` (218 weeks of history). Surfaced while disbursing the 2026-06-05 `tt`/`tut` winners — `tp` rows showed up in the disburser's summary, 7/10 already paid via client-side claims.

## Scope

- Stops **new** `tp` mints only.
- Deactivating the existing `challenges.id='tp'` row (`active=false`, which makes already-minted `tp` rewards unclaimable) was run directly against prod out-of-band, so no migration is included here.
- Leaves `NewTrendingPlaylistProcessor` defined (now unused) in `trending.go` for an easy revert.

## Test plan

- [x] `go build -mod=readonly ./jobs/...` clean
- [x] `go test ./jobs/ -run 'Challenge|Index|Trending'` passes (no test asserted `tp` registration)
- [ ] Post-deploy: no new `tp` rows next Friday reconcile

🤖 Generated with [Claude Code](https://claude.com/claude-code)