### PR TITLE
perf(db): add saves favorites ordering index

### DIFF
--- a/ddl/migrations/0220_saves_user_track_current_blocknumber_idx.sql
+++ b/ddl/migrations/0220_saves_user_track_current_blocknumber_idx.sql
@@ -1,0 +1,17 @@
+-- Supports /v1/users/:id/favorites pagination:
+--
+--   WHERE user_id = ?
+--     AND is_delete = false
+--     AND is_current = true
+--     AND save_type = 'track'
+--   ORDER BY blocknumber, save_item_id DESC
+--
+-- The existing saves_user_idx is ordered by save_item_id before is_delete and
+-- cannot satisfy the endpoint's blocknumber ordering, which showed up in prod
+-- pg_stat_statements with high total temp I/O.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS saves_user_track_current_blocknumber_idx
+    ON public.saves USING btree (user_id, blocknumber, save_item_id DESC)
+    INCLUDE (created_at)
+    WHERE save_type = 'track'
+      AND is_current = true
+      AND is_delete = false;


### PR DESCRIPTION
## Summary
- add a partial concurrent index for active track saves by user
- order the index by `(user_id, blocknumber, save_item_id DESC)` to match `/v1/users/:id/favorites` pagination
- include `created_at` because the endpoint returns it from `saves`

## Evidence
- prod read-only pg_stat_statements showed the favorites/library saves pagination query at roughly 24.7M calls, ~1.0M total seconds, and ~6TB temp I/O
- the hot SQL is in `api/v1_users_favorites.go` and filters `save_type = 'track'`, `is_current = true`, `is_delete = false`, `user_id = ?`, then orders by `saves.blocknumber, saves.save_item_id DESC`\n- existing `saves_user_idx (user_id, save_type, save_item_id, is_delete)` can filter by user/type but cannot satisfy the blocknumber ordering, forcing a sort for paginated responses\n- checked prod in read-only mode; HypoPG is not installed, so this PR cannot include a hypothetical index EXPLAIN without creating anything on prod\n\n## Test Plan\n- `git diff --cached --check` before commit\n- migration-only change