### PR TITLE
docs(api): declare `collaborators` on the track schema in the OpenAPI spec

### DIFF
--- a/api/swagger/swagger-v1.yaml
+++ b/api/swagger/swagger-v1.yaml
@@ -14953,6 +14953,11 @@ components:
           type: string
         user:
           $ref: "#/components/schemas/user"
+        collaborators:
+          type: array
+          description: Accepted collaborator artists on the track.
+          items:
+            $ref: "#/components/schemas/user"
         duration:
           type: integer
         is_downloadable:
@@ -16429,6 +16434,11 @@ components:
           type: string
         user:
           $ref: "#/components/schemas/user"
+        collaborators:
+          type: array
+          description: Accepted collaborator artists on the track.
+          items:
+            $ref: "#/components/schemas/user"
         duration:
           type: integer
         is_downloadable:


### PR DESCRIPTION
Makes the SDK-generated `collaborators` field **durable**.

### Why
The track response already returns `collaborators` (an array of accepted collaborator users, added in #932). But the embedded swagger spec (`api/swagger/swagger-v1.yaml`, served at `/v1/swagger.yaml`) never declared it. The apps SDK is generated from this spec via `openapi-generator`, and the generated models' `FromJSONTyped` only copy fields present in the spec — so `collaborators` was silently dropped during deserialization, and the field never reached the client even though the API returned it.

(The apps PR currently hand-edits the generated `Track.ts`/`SearchTrack.ts` to add the field. That works, but the next `npm run gen` would overwrite it. This PR fixes the root: declare the field in the spec so codegen reproduces it.)

### Change
Add `collaborators` (array of `user`) to the `track` and `search_track` schemas — the two schemas that produce the SDK `Track` and `SearchTrack` models the apps adapter consumes. The generated output (`collaborators?: Array<User>` + the standard array-map in `FromJSONTyped`/`ToJSON`) exactly matches the apps hand-edit, so a regen is a no-op for those files.

### Not included (deliberately)
- **Notification types** (`track_collaborator_invite`/`_accept`): the apps SDK notification models are hand-authored as one shared `TrackCollaboratorNotification`, but generating two swagger schemas would emit two differently-named models — making this a rename + rewire that needs a verified generator run, not a clean spec addition. Tracked separately.
- **`/collaboration_invites`**: no SDK consumer exists yet, so there's nothing for codegen to protect.

Spec validates (`YAML OK`) and the binary builds (the spec is `//go:embed`-ed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)