### PR TITLE
Add comments user pagination index

### DIFF
--- a/api/v1_users_comments.go
+++ b/api/v1_users_comments.go
@@ -8,13 +8,12 @@ import (
 func (app *ApiServer) v1UsersComments(c *fiber.Ctx) error {
 
 	sql := `
-	SELECT comment_id as id
-	FROM comments
-	LEFT JOIN comment_threads USING (comment_id)
-	WHERE user_id = @user_id
-	AND entity_type = 'Track'
-	AND comments.is_delete = false
-	`
+		SELECT comment_id as id
+		FROM comments
+		WHERE user_id = @user_id
+		AND entity_type = 'Track'
+		AND comments.is_delete = false
+		`
 
 	args := pgx.NamedArgs{
 		"user_id": app.getUserId(c),

--- a/ddl/migrations/0224_comments_user_track_created_at_idx.sql
+++ b/ddl/migrations/0224_comments_user_track_created_at_idx.sql
@@ -1,0 +1,14 @@
+-- Supports /v1/users/:id/comments pagination:
+--
+--   WHERE user_id = ?
+--     AND entity_type = 'Track'
+--     AND is_delete = false
+--   ORDER BY created_at DESC
+--
+-- Without this index, the endpoint scans and sorts the full comments table for
+-- every user-comments page request.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS comments_user_track_created_at_idx
+    ON public.comments USING btree (user_id, created_at DESC)
+    INCLUDE (comment_id)
+    WHERE entity_type = 'Track'
+      AND is_delete = false;


### PR DESCRIPTION
## Summary
- add a concurrent partial covering index for `/v1/users/:id/comments` pagination
- remove an unused `comment_threads` join from the user-comments id page query
- keep hydration/filtering behavior in `FullComments` unchanged

## DB evidence
Read-only investigation against `discovery-1-replica` showed this route is currently dominating the read replica.

Live 60-second `pg_stat_statements` delta:
- `SELECT comment_id as id FROM comments ... WHERE user_id = $1 ... ORDER BY comments.created_at DESC LIMIT/OFFSET`
- 1,610 calls in 60s
- ~1,666,937 ms accumulated DB execution time
- ~1,035 ms mean execution time

Post-rollout 30-second delta still showed ongoing pressure:
- 954 calls in 30s
- ~986,306 ms accumulated DB execution time
- ~1,034 ms mean execution time

Representative `EXPLAIN (ANALYZE, BUFFERS)` on the replica:
- user `527480232`, `LIMIT 10 OFFSET 0`: ~1.07s
- user `20`, `LIMIT 10 OFFSET 0`: ~1.05s
- user `527480232`, `LIMIT 10 OFFSET 1000`: ~1.08s

The plan scans the full `comments` table, hashes `comment_threads`, sorts, and returns only a page of ids. Catalog check showed `comments` only had `comments_pkey` and `comments_blocknumber_idx`, with no index matching `user_id + Track + active + created_at`.

Bridge logs also show the live traffic source is IP `162.220.232.107` using `app_name=TEMPO`, `TEMPO_sync`, `TEMPO_engage`, and `TEMPO_analytics` against `/v1/users/:userId/comments`.

## Test
- `go test ./api -run 'TestUserComments|Test200UnAuthed' -count=1`
