### PR TITLE
fix(api): deterministic seed for collaborator notification test (flaky on main)

### DIFF
--- a/api/v1_track_collaborators_test.go
+++ b/api/v1_track_collaborators_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"api.audius.co/api/dbv1"
 	"api.audius.co/database"
@@ -14,9 +15,15 @@ import (
 // seedCollaborators adds: user 1 accepted on track 700 (owned by user 500) and
 // user 1 pending on track 701 (owned by user 500).
 func seedCollaborators(t *testing.T, app *ApiServer) {
+	// created_at must equal updated_at so the notification trigger's "new pending
+	// invite" branch fires (it mirrors the ETL, which writes them equal on
+	// insert). The seed baseRow's defaults call time.Now() twice, which only
+	// round-trip equal when both calls land in the same microsecond — a flaky
+	// coin flip. Pin a single value for both.
+	now := time.Now()
 	database.SeedTable(app.pool.Replicas[0], "track_collaborators", []map[string]any{
-		{"track_id": 700, "collaborator_user_id": 1, "invited_by": 500, "status": "accepted"},
-		{"track_id": 701, "collaborator_user_id": 1, "invited_by": 500, "status": "pending"},
+		{"track_id": 700, "collaborator_user_id": 1, "invited_by": 500, "status": "accepted", "created_at": now, "updated_at": now},
+		{"track_id": 701, "collaborator_user_id": 1, "invited_by": 500, "status": "pending", "created_at": now, "updated_at": now},
 	})
 }
 


### PR DESCRIPTION
Fixes the flaky `TestTrackCollaboratorNotificationsGenerated` failing on `main`.

### Root cause
The notification trigger's "new pending invite" branch fires only when `created_at = updated_at` (this is how it tells a fresh ETL insert from a reconcile re-write — the ETL writes them equal on insert). `seedCollaborators` didn't set those columns, so it inherited the seed `baseRow` defaults, which call `time.Now()` **twice**:
```go
"created_at": time.Now(),
"updated_at": time.Now(),
```
After the `timestamp` column truncates to microseconds, those two calls are equal **only if both landed in the same microsecond** — a per-CI-run coin flip (the baseRow is a package var, initialized once). My local/isolated runs won the toss; CI lost it, so the trigger didn't fire and the test saw 0 notifications. (I'd earlier misattributed this to the unrelated `TestSearch` Elasticsearch panic — apologies.)

### Fix
Pin a single `now` for both `created_at` and `updated_at` in the seed, so the invite branch always fires. Deterministic — passes 5× in a row locally, plus the full collaborator suite.

### Note
The shared `track_collaborators` baseRow in `database/seed.go` still has the two-`time.Now()` default (latent, same as `grants`); not touched here to keep the fix scoped, since the only seeder that depends on the equality is now explicit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)