### PR TITLE
Fix stems endpoint with null original filenames

### DIFF
--- a/api/v1_track_stems.go
+++ b/api/v1_track_stems.go
@@ -25,7 +25,7 @@ func (app *ApiServer) v1TrackStems(c *fiber.Ctx) error {
 	  t.track_cid,
 	  t.owner_id,
 	  t.blocknumber,
-	  t.orig_filename
+	  COALESCE(t.orig_filename, t.title, '') AS orig_filename
 	FROM tracks t
 	JOIN stems s ON s.child_track_id = t.track_id
 	JOIN tracks parent ON parent.track_id = s.parent_track_id
@@ -33,6 +33,7 @@ func (app *ApiServer) v1TrackStems(c *fiber.Ctx) error {
 	  AND t.is_delete = false
 	  AND s.parent_track_id = @track_id
 	  AND parent.is_delete = false
+	ORDER BY t.track_id
 	`
 
 	rows, err := app.pool.Query(c.Context(), sql, pgx.NamedArgs{

--- a/api/v1_track_stems_test.go
+++ b/api/v1_track_stems_test.go
@@ -45,6 +45,17 @@ func TestGetTrackStems(t *testing.T) {
 					"category":        "vocals",
 				},
 			},
+			{
+				"track_id":    4,
+				"owner_id":    1,
+				"title":       "Stem Without Original Filename",
+				"track_cid":   "testcid3",
+				"blocknumber": 101,
+				"stem_of": map[string]any{
+					"parent_track_id": 1,
+					"category":        "guitar",
+				},
+			},
 		},
 		"stems": {
 			{
@@ -53,6 +64,10 @@ func TestGetTrackStems(t *testing.T) {
 			},
 			{
 				"child_track_id":  3,
+				"parent_track_id": 1,
+			},
+			{
+				"child_track_id":  4,
 				"parent_track_id": 1,
 			},
 		},
@@ -64,7 +79,7 @@ func TestGetTrackStems(t *testing.T) {
 	assert.Equal(t, 200, status)
 
 	jsonAssert(t, body, map[string]any{
-		"data.#":               2,
+		"data.#":               3,
 		"data.0.id":            trashid.MustEncodeHashID(2),
 		"data.0.parent_id":     trashid.MustEncodeHashID(1),
 		"data.0.category":      "bass",
@@ -77,5 +92,11 @@ func TestGetTrackStems(t *testing.T) {
 		"data.1.orig_filename": "stem2.wav",
 		"data.1.cid":           "testcid2",
 		"data.1.user_id":       trashid.MustEncodeHashID(1),
+		"data.2.id":            trashid.MustEncodeHashID(4),
+		"data.2.parent_id":     trashid.MustEncodeHashID(1),
+		"data.2.category":      "guitar",
+		"data.2.orig_filename": "Stem Without Original Filename",
+		"data.2.cid":           "testcid3",
+		"data.2.user_id":       trashid.MustEncodeHashID(1),
 	})
 }


### PR DESCRIPTION
## Summary
- return a stable filename string from the track stems endpoint when `tracks.orig_filename` is null
- order stems by track ID for deterministic responses
- add a regression case for a stem row with a null original filename

## Verification
- `go test ./api -run TestGetTrackStems -count=1`

## Live investigation
- `GET /v1/tracks/qJ0RAXE/stems` was returning `500: cannot scan NULL into *string` for Burko's contest track
- read-only prod query verified parent track `1960897973` has 30 current, non-deleted stem rows, 10 distinct titles, and all 30 rows have `orig_filename IS NULL`
