### PR TITLE
chore(config): remove creatornode from STORE_ALL

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -252,7 +252,6 @@ func init() {
 			"https://audius-content-13.cultur3stake.com",
 		}
 		Cfg.StoreAllNodes = []string{
-			"https://creatornode.audius.co",
 			"https://v.monophonic.digital",
 			"https://audius.zeogrid.com",
 		}


### PR DESCRIPTION
## Summary
- remove https://creatornode.audius.co from the production STORE_ALL allowlist
- keep production upload nodes unchanged so creatornode.audius.co remains the upload node

## Test Plan
- go test ./config
- git diff --check