### PR TITLE
perf(db): use precomputed features in user score helpers

### DIFF
--- a/ddl/functions/get_user_score.sql
+++ b/ddl/functions/get_user_score.sql
@@ -15,31 +15,7 @@ create or replace function get_user_score(target_user_id integer) returns table(
         has_profile_picture boolean,
         karma bigint,
         score bigint
-    ) language sql as $function$ with play_activity as (
-        select p.user_id,
-            count(distinct date_trunc('day', p.created_at)) as play_count,
-            count(distinct p.play_item_id) as distinct_tracks_played
-        from plays p
-        where p.user_id = target_user_id
-        group by p.user_id
-    ),
-    fast_challenge_completion as (
-        select u.user_id,
-            u.handle_lc,
-            u.created_at,
-            count(*) as challenge_count,
-            array_agg(uc.challenge_id) as challenge_ids
-        from users u
-            left join user_challenges uc on u.user_id = uc.user_id
-        where u.user_id = target_user_id
-            and uc.is_complete
-            and uc.completed_at - u.created_at <= interval '3 minutes'
-            and uc.challenge_id not in ('m', 'b')
-        group by u.user_id,
-            u.handle_lc,
-            u.created_at
-    ),
-    chat_blocks as (
+    ) language sql as $function$ with chat_blocks as (
         select c.blockee_user_id as user_id,
             count(*) as block_count
         from chat_blocked_users c
@@ -49,9 +25,9 @@ create or replace function get_user_score(target_user_id integer) returns table(
     aggregate_scores as (
         select u.user_id,
             u.handle_lc,
-            coalesce(p.play_count, 0) as play_count,
-            coalesce(p.distinct_tracks_played, 0) as distinct_tracks_played,
-            coalesce(c.challenge_count, 0) as challenge_count,
+            coalesce(udph.hours_with_play, 0)::bigint as play_count,
+            coalesce(udpt.track_count, 0)::bigint as distinct_tracks_played,
+            coalesce(usf.challenge_count, 0)::bigint as challenge_count,
             coalesce(au.following_count, 0) as following_count,
             coalesce(au.follower_count, 0) as follower_count,
             coalesce(cb.block_count, 0) as chat_block_count,
@@ -86,11 +62,13 @@ create or replace function get_user_score(target_user_id integer) returns table(
                 )
             end as karma
         from users u
-            left join play_activity p on u.user_id = p.user_id
-            left join fast_challenge_completion c on u.user_id = c.user_id
+            left join user_distinct_play_hours udph on u.user_id = udph.user_id
+            left join user_distinct_play_tracks udpt on u.user_id = udpt.user_id
+            left join user_score_features usf on u.user_id = usf.user_id
             left join chat_blocks cb on u.user_id = cb.user_id
             left join aggregate_user au on u.user_id = au.user_id
         where u.user_id = target_user_id
+            and u.is_current
             and u.handle_lc is not null
     )
 select a.*,

--- a/ddl/functions/get_user_scores.sql
+++ b/ddl/functions/get_user_scores.sql
@@ -17,36 +17,7 @@ create or replace function get_user_scores(
         has_profile_picture boolean,
         karma bigint,
         score bigint
-    ) language sql as $function$ with play_activity as (
-        select plays.user_id,
-            count(distinct (date_trunc('hour', plays.created_at))) as play_count,
-            count(distinct(plays.play_item_id)) as distinct_tracks_played
-        from plays
-            join users on plays.user_id = users.user_id
-        where target_user_ids is null
-            or plays.user_id = any(target_user_ids)
-        group by plays.user_id
-    ),
-    fast_challenge_completion as (
-        select users.user_id,
-            handle_lc,
-            users.created_at,
-            count(*) as challenge_count,
-            array_agg(user_challenges.challenge_id) as challenge_ids
-        from users
-            left join user_challenges on users.user_id = user_challenges.user_id
-        where user_challenges.is_complete
-            and user_challenges.completed_at - users.created_at <= interval '3 minutes'
-            and user_challenges.challenge_id not in ('m', 'b')
-            and (
-                target_user_ids is null
-                or users.user_id = any(target_user_ids)
-            )
-        group by users.user_id,
-            users.handle_lc,
-            users.created_at
-    ),
-    chat_blocks as (
+    ) language sql as $function$ with chat_blocks as (
         select chat_blocked_users.blockee_user_id as user_id,
             count(*) as block_count
         from chat_blocked_users
@@ -58,11 +29,11 @@ create or replace function get_user_scores(
     aggregate_scores as (
         select users.user_id,
             users.handle_lc,
-            coalesce(play_activity.play_count, 0) as play_count,
-            coalesce(play_activity.distinct_tracks_played, 0) as distinct_tracks_played,
+            coalesce(user_distinct_play_hours.hours_with_play, 0)::bigint as play_count,
+            coalesce(user_distinct_play_tracks.track_count, 0)::bigint as distinct_tracks_played,
             coalesce(aggregate_user.following_count, 0) as following_count,
             coalesce(aggregate_user.follower_count, 0) as follower_count,
-            coalesce(fast_challenge_completion.challenge_count, 0) as challenge_count,
+            coalesce(user_score_features.challenge_count, 0)::bigint as challenge_count,
             coalesce(chat_blocks.block_count, 0) as chat_block_count,
             case
                 when (
@@ -95,11 +66,13 @@ create or replace function get_user_scores(
                 )
             end as karma
         from users
-            left join play_activity on users.user_id = play_activity.user_id
-            left join fast_challenge_completion on users.user_id = fast_challenge_completion.user_id
+            left join user_distinct_play_hours on users.user_id = user_distinct_play_hours.user_id
+            left join user_distinct_play_tracks on users.user_id = user_distinct_play_tracks.user_id
+            left join user_score_features on users.user_id = user_score_features.user_id
             left join chat_blocks on users.user_id = chat_blocks.user_id
             left join aggregate_user on aggregate_user.user_id = users.user_id
         where users.handle_lc is not null
+            and users.is_current
             and (
                 target_user_ids is null
                 or users.user_id = any(target_user_ids)


### PR DESCRIPTION
## Summary
- update get_user_score and get_user_scores to use existing precomputed play/challenge feature tables
- avoid re-aggregating plays and user_challenges inside each score helper call
- keep return shapes and compute_user_score inputs unchanged

## Evidence
- live pg_stat_activity showed notifications running SELECT * FROM get_user_scores() WHERE score <= 0 while waiting on DataFileRead
- pg_stat_statements showed get_user_scores() WHERE score <=  at ~321k calls, ~6.85M total seconds, ~21s mean on the primary
- the replacement tables are already maintained by handle_play.sql and handle_user_challenges.sql and are used by the Go UpdateAggregatesJob path

## Test
- go test ./jobs -run TestNonExistent -count=1
- git diff --check
- verified referenced tables/columns exist in sql/01_schema.sql