### PR TITLE
Add comment_threads reverse lookup index

### DIFF
--- a/ddl/migrations/0226_comment_threads_comment_id_idx.sql
+++ b/ddl/migrations/0226_comment_threads_comment_id_idx.sql
@@ -1,0 +1,10 @@
+-- Supports deferred comment triggers that classify a freshly inserted comment
+-- by checking whether it has a comment_threads row:
+--
+--   WHERE comment_id = ?
+--
+-- The primary key is ordered as (parent_comment_id, comment_id), which is ideal
+-- for parent-thread lookups but not for this reverse lookup used during comment
+-- create handling.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS comment_threads_comment_id_idx
+    ON public.comment_threads USING btree (comment_id);


### PR DESCRIPTION
## Summary
- Add a concurrent index on `comment_threads (comment_id)`.
- Speeds comment-create trigger paths that check whether a newly inserted comment has a thread row by `comment_id`.

## Context
The slow ETL sample was dominated by `Comment Create` outliers, including one ~2.28s handler. Several deferred comment triggers classify top-level comments vs replies with `WHERE comment_id = new.comment_id`, while the existing primary key is ordered as `(parent_comment_id, comment_id)`. This index gives that reverse lookup its own narrow path.

## Testing
- `git diff --check`