### PR TITLE
feat: add last_active_at column and /v1/users/me/ping endpoint

### DIFF
--- a/api/server.go
+++ b/api/server.go
@@ -406,6 +406,7 @@ func NewApiServer(config config.Config) *ApiServer {
 		g.Get("/users/genre/top", app.v1UsersGenreTop)
 		g.Get("/users/account/:wallet", app.requireAuthMiddleware, app.v1UsersAccount)
 		g.Get("/users/verify_token", app.v1UsersVerifyToken)
+		g.Post("/users/me/ping", app.requireAuthMiddleware, app.postV1UsersPing)
 
 		g.Use("/users/handle/:handle", app.requireHandleMiddleware)
 		g.Get("/users/handle/:handle", app.v1User)

--- a/api/v1_users_ping.go
+++ b/api/v1_users_ping.go
@@ -1,0 +1,27 @@
+package api
+
+import (
+	"github.com/gofiber/fiber/v2"
+	"go.uber.org/zap"
+)
+
+func (app *ApiServer) postV1UsersPing(c *fiber.Ctx) error {
+	if app.writePool == nil {
+		return fiber.NewError(fiber.StatusServiceUnavailable, "writes not available")
+	}
+
+	wallet := app.getAuthedWallet(c)
+
+	_, err := app.writePool.Exec(c.Context(), `
+		UPDATE users
+		SET last_active_at = now()
+		WHERE wallet = $1
+		  AND is_current = true
+	`, wallet)
+	if err != nil {
+		app.logger.Error("postV1UsersPing: failed to update last_active_at", zap.Error(err))
+		return fiber.NewError(fiber.StatusInternalServerError, "failed to record activity")
+	}
+
+	return c.JSON(fiber.Map{"status": "ok"})
+}

--- a/ddl/migrations/0221_add_users_last_active_at.sql
+++ b/ddl/migrations/0221_add_users_last_active_at.sql
@@ -1,0 +1,6 @@
+BEGIN;
+
+ALTER TABLE users ADD COLUMN IF NOT EXISTS last_active_at TIMESTAMPTZ DEFAULT NULL;
+COMMENT ON COLUMN users.last_active_at IS 'Timestamp of the user''s most recent app-open event, updated by POST /v1/users/me/ping.';
+
+COMMIT;


### PR DESCRIPTION
## Summary
- Adds `last_active_at TIMESTAMPTZ` column to the `users` table (migration 0221)
- Adds `POST /v1/users/me/ping` — authenticated endpoint that sets `last_active_at = now()` for the calling user's wallet
- This replaces the plays-based inactivity signal with a direct app-open signal for push notifications

## Related PRs
- **apps**: feat(mobile): ping last_active_at on app foreground
- **pedalboard**: notifications: query users.last_active_at for inactive user detection

## Test plan
- [ ] Run migration against local DB, verify column added
- [ ] Call `POST /v1/users/me/ping` with valid auth headers, verify 200 and `last_active_at` updated
- [ ] Call without auth, verify 401
- [ ] Verify `writePool == nil` returns 503

🤖 Generated with [Claude Code](https://claude.com/claude-code)