### PR TITLE
chore: reduce api log noise

### DIFF
--- a/api/server.go
+++ b/api/server.go
@@ -44,6 +44,7 @@ import (
 	"github.com/mcuadros/go-defaults"
 	"github.com/segmentio/encoding/json"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 )
 
 //go:embed swagger/swagger-v1.yaml
@@ -375,7 +376,8 @@ func NewApiServer(config config.Config) *ApiServer {
 
 				return fields
 			},
-			Fields: []string{"status", "method", "url", "route"},
+			Fields: []string{"status", "method", "path", "route"},
+			Levels: []zapcore.Level{zapcore.ErrorLevel, zapcore.WarnLevel, zapcore.DebugLevel},
 		}))
 	}
 
@@ -529,7 +531,7 @@ func NewApiServer(config config.Config) *ApiServer {
 		g.Get("/tracks/unclaimed_id", app.v1TracksUnclaimedId)
 
 		g.Get("/tracks/latest", app.v1TracksLatest)
-			g.Get("/tracks/trending", app.v1TracksTrending)
+		g.Get("/tracks/trending", app.v1TracksTrending)
 		g.Get("/tracks/trending/ids", app.v1TracksTrendingIds)
 		g.Get("/tracks/trending/winners", app.v1TracksTrendingWinners)
 		g.Get("/tracks/trending/underground", app.v1TracksTrendingUnderground)

--- a/esindexer/esindexer.go
+++ b/esindexer/esindexer.go
@@ -219,10 +219,10 @@ func (indexer *EsIndexer) scriptedUpdateSocial(userId int64, fieldName string, e
 		if err := indexer.indexIds("socials", userId); err != nil {
 			slog.Error("socials indexIds failed", "user", userId, "field", fieldName, "id", entityId, "err", err)
 		} else {
-			slog.Info("socials indexIds", "user", userId, "field", fieldName, "id", entityId)
+			slog.Debug("socials indexIds", "user", userId, "field", fieldName, "id", entityId)
 		}
 	} else {
-		slog.Info("social update", "user", userId, "field", fieldName, "id", entityId)
+		slog.Debug("social update", "user", userId, "field", fieldName, "id", entityId)
 	}
 
 }

--- a/solana/indexer/solana_indexer.go
+++ b/solana/indexer/solana_indexer.go
@@ -196,6 +196,7 @@ func (s *SolanaIndexer) ProcessRetryQueue(ctx context.Context) {
 	offset := 0
 	logger := s.logger.Named("RetryQueue")
 	count := 0
+	failedByIndexer := map[string]int{}
 	start := time.Now()
 	logger.Debug("starting to process retry queue...")
 	for {
@@ -217,7 +218,8 @@ func (s *SolanaIndexer) ProcessRetryQueue(ctx context.Context) {
 			}
 			err := indexer.HandleUpdate(ctx, item.UpdateMessage.SubscribeUpdate)
 			if err != nil {
-				logger.Error("failed to retry", zap.String("indexer", locker.NAME), zap.Error(err))
+				logger.Debug("retry queue item failed", zap.String("indexer", item.Indexer), zap.Error(err))
+				failedByIndexer[item.Indexer]++
 				offset++
 			} else {
 				err = common.DeleteFromRetryQueue(ctx, s.pool, item.ID)
@@ -232,6 +234,12 @@ func (s *SolanaIndexer) ProcessRetryQueue(ctx context.Context) {
 	if count == 0 {
 		logger.Debug("no unprocessed transactions to retry")
 		return
+	}
+
+	if len(failedByIndexer) > 0 {
+		logger.Warn("retry queue items failed",
+			zap.Int("failed", offset),
+			zap.Any("failed_by_indexer", failedByIndexer))
 	}
 
 	logger.Info("finished processing retry queue",


### PR DESCRIPTION
## Summary
- log API request `path` instead of full `url` and move successful requests to debug
- move routine social index update logs to debug
- aggregate Solana retry queue failures into one warning while keeping per-item detail at debug

## Testing
- `go test -c -o /tmp/api-package.test ./api`
- `go test ./esindexer ./solana/indexer`
- `go test ./api ./esindexer ./solana/indexer` (blocked locally: search tests require Elasticsearch on `:21401`)