### PR TITLE
chore(api): bump etl for dev-app image_url + rune-count fixes (#350)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,8 +6,8 @@ require (
 	connectrpc.com/connect v1.18.1
 	github.com/AlecAivazis/survey/v2 v2.3.7
 	github.com/Doist/unfurlist v0.0.0-20250409100812-515f2735f8e5
-	github.com/OpenAudio/go-openaudio v1.3.1-0.20260609013415-e8586ac9ce16
-	github.com/OpenAudio/go-openaudio/pkg/etl v1.3.1-0.20260609013415-e8586ac9ce16
+	github.com/OpenAudio/go-openaudio v1.3.1-0.20260609040102-bda0b8b592f5
+	github.com/OpenAudio/go-openaudio/pkg/etl v1.3.1-0.20260609040102-bda0b8b592f5
 	github.com/aquasecurity/esquery v0.2.0
 	github.com/axiomhq/axiom-go v0.23.0
 	github.com/axiomhq/hyperloglog v0.2.5

--- a/go.sum
+++ b/go.sum
@@ -20,10 +20,10 @@ github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2 h1:+vx7roKuyA63n
 github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2/go.mod h1:HBCaDeC1lPdgDeDbhX8XFpy1jqjK0IBG8W5K+xYqA0w=
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5 h1:TngWCqHvy9oXAN6lEVMRuU21PR1EtLVZJmdB18Gu3Rw=
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5/go.mod h1:lmUJ/7eu/Q8D7ML55dXQrVaamCz2vxCfdQBasLZfHKk=
-github.com/OpenAudio/go-openaudio v1.3.1-0.20260609013415-e8586ac9ce16 h1:1UTUQPRBcNJ/DmclEI938wpWa0rjnpYsbWwSV7mawMM=
-github.com/OpenAudio/go-openaudio v1.3.1-0.20260609013415-e8586ac9ce16/go.mod h1:wiFXmVbIUkN2D5lRshknaARCKhzbHtCBKRCZe6UOnVs=
-github.com/OpenAudio/go-openaudio/pkg/etl v1.3.1-0.20260609013415-e8586ac9ce16 h1:Iq4GKCKULpmFI80IN8d78nVy91zp8kPhP7Sl2eQRTNg=
-github.com/OpenAudio/go-openaudio/pkg/etl v1.3.1-0.20260609013415-e8586ac9ce16/go.mod h1:LZKiU9vBYzlZzn6oPRHHLPXteBtMKQPegNH9bX9JuH8=
+github.com/OpenAudio/go-openaudio v1.3.1-0.20260609040102-bda0b8b592f5 h1:ncJjkgXNaL7r8LyNGigHONOgFVq+jBpkMKtgyZrju1o=
+github.com/OpenAudio/go-openaudio v1.3.1-0.20260609040102-bda0b8b592f5/go.mod h1:wiFXmVbIUkN2D5lRshknaARCKhzbHtCBKRCZe6UOnVs=
+github.com/OpenAudio/go-openaudio/pkg/etl v1.3.1-0.20260609040102-bda0b8b592f5 h1:l4KjBR+wR5DpHPV03N0DKFLcPsMhP3Hq82JquBL5Ajo=
+github.com/OpenAudio/go-openaudio/pkg/etl v1.3.1-0.20260609040102-bda0b8b592f5/go.mod h1:LZKiU9vBYzlZzn6oPRHHLPXteBtMKQPegNH9bX9JuH8=
 github.com/StackExchange/wmi v1.2.1 h1:VIkavFPXSjcnS+O8yTq7NI32k0R5Aj+v39y29VYDOSA=
 github.com/StackExchange/wmi v1.2.1/go.mod h1:rcmrprowKIVzvc+NUiLncP2uuArMWLCbu9SBzvHz7e8=
 github.com/VictoriaMetrics/fastcache v1.12.2 h1:N0y9ASrJ0F6h0QaC3o6uJb3NIZ9VKLjCM7NQbSmF7WI=


### PR DESCRIPTION
## Summary

Bumps `github.com/OpenAudio/go-openaudio` and `.../pkg/etl` from `e8586ac` (#933) to **`bda0b8b`**.

**Primary:** go-openaudio **#350** —
- persists `developer_apps.image_url` (previously dropped; 271 prod apps have it), gated by the legacy `is_fqdn` check;
- rune-counts the comment `video_url` and oauth `redirect_uri` length caps (byte-vs-rune over-strictness, same class as the name/bio fix).

**Also carried** (main advanced past the baseline):
- #349 — let a collaborator leave a track after accepting (reuses the `track_collaborators` table).
- #351 — accept any genre string up to 100 chars (relaxes the genre allowlist).

`core-indexer` runs this vendored image, so the bump is required to ship the fixes.

## Changes
- `go.mod` / `go.sum`: both go-openaudio modules → `v1.3.1-0.20260609040102-bda0b8b592f5`

## Deploy note — no migration
Latest ETL migration stays **0033** (#349 reuses the existing `track_collaborators` table). Everything here is code-only — no schema change, no special rollout.

## Test plan
- [x] `go mod tidy` — only go.mod/go.sum changed
- [x] `go build ./...` passes
- [x] resolved module contains the image_url fix (`validatedAppImageURL`); migration unchanged (0033)
- [ ] Post-deploy: set a dev-app icon and a long multibyte comment video on the test account → both persist

🤖 Generated with [Claude Code](https://claude.com/claude-code)