### PR TITLE
perf: stop computing unused track trending scores

### DIFF
--- a/jobs/challenges/trending.go
+++ b/jobs/challenges/trending.go
@@ -108,12 +108,11 @@ func (p *TrendingProcessor) Reconcile(ctx context.Context, tx pgx.Tx) error {
 		// make_get_unpopulated_tracks in get_underground_trending.py (the
 		// underground strategy there reuses the TRACKS strategy, so it reads
 		// TRACKS-typed scores). Selecting raw UNDERGROUND_TRACKS scores
-		// instead — which index_trending computes identically to TRACKS,
-		// with no eligibility filter — made underground winners nearly
-		// identical to regular trending. The same filter already lives in
-		// the read endpoint, api/v1_tracks_trending_underground.go. version
-		// stays p.Version (pnagD); the written trending_results rows keep
-		// type = UNDERGROUND_TRACKS.
+		// instead made underground winners nearly identical to regular
+		// trending. The same filter already lives in the read endpoint,
+		// api/v1_tracks_trending_underground.go. version stays p.Version
+		// (pnagD); the written trending_results rows keep type =
+		// UNDERGROUND_TRACKS.
 		rows, err = tx.Query(ctx, `
 			WITH top_trending AS (
 				SELECT s.track_id

--- a/jobs/index_trending.go
+++ b/jobs/index_trending.go
@@ -32,7 +32,7 @@ import (
 //
 // Scheduled hourly to match discovery (default trending_refresh_seconds=3600;
 // see indexer's startParityJobs). Score expressions are copied from apps'
-// trending_strategies/{pnagD,AnlGe}_*.py so scoring stays bit-identical.
+// trending_strategies/pnagD_*.py so scoring stays bit-identical.
 type TrendingJob struct {
 	pool   database.DbPool
 	logger *zap.Logger
@@ -98,14 +98,6 @@ func (j *TrendingJob) run(ctx context.Context) error {
 	if err := j.computeTrendingTracks(ctx, "TRACKS", "pnagD", trackParamsPnagD); err != nil {
 		return fmt.Errorf("trending tracks pnagD: %w", err)
 	}
-	if err := j.computeTrendingTracks(ctx, "TRACKS", "AnlGe", trackParamsAnlGe); err != nil {
-		return fmt.Errorf("trending tracks AnlGe: %w", err)
-	}
-	// Underground uses the same TRACKS strategies but registers under a
-	// different trending_type key; apps only registers pnagD for it.
-	if err := j.computeTrendingTracks(ctx, "UNDERGROUND_TRACKS", "pnagD", trackParamsPnagD); err != nil {
-		return fmt.Errorf("trending underground tracks pnagD: %w", err)
-	}
 
 	if err := j.computeTrendingPlaylists(ctx, "PLAYLISTS", "pnagD"); err != nil {
 		return fmt.Errorf("trending playlists pnagD: %w", err)
@@ -138,20 +130,14 @@ func (j *TrendingJob) refreshMatview(ctx context.Context, mv string) error {
 	return nil
 }
 
-// trackScoreParams holds the scalar weights used by a tracks strategy. The
-// only behavior difference between pnagD and AnlGe is whether the trailing
-// multiplier is `karma` or `(1 + LOG(1 + karma))`.
+// trackScoreParams holds the scalar weights used by a tracks strategy.
 type trackScoreParams struct {
 	karmaExpr string
 }
 
-var (
-	trackParamsPnagD = trackScoreParams{karmaExpr: "tp.karma"}
-	trackParamsAnlGe = trackScoreParams{karmaExpr: "(1 + LOG(1 + tp.karma))"}
-)
+var trackParamsPnagD = trackScoreParams{karmaExpr: "tp.karma"}
 
 // Score weights matching apps' constants in pnagD_trending_tracks_strategy.py
-// (and AnlGe — they share the same constants).
 const (
 	trendingN  = 1
 	trendingF  = 50

--- a/jobs/index_trending_test.go
+++ b/jobs/index_trending_test.go
@@ -49,12 +49,11 @@ func TestTrendingJob_PopulatesScores(t *testing.T) {
 	job := NewTrendingJob(newTestConfig(), pool)
 	require.NoError(t, job.run(ctx))
 
-	// Track scores: 3 ranges for TRACKS/pnagD, TRACKS/AnlGe, and
-	// UNDERGROUND_TRACKS/pnagD. At minimum we expect 9 positive rows for the
-	// seeded track.
+	// Track scores: 3 ranges for TRACKS/pnagD.
+	// At minimum we expect 3 positive rows for the seeded track.
 	var nTracks int
 	require.NoError(t, pool.QueryRow(ctx, "SELECT COUNT(*) FROM track_trending_scores WHERE track_id = 100").Scan(&nTracks))
-	assert.GreaterOrEqual(t, nTracks, 9, "expected at least 9 score rows for the seeded track")
+	assert.GreaterOrEqual(t, nTracks, 3, "expected at least 3 score rows for the seeded track")
 
 	// Re-running should keep the same row shape.
 	require.NoError(t, job.run(ctx))


### PR DESCRIPTION
## Summary
- stop TrendingJob from computing unused TRACKS/AnlGe scores
- stop TrendingJob from computing raw UNDERGROUND_TRACKS/pnagD score rows; underground endpoint and winners use TRACKS/pnagD scores with the underground filter
- update TrendingJob smoke test expectations and clean up the underground winners comment

## Test
- go test ./jobs -run TestTrendingJob -count=1
- go test ./jobs/challenges -run TestTrending_UndergroundFiltersMainstream -count=1