### PR TITLE
perf(db): drop superseded playlist trending index

### DIFF
--- a/ddl/migrations/0219_drop_superseded_playlist_trending_scores_idx.sql
+++ b/ddl/migrations/0219_drop_superseded_playlist_trending_scores_idx.sql
@@ -1,0 +1,8 @@
+-- idx_playlist_trending_scores_filtered orders (type, version, time_range,
+-- playlist_id, score DESC), so it does not match playlist trending callers
+-- that filter by type/version/time_range and order by score DESC,
+-- playlist_id DESC. idx_playlist_trending_scores_ordered covers that hot
+-- order, and playlist_trending_scores_pkey / ix_playlist_trending_scores_playlist_id
+-- still cover point lookups by playlist_id.
+
+drop index concurrently if exists public.idx_playlist_trending_scores_filtered;


### PR DESCRIPTION
## Summary
- drop `idx_playlist_trending_scores_filtered`
- keep `idx_playlist_trending_scores_ordered`, which matches the hot `ORDER BY score DESC, playlist_id DESC` path
- keep the primary key and playlist-id index for point lookups

## Read-only prod evidence
- old index is ~106 MB and ordered `(type, version, time_range, playlist_id, score DESC)`
- hot playlist trending query plans as an index-only scan on `idx_playlist_trending_scores_ordered` for `(type, version, time_range) ORDER BY score DESC, playlist_id DESC LIMIT ...`
- planner still chose the old index for a point lookup shape, but `playlist_trending_scores_pkey` has the same equality columns `(playlist_id, type, version, time_range)`, and `ix_playlist_trending_scores_playlist_id` remains for playlist-id access
- did not drop the large track genre/time score index because genre trending queries still make that unsafe without more evidence

## Test
- `git diff --cached --check`