### PR TITLE
perf: reduce trending job score writes

### DIFF
--- a/ddl/migrations/0222_drop_superseded_track_trending_indexes.sql
+++ b/ddl/migrations/0222_drop_superseded_track_trending_indexes.sql
@@ -1,0 +1,6 @@
+-- Hot trending reads now order by score DESC, track_id DESC and are covered by
+-- ix_trending_scores_desc_tiebreak / idx_track_trending_scores_for_you_desc_tiebreak.
+-- Drop the older ascending-tiebreak indexes to reduce TrendingJob write
+-- amplification when it refreshes track_trending_scores.
+drop index concurrently if exists public.ix_trending_scores;
+drop index concurrently if exists public.idx_track_trending_scores_for_you;

--- a/jobs/challenges/tastemaker.go
+++ b/jobs/challenges/tastemaker.go
@@ -45,7 +45,7 @@ func (p *TastemakerProcessor) Reconcile(ctx context.Context, tx pgx.Tx) error {
 		SELECT track_id
 		FROM track_trending_scores
 		WHERE type = 'TRACKS' AND version = 'pnagD' AND time_range = 'week'
-		ORDER BY score DESC NULLS LAST
+		ORDER BY score DESC, track_id DESC
 		LIMIT $1
 	`, tastemakerTrackLimit)
 	if err != nil {

--- a/jobs/challenges/trending.go
+++ b/jobs/challenges/trending.go
@@ -150,7 +150,7 @@ func (p *TrendingProcessor) Reconcile(ctx context.Context, tx pgx.Tx) error {
 			FROM track_trending_scores s
 			JOIN tracks t ON t.track_id = s.track_id AND t.is_current = true
 			WHERE s.type = $1 AND s.version = $2 AND s.time_range = 'week'
-			ORDER BY s.score DESC NULLS LAST
+			ORDER BY s.score DESC, s.track_id DESC
 			LIMIT $3
 		`, p.TrendingTyp, p.Version, trendingTopN)
 	default:
