### PR TITLE
Add reposts user created-at index

### DIFF
--- a/ddl/migrations/0223_reposts_user_created_at_idx.sql
+++ b/ddl/migrations/0223_reposts_user_created_at_idx.sql
@@ -1,0 +1,14 @@
+-- Supports /v1/users/:id/reposts pagination:
+--
+--   WHERE user_id = ?
+--     AND is_delete = false
+--   ORDER BY created_at DESC
+--
+-- The existing reposts_user_idx is ordered by repost_type and repost_item_id
+-- before created_at. For users whose reposts are not recent globally, Postgres
+-- can choose reposts_new_created_at_idx and scan millions of unrelated rows to
+-- find the user's newest reposts.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS reposts_user_created_at_active_idx
+    ON public.reposts USING btree (user_id, created_at DESC)
+    INCLUDE (repost_type, repost_item_id)
+    WHERE is_delete = false;


### PR DESCRIPTION
## Summary
- add a concurrent partial covering index for `/v1/users/:id/reposts` pagination
- index active reposts by `(user_id, created_at DESC)` and include `repost_type` / `repost_item_id`
- keep endpoint SQL unchanged; this codifies the index that was manually applied and validated on prod

## DB evidence
Live read-only analysis showed the existing plan could scan global `reposts_new_created_at_idx` and discard millions of unrelated rows for users whose reposts were not globally recent.

For heavy user `279392` before the index:
- `LIMIT 10 OFFSET 0`: ~7.7s cold, skipped ~2.65M unrelated rows
- `LIMIT 100 OFFSET 0`: ~1.35s warm, skipped ~4.51M unrelated rows
- `LIMIT 100 OFFSET 1000`: ~1.30s warm, skipped ~4.52M unrelated rows

After applying `reposts_user_created_at_active_idx`, the planner used `Index Only Scan using reposts_user_created_at_active_idx`:
- `LIMIT 10 OFFSET 0`: ~6.5ms
- `LIMIT 100 OFFSET 0`: ~6.4ms
- `LIMIT 100 OFFSET 1000`: ~35ms
- fresh-heavy user `714646433 LIMIT 10 OFFSET 0`: ~4.9ms

The live index was valid/ready/live and ~226 MB.

## Test
- `go test ./api -run Test200UnAuthed -count=1`
