### PR TITLE
chore(api): bump etl for playlists.last_added_to (#348)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,8 +6,8 @@ require (
 	connectrpc.com/connect v1.18.1
 	github.com/AlecAivazis/survey/v2 v2.3.7
 	github.com/Doist/unfurlist v0.0.0-20250409100812-515f2735f8e5
-	github.com/OpenAudio/go-openaudio v1.3.1-0.20260609000702-c5fcacffbb79
-	github.com/OpenAudio/go-openaudio/pkg/etl v1.3.1-0.20260609000702-c5fcacffbb79
+	github.com/OpenAudio/go-openaudio v1.3.1-0.20260609013415-e8586ac9ce16
+	github.com/OpenAudio/go-openaudio/pkg/etl v1.3.1-0.20260609013415-e8586ac9ce16
 	github.com/aquasecurity/esquery v0.2.0
 	github.com/axiomhq/axiom-go v0.23.0
 	github.com/axiomhq/hyperloglog v0.2.5

--- a/go.sum
+++ b/go.sum
@@ -20,10 +20,10 @@ github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2 h1:+vx7roKuyA63n
 github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2/go.mod h1:HBCaDeC1lPdgDeDbhX8XFpy1jqjK0IBG8W5K+xYqA0w=
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5 h1:TngWCqHvy9oXAN6lEVMRuU21PR1EtLVZJmdB18Gu3Rw=
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5/go.mod h1:lmUJ/7eu/Q8D7ML55dXQrVaamCz2vxCfdQBasLZfHKk=
-github.com/OpenAudio/go-openaudio v1.3.1-0.20260609000702-c5fcacffbb79 h1:eqTu4/JR74mPNa3JqlL2u5C8QZUzqzcIg88CuOHNgkY=
-github.com/OpenAudio/go-openaudio v1.3.1-0.20260609000702-c5fcacffbb79/go.mod h1:wiFXmVbIUkN2D5lRshknaARCKhzbHtCBKRCZe6UOnVs=
-github.com/OpenAudio/go-openaudio/pkg/etl v1.3.1-0.20260609000702-c5fcacffbb79 h1:0JRNoJtyEx0ngJr24LI4CPW4eTQm3lbfU6OmVGVDuFs=
-github.com/OpenAudio/go-openaudio/pkg/etl v1.3.1-0.20260609000702-c5fcacffbb79/go.mod h1:LZKiU9vBYzlZzn6oPRHHLPXteBtMKQPegNH9bX9JuH8=
+github.com/OpenAudio/go-openaudio v1.3.1-0.20260609013415-e8586ac9ce16 h1:1UTUQPRBcNJ/DmclEI938wpWa0rjnpYsbWwSV7mawMM=
+github.com/OpenAudio/go-openaudio v1.3.1-0.20260609013415-e8586ac9ce16/go.mod h1:wiFXmVbIUkN2D5lRshknaARCKhzbHtCBKRCZe6UOnVs=
+github.com/OpenAudio/go-openaudio/pkg/etl v1.3.1-0.20260609013415-e8586ac9ce16 h1:Iq4GKCKULpmFI80IN8d78nVy91zp8kPhP7Sl2eQRTNg=
+github.com/OpenAudio/go-openaudio/pkg/etl v1.3.1-0.20260609013415-e8586ac9ce16/go.mod h1:LZKiU9vBYzlZzn6oPRHHLPXteBtMKQPegNH9bX9JuH8=
 github.com/StackExchange/wmi v1.2.1 h1:VIkavFPXSjcnS+O8yTq7NI32k0R5Aj+v39y29VYDOSA=
 github.com/StackExchange/wmi v1.2.1/go.mod h1:rcmrprowKIVzvc+NUiLncP2uuArMWLCbu9SBzvHz7e8=
 github.com/VictoriaMetrics/fastcache v1.12.2 h1:N0y9ASrJ0F6h0QaC3o6uJb3NIZ9VKLjCM7NQbSmF7WI=


### PR DESCRIPTION
## Summary

Bumps `github.com/OpenAudio/go-openaudio` and `.../pkg/etl` from `c5fcacf` (#924) to **`e8586ac`**.

**Primary:** go-openaudio **#348** — fixes `playlists.last_added_to` never being written (perpetually NULL), which silently broke the "recently added to" sort and the playlist-update notification. Now set to the block time of the most recent track add (code-only in #348).

**Also carried** (main advanced past the baseline): #345/#346 — the **TrackCollaborator** entity. This adds ETL migration **0033**, which `CREATE TABLE IF NOT EXISTS track_collaborators` (a new, empty table) plus one index on it.

`core-indexer` runs this vendored image, so the bump is required to ship the fix.

## Changes
- `go.mod` / `go.sum`: both go-openaudio modules → `v1.3.1-0.20260609013415-e8586ac9ce16`

## Deploy note — migration 0033 is low risk
0033 creates a brand-new empty table + index with `IF NOT EXISTS`. There's no existing data to scan and no `ACCESS EXCLUSIVE` lock on a populated table (unlike the 0031 slug index), so it applies instantly — no pre-build/CONCURRENT step needed. The `last_added_to` fix itself is code-only (no migration).

## Test plan
- [x] `go mod tidy` — only go.mod/go.sum changed
- [x] `go build ./...` passes
- [x] resolved module contains the `last_added_to` writes (`LastAddedTo` in playlist_row.go) and migration `0033`
- [ ] Post-deploy: migration version 33 applied clean; creating/editing a playlist populates `last_added_to`, and a rename preserves it

🤖 Generated with [Claude Code](https://claude.com/claude-code)