### PR TITLE
Add track_routes slug allocation index

### DIFF
--- a/ddl/migrations/0225_track_routes_slug_allocation_idx.sql
+++ b/ddl/migrations/0225_track_routes_slug_allocation_idx.sql
@@ -1,0 +1,12 @@
+-- Supports ETL track route allocation:
+--
+--   SELECT MAX(collision_id)
+--   FROM track_routes
+--   WHERE owner_id = ?
+--     AND title_slug = ?
+--
+-- The primary key covers (owner_id, slug), but not title_slug. Track creates
+-- run this lookup before inserting each track_routes row, so give Postgres a
+-- narrow index for the slug-allocation path.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS track_routes_owner_title_slug_collision_idx
+    ON public.track_routes USING btree (owner_id, title_slug, collision_id DESC);


### PR DESCRIPTION
## Summary
- Add a concurrent index on `track_routes (owner_id, title_slug, collision_id DESC)`.
- Speeds the Core ETL `Track Create` slug allocation query that does `SELECT MAX(collision_id)` by owner and title slug before inserting `track_routes`.

## Context
Recent CoreIndexer logs had a `Track Create` outlier at ~2.46s. The handler calls `GenerateSlugAndCollisionID`, and the schema only covered `track_routes` by `(owner_id, slug)` and `track_id`; it did not cover the `(owner_id, title_slug)` lookup used for collision allocation.

## Testing
- `git diff --check`