@@ -159,7 +159,7 @@ func (p *TrendingProcessor) Reconcile(ctx context.Context, tx pgx.Tx) error {
 			FROM playlist_trending_scores s
 			JOIN playlists pl ON pl.playlist_id = s.playlist_id AND pl.is_current = true
 			WHERE s.type = $1 AND s.version = $2 AND s.time_range = 'week'
-			ORDER BY s.score DESC NULLS LAST
+			ORDER BY s.score DESC, s.playlist_id DESC
 			LIMIT $3
 		`, p.TrendingTyp, p.Version, trendingTopN)
 	}

--- a/jobs/index_trending.go
+++ b/jobs/index_trending.go
@@ -24,15 +24,15 @@ import (
 // This DELETE-all + bulk-INSERT is what discovery's Python did for years. A
 // previous attempt to replace it with a skip-unchanged upsert (temp-table stage
 // + INSERT ... ON CONFLICT DO UPDATE + anti-join prune) aimed to avoid rewriting
-// the whole ~16GB table and its indexes each run, but in practice the per-row
+// the whole multi-GB table and its indexes each run, but in practice the per-row
 // unique-index probe over ~4M rows took 40+ minutes and never finished inside
-// the hourly window, so scores went stale. The bulk rewrite costs more dead
-// tuples (autovacuum handles it, as it did under Python) but completes in
-// seconds, which is the tradeoff that actually matters here.
+// the hourly window, so scores went stale. The bulk rewrite avoids that probe
+// storm, and this job only persists positive track scores to keep the rewrite
+// and index maintenance bounded as the track corpus grows.
 //
 // Scheduled hourly to match discovery (default trending_refresh_seconds=3600;
-// see indexer's startParityJobs). Score templates are copied verbatim from
-// apps' trending_strategies/{pnagD,AnlGe}_*.py so scoring stays bit-identical.
+// see indexer's startParityJobs). Score expressions are copied from apps'
+// trending_strategies/{pnagD,AnlGe}_*.py so scoring stays bit-identical.
 type TrendingJob struct {
 	pool   database.DbPool
 	logger *zap.Logger
@@ -183,8 +183,9 @@ func (j *TrendingJob) computeTrendingTracks(ctx context.Context, trendingType, v
 	// ~4M-row-per-cycle upsert — one unique-index probe and IS DISTINCT FROM
 	// comparison per row — which took 40+ minutes and could never finish inside
 	// the refresh interval. The blunt DELETE + append matches the proven Python
-	// behavior and runs in seconds. The score expressions below are byte-for-byte
-	// the discovery templates.
+	// behavior. The score expressions below are intentionally kept aligned with
+	// the discovery templates, then filtered so we only persist tracks that can
+	// actually appear ahead of the zero-score tail.
 	if _, err := tx.Exec(ctx,
 		`DELETE FROM track_trending_scores WHERE type = $1 AND version = $2`,
 		trendingType, version,
@@ -207,39 +208,50 @@ func (j *TrendingJob) computeTrendingTracks(ctx context.Context, trendingType, v
 			INSERT INTO track_trending_scores
 				(track_id, genre, type, version, time_range, score, created_at)
 			SELECT
-				tp.track_id,
-				tp.genre,
-				$1,
-				$2,
-				$3,
-				CASE
-				WHEN tp.owner_follower_count < $4 THEN 0
-				WHEN EXTRACT(DAYS FROM now() - (
+				track_id,
+				genre,
+				trending_type,
+				trending_version,
+				score_time_range,
+				score,
+				created_at
+			FROM (
+				SELECT
+					tp.track_id,
+					tp.genre,
+					$1::varchar AS trending_type,
+					$2::varchar AS trending_version,
+					$3::varchar AS score_time_range,
 					CASE
-						WHEN tp.release_date > now() THEN aip.created_at
-						ELSE GREATEST(tp.release_date, aip.created_at)
-					END
-				)) > $5 THEN GREATEST(
-					1.0 / $6,
-					POW($6, GREATEST(
-						-10,
-						1.0 - 1.0 * EXTRACT(DAYS FROM now() - (
-							CASE
-								WHEN tp.release_date > now() THEN aip.created_at
-								ELSE GREATEST(tp.release_date, aip.created_at)
-							END
-						)) / $5
-					))
-				) * (
-					$7 * %s + $8 * %s + $9 * %s + $10 * tp.repost_count + $11 * tp.save_count
-				) * %s
-				ELSE (
-					$7 * %s + $8 * %s + $9 * %s + $10 * tp.repost_count + $11 * tp.save_count
-				) * %s
-				END,
-				now()
-			FROM trending_params tp
-			INNER JOIN aggregate_interval_plays aip ON tp.track_id = aip.track_id
+					WHEN tp.owner_follower_count < $4 THEN 0
+					WHEN EXTRACT(DAYS FROM now() - (
+						CASE
+							WHEN tp.release_date > now() THEN aip.created_at
+							ELSE GREATEST(tp.release_date, aip.created_at)
+						END
+					)) > $5 THEN GREATEST(
+						1.0 / $6,
+						POW($6, GREATEST(
+							-10,
+							1.0 - 1.0 * EXTRACT(DAYS FROM now() - (
+								CASE
+									WHEN tp.release_date > now() THEN aip.created_at
+									ELSE GREATEST(tp.release_date, aip.created_at)
+								END
+							)) / $5
+						))
+					) * (
+						$7 * %s + $8 * %s + $9 * %s + $10 * tp.repost_count + $11 * tp.save_count
+					) * %s
+					ELSE (
+						$7 * %s + $8 * %s + $9 * %s + $10 * tp.repost_count + $11 * tp.save_count
+					) * %s
+					END AS score,
+					now() AS created_at
+				FROM trending_params tp
+				INNER JOIN aggregate_interval_plays aip ON tp.track_id = aip.track_id
+			) scored
+			WHERE score > 0
 		`,
 			r.listenField, r.repostField, r.saveField, p.karmaExpr,
 			r.listenField, r.repostField, r.saveField, p.karmaExpr,
@@ -259,19 +271,34 @@ func (j *TrendingJob) computeTrendingTracks(ctx context.Context, trendingType, v
 		INSERT INTO track_trending_scores
 			(track_id, genre, type, version, time_range, score, created_at)
 		SELECT
-			tp.track_id, tp.genre, $1, $2, 'allTime',
-			CASE
-			WHEN tp.owner_follower_count < $3 THEN 0
-			ELSE ($4 * ap.count + $5 * tp.repost_count + $6 * tp.save_count) * %s
-			END,
-			now()
-		FROM trending_params tp
-		INNER JOIN aggregate_plays ap ON tp.track_id = ap.play_item_id
-		INNER JOIN tracks t ON ap.play_item_id = t.track_id
-		WHERE t.is_current IS TRUE
-		  AND t.is_delete IS FALSE
-		  AND t.is_unlisted IS FALSE
-		  AND t.stem_of IS NULL
+			track_id,
+			genre,
+			trending_type,
+			trending_version,
+			time_range,
+			score,
+			created_at
+		FROM (
+			SELECT
+				tp.track_id,
+				tp.genre,
+				$1::varchar AS trending_type,
+				$2::varchar AS trending_version,
+				'allTime'::varchar AS time_range,
+				CASE
+				WHEN tp.owner_follower_count < $3 THEN 0
+				ELSE ($4 * ap.count + $5 * tp.repost_count + $6 * tp.save_count) * %s
+				END AS score,
+				now() AS created_at
+			FROM trending_params tp
+			INNER JOIN aggregate_plays ap ON tp.track_id = ap.play_item_id
+			INNER JOIN tracks t ON ap.play_item_id = t.track_id
+			WHERE t.is_current IS TRUE
+			  AND t.is_delete IS FALSE
+			  AND t.is_unlisted IS FALSE
+			  AND t.stem_of IS NULL
+		) scored
+		WHERE score > 0
 	`, p.karmaExpr)
 	if _, err := tx.Exec(ctx, q,
 		trendingType, version,

--- a/jobs/index_trending_test.go
+++ b/jobs/index_trending_test.go
@@ -22,7 +22,17 @@ func TestTrendingJob_PopulatesScores(t *testing.T) {
 
 	now := time.Now()
 	database.Seed(pool, database.FixtureMap{
-		"users": {{"user_id": 1, "wallet": "0x01", "name": "Alice"}},
+		"users": {
+			{"user_id": 1, "wallet": "0x01", "name": "Alice"},
+			{
+				"user_id": 2, "wallet": "0x02", "name": "Bob",
+				"cover_photo": "cover", "profile_picture": "profile", "bio": "bio",
+			},
+		},
+		"aggregate_user": {
+			{"user_id": 1, "follower_count": 10},
+			{"user_id": 2, "follower_count": 100},
+		},
 		"tracks": {{
 			"track_id": 100, "owner_id": 1, "title": "T",
 			"release_date": now.Add(-2 * 24 * time.Hour),
@@ -31,32 +41,29 @@ func TestTrendingJob_PopulatesScores(t *testing.T) {
 		"plays": {
 			{"id": 1, "user_id": 1, "play_item_id": 100, "created_at": now.Add(-1 * time.Hour)},
 		},
+		"reposts": {
+			{"user_id": 2, "repost_item_id": 100, "repost_type": "track", "created_at": now.Add(-1 * time.Hour)},
+		},
 	})
 
 	job := NewTrendingJob(newTestConfig(), pool)
 	require.NoError(t, job.run(ctx))
 
-	// Track scores: 3 ranges (week, month, allTime) × 2 versions (pnagD,
-	// AnlGe) × 2 types (TRACKS, UNDERGROUND_TRACKS via pnagD only) =
-	//   2 (week/month + allTime) × 3 + 3 = 9 (TRACKS pnagD: 3, TRACKS AnlGe: 3, UNDERGROUND_TRACKS pnagD: 3)
-	// At minimum we expect 9 rows for the seeded track.
+	// Track scores: 3 ranges for TRACKS/pnagD, TRACKS/AnlGe, and
+	// UNDERGROUND_TRACKS/pnagD. At minimum we expect 9 positive rows for the
+	// seeded track.
 	var nTracks int
 	require.NoError(t, pool.QueryRow(ctx, "SELECT COUNT(*) FROM track_trending_scores WHERE track_id = 100").Scan(&nTracks))
 	assert.GreaterOrEqual(t, nTracks, 9, "expected at least 9 score rows for the seeded track")
 
-	// Re-running should not duplicate (upsert keyed on the PK).
+	// Re-running should keep the same row shape.
 	require.NoError(t, job.run(ctx))
 	var nAfter int
 	require.NoError(t, pool.QueryRow(ctx, "SELECT COUNT(*) FROM track_trending_scores WHERE track_id = 100").Scan(&nAfter))
 	assert.Equal(t, nTracks, nAfter, "second run must not duplicate rows")
 }
 
-// TestTrendingJob_PrunesStaleRows verifies the anti-join prune: a track that
-// drops out of the trending source set (here, by being deleted) has its
-// previously-written score rows removed on the next run. The old
-// DELETE-then-INSERT approach got this for free; the upsert+prune rewrite has
-// to do it explicitly, so it's worth a dedicated test.
-func TestTrendingJob_PrunesStaleRows(t *testing.T) {
+func TestTrendingJob_SkipsZeroTrackScores(t *testing.T) {
 	pool := database.CreateTestDatabase(t, "test_jobs")
 	defer pool.Close()
 	ctx := context.Background()
@@ -64,6 +71,48 @@ func TestTrendingJob_PrunesStaleRows(t *testing.T) {
 	now := time.Now()
 	database.Seed(pool, database.FixtureMap{
 		"users": {{"user_id": 1, "wallet": "0x01", "name": "Alice"}},
+		"aggregate_user": {
+			{"user_id": 1, "follower_count": 0},
+		},
+		"tracks": {{
+			"track_id": 150, "owner_id": 1, "title": "Quiet Track",
+			"release_date": now.Add(-2 * 24 * time.Hour),
+			"created_at":   now.Add(-2 * 24 * time.Hour),
+		}},
+		"plays": {
+			{"id": 1, "user_id": 1, "play_item_id": 150, "created_at": now.Add(-1 * time.Hour)},
+		},
+	})
+
+	job := NewTrendingJob(newTestConfig(), pool)
+	require.NoError(t, job.run(ctx))
+
+	var n int
+	require.NoError(t, pool.QueryRow(ctx, "SELECT COUNT(*) FROM track_trending_scores WHERE track_id = 150").Scan(&n))
+	assert.Equal(t, 0, n, "zero-score tracks should not be persisted")
+}
+
+// TestTrendingJob_PrunesStaleRows verifies that a track that drops out of the
+// trending source set (here, by being deleted) has its previously-written score
+// rows removed on the next run.
+func TestTrendingJob_PrunesStaleRows(t *testing.T) {
+	pool := database.CreateTestDatabase(t, "test_jobs")
+	defer pool.Close()
+	ctx := context.Background()
+
+	now := time.Now()
+	database.Seed(pool, database.FixtureMap{
+		"users": {
+			{"user_id": 1, "wallet": "0x01", "name": "Alice"},
+			{
+				"user_id": 2, "wallet": "0x02", "name": "Bob",
+				"cover_photo": "cover", "profile_picture": "profile", "bio": "bio",
+			},
+		},
+		"aggregate_user": {
+			{"user_id": 1, "follower_count": 10},
+			{"user_id": 2, "follower_count": 100},
+		},
 		"tracks": {{
 			"track_id": 200, "owner_id": 1, "title": "T",
 			"release_date": now.Add(-2 * 24 * time.Hour),
@@ -71,6 +120,9 @@ func TestTrendingJob_PrunesStaleRows(t *testing.T) {
 		}},
 		"plays": {
 			{"id": 1, "user_id": 1, "play_item_id": 200, "created_at": now.Add(-1 * time.Hour)},
+		},
+		"reposts": {
+			{"user_id": 2, "repost_item_id": 200, "repost_type": "track", "created_at": now.Add(-1 * time.Hour)},
 		},
 	})
 
@@ -81,8 +133,8 @@ func TestTrendingJob_PrunesStaleRows(t *testing.T) {
 	require.NoError(t, pool.QueryRow(ctx, "SELECT COUNT(*) FROM track_trending_scores WHERE track_id = 200").Scan(&nBefore))
 	require.Greater(t, nBefore, 0, "expected score rows for the seeded track before deletion")
 
-	// Remove the track from the trending source set, then re-run. The
-	// anti-join prune must clear its now-stale score rows.
+	// Remove the track from the trending source set, then re-run. The job must
+	// clear its now-stale score rows.
 	_, err := pool.Exec(ctx, "UPDATE tracks SET is_delete = true WHERE track_id = 200")
 	require.NoError(t, err)
 	require.NoError(t, job.run(ctx))


### PR DESCRIPTION
## Summary
- Persist only positive track trending scores while keeping the existing score expressions intact, reducing the zero-score tail rewritten by TrendingJob.
- Drop superseded ascending-tiebreak track trending indexes now covered by desc-tiebreak indexes.
- Align challenge/tastemaker trending reads with the desc-tiebreak index order and add tests for positive-row persistence plus zero-score pruning.

## Production evidence
- track_trending_scores is about 12.2M rows / 17GB total in prod, with about 16GB of indexes.
- Read-only prod counts showed only about 2.31M positive track score rows; week/month ranges are overwhelmingly zero-score rows.
- score is NOT NULL in prod, so removing NULLS LAST from challenge reads should preserve ordering while letting Postgres use the existing desc-tiebreak indexes.

## Compatibility note
- This intentionally stops returning arbitrary zero-score filler rows from track_trending_scores. Shallow trending reads should be unaffected, but very deep pagination or sparse genre queries may return fewer rows after all positive scores are exhausted.

## Test plan
- go test ./jobs -run TestTrendingJob -count=1
- go test ./jobs/challenges -run "TestTrending|TestTastemaker" -count=1
- go test ./api -run "Trending|RecommendedTracks|GenreTop" -count=1
- git diff --check