### PR TITLE
perf(db): add chat message range index

### DIFF
--- a/ddl/migrations/0220_chat_message_chat_created_idx.sql
+++ b/ddl/migrations/0220_chat_message_chat_created_idx.sql
@@ -1,0 +1,10 @@
+-- Chat unread/message fanout queries constrain by chat_id and created_at.
+-- The old partial index led with created_at and had 0 scans in production,
+-- while chat_message lookups were producing heavy temp I/O. Lead with chat_id
+-- so the per-chat range checks can use a small ordered slice.
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS chat_message_chat_created_non_blast_idx
+    ON public.chat_message USING btree (chat_id, created_at, user_id)
+    WHERE blast_id IS NULL;
+
+DROP INDEX CONCURRENTLY IF EXISTS public.chat_message_non_blast_created_at_idx;


### PR DESCRIPTION
## Summary
- add a partial chat_message index led by chat_id and created_at for per-chat range lookups
- drop the old created_at-led non-blast index that had 0 production scans

## Evidence
- pg_stat_statements showed a chat fanout/unread query as the top temp-I/O statement on the primary, with ~378TB temp I/O over the stats window
- pg_stat_user_indexes showed chat_message_non_blast_created_at_idx had idx_scan = 0
- current chat unread/message paths constrain by chat_id and created_at, so this index matches the access pattern more closely

## Test
- git diff --check