### PR TITLE
perf(db): index chat notification timestamp scans

### DIFF
--- a/ddl/migrations/0219_chat_notification_timestamp_indexes.sql
+++ b/ddl/migrations/0219_chat_notification_timestamp_indexes.sql
@@ -1,0 +1,21 @@
+-- Pedalboard's DM notification worker scans for chat messages/reactions newer
+-- than its timestamp cursor, then joins those rows to chat_member. These
+-- timestamp-leading indexes let Postgres start from the small "new since
+-- cursor" slice instead of scanning the whole chat table every poll.
+--
+-- NOTE: intentionally NOT wrapped in BEGIN/COMMIT so CREATE INDEX
+-- CONCURRENTLY can run without holding an ACCESS EXCLUSIVE lock on chat
+-- tables. IF NOT EXISTS makes the migration idempotent.
+
+create index concurrently if not exists chat_message_non_blast_created_at_idx
+    on public.chat_message (created_at, chat_id, user_id)
+    where blast_id is null;
+
+comment on index public.chat_message_non_blast_created_at_idx is
+    'Supports DM notification polling for non-blast chat messages by timestamp cursor.';
+
+create index concurrently if not exists chat_message_reactions_updated_at_idx
+    on public.chat_message_reactions (updated_at, message_id, user_id);
+
+comment on index public.chat_message_reactions_updated_at_idx is
+    'Supports DM reaction notification polling by updated_at cursor.';


### PR DESCRIPTION
## Summary
- add a partial `chat_message(created_at, chat_id, user_id)` index for non-blast DM notification polling
- add `chat_message_reactions(updated_at, message_id, user_id)` for reaction notification polling
- build both indexes concurrently and keep this DB-only change separate from the pedalboard query rewrite

## Read-only prod evidence
- DM message notifier statement has ~33.0M calls, ~7.17M total seconds, ~217ms mean, and ~25.5B temp blocks written in `pg_stat_statements`
- current one-hour message plan scans ~1.98M `chat_message` rows and ~522k `chat_member` rows even though only 4 non-blast messages matched the one-hour window
- DM reaction notifier statement has ~33.0M calls, ~5.48M total seconds, ~166ms mean
- reaction table is smaller today (~14.5k rows), but the worker polls constantly and the rewrite can use an `updated_at` range

## Test
- `git diff --cached --check`