### PR TITLE
perf(db): drop duplicate chat id index

### DIFF
--- a/ddl/migrations/0219_drop_duplicate_chat_id_idx.sql
+++ b/ddl/migrations/0219_drop_duplicate_chat_id_idx.sql
@@ -1,0 +1,4 @@
+-- chat_chat_id_idx duplicates chat_pkey: both are btree indexes on chat_id.
+-- Keep the unique primary-key index and remove the redundant non-unique copy.
+
+drop index concurrently if exists public.chat_chat_id_idx;


### PR DESCRIPTION
## Summary
- drop redundant non-unique `chat_chat_id_idx`
- keep `chat_pkey`, the unique primary-key index on the same `chat_id` column

## Read-only prod evidence
- `chat_chat_id_idx`: `CREATE INDEX ... (chat_id)`, size ~13 MB
- `chat_pkey`: `CREATE UNIQUE INDEX ... (chat_id)`, size ~12 MB
- both indexes support the same lookup key, so the non-unique copy adds storage/write maintenance without expanding query coverage

## Test
- `git diff --cached --check`