### PR TITLE
feat: add last_active_at column and POST /v1/users/me/ping endpoint

### DIFF
--- a/api/resolve_middleware.go
+++ b/api/resolve_middleware.go
@@ -45,6 +45,10 @@ func (app *ApiServer) getUserId(c *fiber.Ctx) int32 {
 }
 
 func (app *ApiServer) requireUserIdMiddleware(c *fiber.Ctx) error {
+	// Allow /users/me/* routes to pass through without userId resolution
+	if c.Params("userId") == "me" {
+		return c.Next()
+	}
 	userId, err := trashid.DecodeHashId(c.Params("userId"))
 	if err != nil || userId == 0 {
 		return fiber.NewError(fiber.StatusBadRequest, "invalid userId")

--- a/api/server.go
+++ b/api/server.go
@@ -406,6 +406,7 @@ func NewApiServer(config config.Config) *ApiServer {
 		g.Get("/users/genre/top", app.v1UsersGenreTop)
 		g.Get("/users/account/:wallet", app.requireAuthMiddleware, app.v1UsersAccount)
 		g.Get("/users/verify_token", app.v1UsersVerifyToken)
+		g.Post("/users/me/ping", app.requireAuthMiddleware, app.postV1UsersPing)
 
 		g.Use("/users/handle/:handle", app.requireHandleMiddleware)
 		g.Get("/users/handle/:handle", app.v1User)

--- a/api/v1_users_ping.go
+++ b/api/v1_users_ping.go
@@ -1,0 +1,27 @@
+package api
+
+import (
+	"github.com/gofiber/fiber/v2"
+	"go.uber.org/zap"
+)
+
+func (app *ApiServer) postV1UsersPing(c *fiber.Ctx) error {
+	if app.writePool == nil {
+		return fiber.NewError(fiber.StatusServiceUnavailable, "writes not available")
+	}
+
+	wallet := app.getAuthedWallet(c)
+
+	_, err := app.writePool.Exec(c.Context(), `
+		UPDATE users
+		SET last_active_at = now()
+		WHERE wallet = $1
+		  AND is_current = true
+	`, wallet)
+	if err != nil {
+		app.logger.Error("postV1UsersPing: failed to update last_active_at", zap.Error(err))
+		return fiber.NewError(fiber.StatusInternalServerError, "failed to record activity")
+	}
+
+	return c.JSON(fiber.Map{"status": "ok"})
+}

--- a/ddl/migrations/0221_add_users_last_active_at.sql
+++ b/ddl/migrations/0221_add_users_last_active_at.sql
@@ -1,0 +1,6 @@
+BEGIN;
+
+ALTER TABLE users ADD COLUMN IF NOT EXISTS last_active_at TIMESTAMPTZ DEFAULT NULL;
+COMMENT ON COLUMN users.last_active_at IS 'Timestamp of the user''s most recent app-open event, updated by POST /v1/users/me/ping.';
+
+COMMIT;


### PR DESCRIPTION
## Summary
- Adds `last_active_at` timestamp column to the `users` table (migration 0221)
- Adds `POST /v1/users/me/ping` endpoint that updates `last_active_at` for the authenticated user
- Fixes routing: the `g.Use("/users/:userId")` prefix middleware was catching `/users/me/ping` (with `:userId`="me") and returning 400 before the ping handler could run — the middleware now passes through when `:userId` is the literal "me"

## Test plan
- [ ] Verify `POST /v1/users/me/ping` returns `{"status": "ok"}` for authenticated requests
- [ ] Verify `last_active_at` is updated in the DB after a ping
- [ ] Verify existing `/users/:userId` routes still resolve user IDs correctly
- [ ] Verify `GET /users/<invalid_id>` still returns 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)