### PR TITLE
perf(indexer): cap aggregate score update cadence

### DIFF
--- a/indexer/aggregates_calculator.go
+++ b/indexer/aggregates_calculator.go
@@ -20,6 +20,8 @@ type AggregatesCalculator struct {
 	updateAggregatesJob *jobs.UpdateAggregatesJob
 }
 
+const aggregateScoreUpdateInterval = 10 * time.Minute
+
 func NewAggregatesCalculator(config config.Config) *AggregatesCalculator {
 	logger := logging.NewZapLogger(config).Named("AggregatesCalculator")
 	readPool, err := dbv1.NewDBPools([]string{config.ReadDbUrl}, logger, config.Env, config.ZapLevel)
@@ -46,7 +48,8 @@ func NewAggregatesCalculator(config config.Config) *AggregatesCalculator {
 func (a *AggregatesCalculator) Start(ctx context.Context) error {
 	a.logger.Info("Starting aggregates calculator")
 	go logging.SyncOnTicks(ctx, a.logger, time.Second*10)
-	// This job runs in a continous loop until the context is cancelled.
+	// This job scans all scoreable users. Keep the cadence bounded so a
+	// completed full pass does not immediately start another full pass.
 	for {
 		select {
 		case <-ctx.Done():
@@ -54,6 +57,20 @@ func (a *AggregatesCalculator) Start(ctx context.Context) error {
 			return ctx.Err()
 		default:
 			a.updateAggregatesJob.Run(ctx)
+		}
+
+		timer := time.NewTimer(aggregateScoreUpdateInterval)
+		select {
+		case <-ctx.Done():
+			if !timer.Stop() {
+				select {
+				case <-timer.C:
+				default:
+				}
+			}
+			a.logger.Info("Shutting down aggregates calculator")
+			return ctx.Err()
+		case <-timer.C:
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- add a 10 minute pause between full aggregate score update passes
- keep shutdown responsive to context cancellation

## Evidence
- production read-replica pg_stat_statements showed the aggregate score batch query as the top total-time read-path statement: ~39.5M calls, ~13.4M total seconds, ~340ms mean
- live pg_stat_activity showed core-indexer actively running the same user-score batch query after the read replica drain
- the old loop immediately started another full pass after each full scan, so this bounds repeated read load without changing scoring semantics

## Test
- go test ./indexer ./jobs -count=1