### PR TITLE
perf(api): use exact api key for RPM metrics lookup

### DIFF
--- a/api/metrics_middleware.go
+++ b/api/metrics_middleware.go
@@ -110,7 +110,7 @@ func (rmc *MetricsCollector) Middleware(apiServer *ApiServer) fiber.Handler {
 			}
 		}
 		if apiKey == "" && appName == "" {
-			apiKey = c.Query("api_key")
+			apiKey = normalizeAPIKeyForLookup(c.Query("api_key"))
 			appName = c.Query("app_name")
 		}
 		ipAddress := utils.GetIP(c)

--- a/api/rate_limit_middleware.go
+++ b/api/rate_limit_middleware.go
@@ -198,7 +198,7 @@ func (rlm *RateLimitMiddleware) checkRpm(ctx context.Context, identifier string,
 		err := rlm.writePool.QueryRow(ctx, `
 			SELECT COALESCE(SUM(request_count), 0)
 			FROM api_metrics_apps
-			WHERE (LOWER(api_key) = LOWER($1) OR LOWER(app_name) = LOWER($1))
+			WHERE api_key = $1
 			  AND date >= CURRENT_DATE - INTERVAL '30 days'
 		`, identifier).Scan(&dbCount)
 		if err != nil {

--- a/api/rate_limit_middleware_test.go
+++ b/api/rate_limit_middleware_test.go
@@ -78,3 +78,23 @@ func TestRateLimitMiddleware_NormalizesApiKeyWithout0xPrefix(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, fiber.StatusTooManyRequests, res2.StatusCode, "second request should be rate limited")
 }
+
+func TestRateLimitMiddleware_CheckRpmUsesCanonicalApiKeyBucket(t *testing.T) {
+	pool := database.CreateTestDatabase(t, "test_api")
+	ctx := context.Background()
+
+	_, err := pool.Exec(ctx, `
+		INSERT INTO api_metrics_apps (date, api_key, app_name, request_count)
+		VALUES
+			(CURRENT_DATE, '0xrate-test-key', '', 490),
+			(CURRENT_DATE, '0xother-key', '0xrate-test-key', 490)
+	`)
+	assert.NoError(t, err)
+
+	logger := logging.NewZapLogger(config.Config{}).With()
+	rlm := NewRateLimitMiddleware(logger, pool)
+
+	allowed, remaining := rlm.checkRpm(ctx, "0xrate-test-key", 500)
+	assert.True(t, allowed, "only the api_key bucket should count toward RPM")
+	assert.Equal(t, int64(9), remaining)
+}


### PR DESCRIPTION
## Summary
- normalize query-string `api_key` before request metrics are flushed
- use the canonical `api_key` bucket for RPM monthly counts instead of `LOWER(api_key) OR LOWER(app_name)`
- add a regression test so unrelated `app_name` rows no longer count toward an API key RPM limit

## Read-only prod evidence
- hot statement: `api_metrics_apps` RPM query had ~19.6M calls, ~444.6k total seconds, ~22.7ms mean in `pg_stat_statements`
- current query plan uses `idx_api_metrics_apps_date` then filters recent rows with `lower(...)`; planner cost ~4583
- exact `api_key = $1` query uses `idx_api_metrics_apps_api_key`; planner cost ~288
- last 30 days had 12 mixed-case `api_key` metric rows / 161 requests; normalizing writes prevents new rows in the wrong bucket

## Test
- `go test ./api -run 'TestRateLimitMiddleware' -count=1 -timeout=3m`