### PR TITLE
chore(ci): stop building Docker images on every branch push

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,8 +1,19 @@
 name: Build Docker Image
 
 on:
+  # Only build/push images on main. Previously this ran on every push to every
+  # branch ("**"), producing a full amd64 + arm64 multi-arch build, push, and
+  # GitHub Release for every feature-branch commit — by far the largest source
+  # of Actions spend in this repo. Feature-branch images are not consumed by any
+  # deploy; use the manual trigger below to build one on demand when needed.
   push:
-    branches: ["**"]
+    branches: [ main ]
+  workflow_dispatch:
+
+# Serialize main builds; a newer main push supersedes an older in-flight build.
+concurrency:
+  group: build-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build-amd64:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,10 +1,16 @@
 name: Go Tests with Docker Compose
 
 on:
-  push:
-    branches: [ main ]
+  # Tests gate PRs into main. The redundant push:main run (same commits already
+  # tested on the PR) is dropped; keep workflow_dispatch for manual reruns.
   pull_request:
     branches: [ main ]
+  workflow_dispatch:
+
+# Cancel superseded runs when a PR is updated with new commits.
+concurrency:
+  group: test-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   test:


### PR DESCRIPTION
## Goal
Cut GitHub Actions spend. This repo's Actions cost is dominated by `build.yml`.

## Changes
**`build.yml` — the big one.** It previously ran on `push: branches: ["**"]` — a full **amd64 + arm64 multi-arch build + push + GitHub Release on every push to every branch**. Branch-sha images aren't consumed by any deploy (`latest` is only tagged on main). Now:
- builds only on `push: main`
- `workflow_dispatch` retained so anyone can build a branch image on demand
- `cancel-in-progress` concurrency so a newer main push supersedes an in-flight build

**`test.yml`** — dropped the redundant `push: main` trigger (those commits were already tested on the PR) and added `cancel-in-progress` concurrency. Tests still gate every PR into main.

## Estimated savings
Eliminates multi-arch Docker builds on all feature-branch pushes — the majority of this repo's ~$14/mo. Rough estimate **~60–70% of api Actions spend (~$8–10/mo)**.

## ⚠️ Reviewer check
Confirm nothing pulls `audius/api:<sha>` images built from non-main branches (e.g. ephemeral test envs). If something does, we can re-add a narrower trigger. The manual `workflow_dispatch` covers ad-hoc branch builds in the meantime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)