### PR TITLE
feat: add last_active_at ping endpoint

### DIFF
--- a/api/v1_users_ping_test.go
+++ b/api/v1_users_ping_test.go
@@ -1,0 +1,41 @@
+package api
+
+import (
+	"context"
+	"testing"
+
+	"api.audius.co/api/testdata"
+	"api.audius.co/database"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPostV1UsersPing(t *testing.T) {
+	app := emptyTestApp(t)
+
+	_, err := app.pool.Exec(context.Background(), `
+		INSERT INTO public.blocks (blockhash, parenthash, number)
+		VALUES ('block1', 'block0', 101)
+		ON CONFLICT DO NOTHING;`)
+	require.NoError(t, err)
+
+	database.SeedTable(app.pool.Replicas[0], "users", testdata.UserFixtures)
+
+	// user 1 = wallet 0x7d273271690538cf855e5b3002a0dd8c154bb060, encoded = 7eP5n
+	wallet := "0x7d273271690538cf855e5b3002a0dd8c154bb060"
+
+	t.Run("authenticated request returns 200", func(t *testing.T) {
+		status, body := testPostWithWallet(t, app, "/v1/users/me/ping?user_id=7eP5n", wallet, nil, nil)
+		assert.Equal(t, 200, status, "body: %s", string(body))
+	})
+
+	t.Run("missing user_id returns 400", func(t *testing.T) {
+		status, _ := testPostWithWallet(t, app, "/v1/users/me/ping", wallet, nil, nil)
+		assert.Equal(t, 400, status)
+	})
+
+	t.Run("unauthenticated request with user_id returns 403", func(t *testing.T) {
+		status, _ := testPost(t, app, "/v1/users/me/ping?user_id=7eP5n", nil, nil)
+		assert.Equal(t, 403, status)
+	})
+}

--- a/api/v1_users_ping_test.go
+++ b/api/v1_users_ping_test.go
@@ -13,10 +13,13 @@ import (
 func TestPostV1UsersPing(t *testing.T) {
 	app := emptyTestApp(t)
 
-	_, err := app.pool.Exec(context.Background(), `
+	ctx := context.Background()
+	_, err := app.pool.Exec(ctx, `
 		INSERT INTO public.blocks (blockhash, parenthash, number)
 		VALUES ('block1', 'block0', 101)
 		ON CONFLICT DO NOTHING;`)
+	require.NoError(t, err)
+	_, err = app.pool.Exec(ctx, `ALTER TABLE users ADD COLUMN IF NOT EXISTS last_active_at TIMESTAMPTZ DEFAULT NULL;`)
 	require.NoError(t, err)
 
 	database.SeedTable(app.pool.Replicas[0], "users", testdata.UserFixtures)

--- a/sql/01_schema.sql
+++ b/sql/01_schema.sql
@@ -10286,7 +10286,8 @@ CREATE TABLE public.users (
     website character varying,
     donation character varying,
     profile_type public.profile_type_enum,
-    coin_flair_mint text
+    coin_flair_mint text,
+    last_active_at timestamp with time zone
 );
 
 


### PR DESCRIPTION
## Summary
- Adds integration tests for the `POST /v1/users/me/ping` endpoint (already merged in #954)
- Tests cover: authenticated 200, missing user_id 400, unauthenticated 403
- Fixes test DB setup: seeds `blocks` table before `users` (foreign key constraint) and ensures `last_active_at` column exists
- Updates `01_schema.sql` to include `last_active_at` on the `users` table

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./api/...` passes
- [x] `TestPostV1UsersPing` passes locally (all 3 subtests)
- [x] Full `go test ./api/...` passes (except pre-existing `TestSearch` which requires Elasticsearch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)