### PR TITLE
fix: make 0218 event_routes migration idempotent

### DIFF
--- a/ddl/migrations/0218_create_event_routes.sql
+++ b/ddl/migrations/0218_create_event_routes.sql
@@ -4,7 +4,6 @@
 -- indexer when an event is created, owner_id points to the event's host user,
 -- and is_current flags the canonical row so a LEFT JOIN ON is_current = true
 -- always lands on at most one row per event.
-
 CREATE TABLE IF NOT EXISTS public.event_routes (
     slug         character varying NOT NULL,
     owner_id     integer           NOT NULL,
@@ -12,11 +11,8 @@ CREATE TABLE IF NOT EXISTS public.event_routes (
     is_current   boolean           NOT NULL,
     blockhash    character varying NOT NULL,
     blocknumber  integer           NOT NULL,
-    txhash       character varying NOT NULL
+    txhash       character varying NOT NULL,
+    CONSTRAINT event_routes_pkey PRIMARY KEY (owner_id, slug)
 );
-
-ALTER TABLE ONLY public.event_routes
-    ADD CONSTRAINT event_routes_pkey PRIMARY KEY (owner_id, slug);
-
 CREATE INDEX IF NOT EXISTS event_routes_event_id_idx
     ON public.event_routes USING btree (event_id);


### PR DESCRIPTION
The ALTER TABLE ADD CONSTRAINT was not guarded, causing bridge migrate to fail when the table already exists. Inlines PRIMARY KEY into CREATE TABLE IF NOT EXISTS so re-runs are safe. This was blocking all auto-upgrades since June 10.