### PR TITLE
chore: bump go-openaudio ETL dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,8 +6,8 @@ require (
 	connectrpc.com/connect v1.18.1
 	github.com/AlecAivazis/survey/v2 v2.3.7
 	github.com/Doist/unfurlist v0.0.0-20250409100812-515f2735f8e5
-	github.com/OpenAudio/go-openaudio v1.5.1-0.20260629182311-eb976ab7d10a
-	github.com/OpenAudio/go-openaudio/pkg/etl v1.5.1-0.20260629182311-eb976ab7d10a
+	github.com/OpenAudio/go-openaudio v1.5.1-0.20260629214354-ad45fd6ad456
+	github.com/OpenAudio/go-openaudio/pkg/etl v1.5.1-0.20260629214354-ad45fd6ad456
 	github.com/aquasecurity/esquery v0.2.0
 	github.com/axiomhq/axiom-go v0.23.0
 	github.com/axiomhq/hyperloglog v0.2.5

--- a/go.sum
+++ b/go.sum
@@ -24,10 +24,14 @@ github.com/OpenAudio/go-openaudio v1.4.1-0.20260618012656-5aa118b67bc1 h1:nfnIHX
 github.com/OpenAudio/go-openaudio v1.4.1-0.20260618012656-5aa118b67bc1/go.mod h1:wiFXmVbIUkN2D5lRshknaARCKhzbHtCBKRCZe6UOnVs=
 github.com/OpenAudio/go-openaudio v1.5.1-0.20260629182311-eb976ab7d10a h1:Rmk8XrfEwdmDnISU87CnaRjv0u7c8aKJRNmR0gAVvWg=
 github.com/OpenAudio/go-openaudio v1.5.1-0.20260629182311-eb976ab7d10a/go.mod h1:lLRvUF5oWkxOyZx8rp/ecqxuMo3yzPvuvJbLSfvxguQ=
+github.com/OpenAudio/go-openaudio v1.5.1-0.20260629214354-ad45fd6ad456 h1:cyZrZPClM98kQbV2HCyJZHqEy+8Rp0e3CzSt98Qydb8=
+github.com/OpenAudio/go-openaudio v1.5.1-0.20260629214354-ad45fd6ad456/go.mod h1:lLRvUF5oWkxOyZx8rp/ecqxuMo3yzPvuvJbLSfvxguQ=
 github.com/OpenAudio/go-openaudio/pkg/etl v1.4.1-0.20260618012656-5aa118b67bc1 h1:DeKyFpz5BFelTSFRqSnu58RfDDwn38BCtYfBsoUg3gg=
 github.com/OpenAudio/go-openaudio/pkg/etl v1.4.1-0.20260618012656-5aa118b67bc1/go.mod h1:qOtZr4+Xkp/Zp+yM4axDcKdYF03+xA98PjhwjFQMGvg=
 github.com/OpenAudio/go-openaudio/pkg/etl v1.5.1-0.20260629182311-eb976ab7d10a h1:brZAgN0X5AWXgnoXywusHFCQ28H3lxIDNw4llsY89JQ=
 github.com/OpenAudio/go-openaudio/pkg/etl v1.5.1-0.20260629182311-eb976ab7d10a/go.mod h1:GOtIlg6gDySPB0ekNVP1SPrlky6EfIigP2MGZ9g+ih4=
+github.com/OpenAudio/go-openaudio/pkg/etl v1.5.1-0.20260629214354-ad45fd6ad456 h1:SLIEnfT7ah+w4Y+ORU9M2OZ2HV1HR3cSlXQBlJg5AGk=
+github.com/OpenAudio/go-openaudio/pkg/etl v1.5.1-0.20260629214354-ad45fd6ad456/go.mod h1:GOtIlg6gDySPB0ekNVP1SPrlky6EfIigP2MGZ9g+ih4=
 github.com/StackExchange/wmi v1.2.1 h1:VIkavFPXSjcnS+O8yTq7NI32k0R5Aj+v39y29VYDOSA=
 github.com/StackExchange/wmi v1.2.1/go.mod h1:rcmrprowKIVzvc+NUiLncP2uuArMWLCbu9SBzvHz7e8=
 github.com/VictoriaMetrics/fastcache v1.12.2 h1:N0y9ASrJ0F6h0QaC3o6uJb3NIZ9VKLjCM7NQbSmF7WI=


### PR DESCRIPTION
## Summary
- Bump `github.com/OpenAudio/go-openaudio` and `github.com/OpenAudio/go-openaudio/pkg/etl` to `v1.5.1-0.20260629214354-ad45fd6ad456`.
- Consumes the merged ETL performance PRs:
  - OpenAudio/go-openaudio#390: skip empty track-create relationship reconciliation.
  - OpenAudio/go-openaudio#391: reduce comment-create database round trips.

## Testing
- `git diff --check`
- `go test ./...`

Note: the first `go test ./...` run failed because local Postgres on `localhost:21300` and Elasticsearch test service on `localhost:21401` were not running. After starting repo-local test services with Docker Compose, the full suite passed. Test containers were torn down afterward.