### PR TITLE
chore: bump go-openaudio to pick up genre normalization

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,8 +6,8 @@ require (
 	connectrpc.com/connect v1.18.1
 	github.com/AlecAivazis/survey/v2 v2.3.7
 	github.com/Doist/unfurlist v0.0.0-20250409100812-515f2735f8e5
-	github.com/OpenAudio/go-openaudio v1.3.1-0.20260609215252-7758ae709d18
-	github.com/OpenAudio/go-openaudio/pkg/etl v1.3.1-0.20260609215252-7758ae709d18
+	github.com/OpenAudio/go-openaudio v1.4.1-0.20260618012656-5aa118b67bc1
+	github.com/OpenAudio/go-openaudio/pkg/etl v1.4.1-0.20260618012656-5aa118b67bc1
 	github.com/aquasecurity/esquery v0.2.0
 	github.com/axiomhq/axiom-go v0.23.0
 	github.com/axiomhq/hyperloglog v0.2.5

--- a/go.sum
+++ b/go.sum
@@ -20,10 +20,10 @@ github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2 h1:+vx7roKuyA63n
 github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2/go.mod h1:HBCaDeC1lPdgDeDbhX8XFpy1jqjK0IBG8W5K+xYqA0w=
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5 h1:TngWCqHvy9oXAN6lEVMRuU21PR1EtLVZJmdB18Gu3Rw=
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5/go.mod h1:lmUJ/7eu/Q8D7ML55dXQrVaamCz2vxCfdQBasLZfHKk=
-github.com/OpenAudio/go-openaudio v1.3.1-0.20260609215252-7758ae709d18 h1:iadp1dH4zGKV2XGBIwDMEbHkb3jZydQoF71YM0AYiq8=
-github.com/OpenAudio/go-openaudio v1.3.1-0.20260609215252-7758ae709d18/go.mod h1:wiFXmVbIUkN2D5lRshknaARCKhzbHtCBKRCZe6UOnVs=
-github.com/OpenAudio/go-openaudio/pkg/etl v1.3.1-0.20260609215252-7758ae709d18 h1:prKZiZ5PsiklV03i2Rt2yHEG0oAZQkNWxa6UCcQxuHg=
-github.com/OpenAudio/go-openaudio/pkg/etl v1.3.1-0.20260609215252-7758ae709d18/go.mod h1:LZKiU9vBYzlZzn6oPRHHLPXteBtMKQPegNH9bX9JuH8=
+github.com/OpenAudio/go-openaudio v1.4.1-0.20260618012656-5aa118b67bc1 h1:nfnIHX+rbMcm1Xdr4AkfinF5ms/RQVKXtV/3S5gqO3w=
+github.com/OpenAudio/go-openaudio v1.4.1-0.20260618012656-5aa118b67bc1/go.mod h1:wiFXmVbIUkN2D5lRshknaARCKhzbHtCBKRCZe6UOnVs=
+github.com/OpenAudio/go-openaudio/pkg/etl v1.4.1-0.20260618012656-5aa118b67bc1 h1:DeKyFpz5BFelTSFRqSnu58RfDDwn38BCtYfBsoUg3gg=
+github.com/OpenAudio/go-openaudio/pkg/etl v1.4.1-0.20260618012656-5aa118b67bc1/go.mod h1:qOtZr4+Xkp/Zp+yM4axDcKdYF03+xA98PjhwjFQMGvg=
 github.com/StackExchange/wmi v1.2.1 h1:VIkavFPXSjcnS+O8yTq7NI32k0R5Aj+v39y29VYDOSA=
 github.com/StackExchange/wmi v1.2.1/go.mod h1:rcmrprowKIVzvc+NUiLncP2uuArMWLCbu9SBzvHz7e8=
 github.com/VictoriaMetrics/fastcache v1.12.2 h1:N0y9ASrJ0F6h0QaC3o6uJb3NIZ9VKLjCM7NQbSmF7WI=


### PR DESCRIPTION
## What

Bumps both go-openaudio pins to the merge commit of **go-openaudio #367** (`5aa118b67bc19474a56f81a6665f2f47854d72e4`), which normalizes genre at the **ETL write path** (`entity_manager` track create/update).

```
github.com/OpenAudio/go-openaudio          v1.3.1-...-7758ae709d18 -> v1.4.1-0.20260618012656-5aa118b67bc1
github.com/OpenAudio/go-openaudio/pkg/etl  v1.3.1-...-7758ae709d18 -> v1.4.1-0.20260618012656-5aa118b67bc1
```

Both pins are kept in lockstep (the root module and the `/pkg/etl` submodule), as before.

## Why

This repo runs the production indexer by vendoring go-openaudio's ETL (`indexer/indexer.go` → `etl.Indexer.Run()`); it does not implement track indexing itself. #367 makes the indexer write **canonical genre values at rest**, so genre variants (`hip-hop`/`hiphop` → `Hip-Hop/Rap`, etc.) now collapse on write upstream. That is the durable fix behind the read-side, display-only stopgap merged in #962 — and unlike the API read path, write-side normalization also fixes genre **filtering**.

## Verification

- `go get` both modules @ the SHA, then `go mod tidy` — only `go.mod`/`go.sum` changed.
- `go build ./...` — passes
- `go vet ./...` — passes

## Heads-up for reviewers

With the indexer now normalizing genre, the ETL parity check against the legacy Python discovery-provider may begin flagging `genre` column diffs (Python doesn't normalize). That's expected and is handled on the go-openaudio side — flag to whoever owns the parity job if it surfaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)