### PR TITLE
perf(db): drop duplicate core indexed blocks index

### DIFF
--- a/api/health_check.go
+++ b/api/health_check.go
@@ -42,12 +42,10 @@ func (app *ApiServer) getCoreIndexerHealth(ctx context.Context) (*coreIndexerHea
 	// COALESCE handles the cold-start case before any blocks are indexed.
 	//
 	// The chain_id predicate is required for index usage. `core_indexed_blocks`
-	// has indexes (PK on (chain_id, height) and idx_chain_id_height), all
-	// leading with chain_id. Without the filter, MAX(height) degrades to a
-	// sequential scan over the whole table (~tens of millions of rows on
-	// prod) — at k8s probe cadence × bridge replicas that becomes enough
-	// load to saturate I/O and exhaust the connection pool. The filter
-	// makes it a sub-millisecond index seek.
+	// has a primary-key index on (chain_id, height), so the filter makes this a
+	// sub-millisecond index seek. Without the filter, MAX(height) degrades to a
+	// sequential scan over the whole table (~tens of millions of rows on prod)
+	// at k8s probe cadence.
 	//
 	// We reuse the Chainid from the just-fetched nodeInfo rather than
 	// plumbing a separate config field — same value ETL uses when it

--- a/ddl/migrations/0219_drop_duplicate_core_indexed_blocks_chain_height_idx.sql
+++ b/ddl/migrations/0219_drop_duplicate_core_indexed_blocks_chain_height_idx.sql
@@ -1,0 +1,6 @@
+-- idx_chain_id_height duplicates the core_indexed_blocks primary key index:
+-- both are btree indexes on (chain_id, height). Keep the unique primary-key
+-- index and remove the redundant non-unique copy to avoid extra write and
+-- storage cost on the core indexer state table.
+
+drop index concurrently if exists public.idx_chain_id_height;


### PR DESCRIPTION
## Summary
- drop redundant non-unique `idx_chain_id_height` on `core_indexed_blocks`
- keep the primary-key index `pk_chain_id_height` on the exact same `(chain_id, height)` key
- update the health-check comment so it no longer documents the duplicate index

## Read-only prod evidence
- `idx_chain_id_height`: `CREATE INDEX ... (chain_id, height)`, size ~1506 MB
- `pk_chain_id_height`: `CREATE UNIQUE INDEX ... (chain_id, height)`, size ~1506 MB
- the primary key covers the health-check `WHERE chain_id = $1` / `MAX(height)` access path, so the non-unique duplicate only adds storage/write maintenance cost

## Test
- `go test ./api -run 'TestHealth|TestCoreIndexerHealth' -count=1 -timeout=3m`