### PR TITLE
perf(db): index scheduled release publisher scans

### DIFF
--- a/ddl/migrations/0219_scheduled_release_publisher_indexes.sql
+++ b/ddl/migrations/0219_scheduled_release_publisher_indexes.sql
@@ -1,0 +1,30 @@
+-- The scheduled-release publisher runs once per minute and updates only due
+-- scheduled tracks/albums. Without these partial indexes, idle ticks scan tens
+-- of thousands of current public/unlisted rows to discover that nothing is due.
+--
+-- NOTE: intentionally NOT wrapped in BEGIN/COMMIT so CREATE INDEX
+-- CONCURRENTLY can run without holding an ACCESS EXCLUSIVE lock on tracks or
+-- playlists. IF NOT EXISTS makes the migration idempotent.
+
+create index concurrently if not exists tracks_scheduled_release_due_idx
+    on public.tracks (release_date)
+    where is_unlisted = true
+      and is_scheduled_release = true
+      and release_date is not null
+      and is_current = true
+      and is_delete = false;
+
+comment on index public.tracks_scheduled_release_due_idx is
+    'Covers the scheduled-release publisher tracks update by release_date for due unlisted scheduled tracks.';
+
+create index concurrently if not exists playlists_scheduled_release_due_idx
+    on public.playlists (release_date)
+    where is_private = true
+      and is_album = true
+      and is_scheduled_release = true
+      and release_date is not null
+      and is_current = true
+      and is_delete = false;
+
+comment on index public.playlists_scheduled_release_due_idx is
+    'Covers the scheduled-release publisher album update by release_date for due private scheduled albums.';


### PR DESCRIPTION
## Summary
- add a partial `tracks(release_date)` index matching the scheduled-release track publisher predicate
- add a partial `playlists(release_date)` index matching the scheduled-release album publisher predicate
- both indexes are built concurrently and only include still-private/unlisted scheduled releases

## Read-only prod evidence
- `UPDATE tracks ... is_scheduled_release ... release_date < now()` had 16,161 calls, ~18,432 total seconds, ~1.14s mean, and only 57 total rows updated
- `UPDATE playlists ... is_scheduled_release ... release_date < now()` had 16,161 calls, ~13,688 total seconds, ~0.85s mean, and only 3 total rows updated
- current plans scan ~53k track-status entries and ~62k album-status entries each minute to find due rows
- current candidate counts were tiny: 365 scheduled track candidates / 0 due, 14 scheduled album candidates / 0 due

## Test
- `git diff --cached --check`