### PR TITLE
Show manager request notifications for low-score users

### DIFF
--- a/api/v1_notifications.go
+++ b/api/v1_notifications.go
@@ -166,7 +166,10 @@ WHERE
 					WHERE u2.user_id = (n.data->>'user_id')::integer
 					AND u2.is_current = true
 					AND u2.is_deactivated = false
-					AND a2.score >= 0
+					AND (
+						n.type in ('request_manager', 'approve_manager_request')
+						OR a2.score >= 0
+					)
 				)
 			)
 			AND (

--- a/api/v1_notifications_test.go
+++ b/api/v1_notifications_test.go
@@ -331,6 +331,59 @@ func TestV1Notifications_LowScore(t *testing.T) {
 	})
 }
 
+func TestV1Notifications_LowScoreManagerRequest(t *testing.T) {
+	app := emptyTestApp(t)
+
+	const recipientUserID = 1
+	const lowScoreGrantorUserID = 67576
+
+	fixtures := database.FixtureMap{
+		"users": []map[string]any{
+			{
+				"user_id":        lowScoreGrantorUserID,
+				"is_deactivated": false,
+			},
+		},
+		"aggregate_user": []map[string]any{
+			{
+				"user_id": lowScoreGrantorUserID,
+				"score":   -1,
+			},
+		},
+		"notification": []map[string]any{
+			{
+				"id":        1,
+				"specifier": strconv.Itoa(lowScoreGrantorUserID),
+				"group_id":  "request_manager:grantee_user_id:1:user_id:67576",
+				"type":      "request_manager",
+				"user_ids":  []int{recipientUserID},
+				"data": []byte(
+					`{"user_id": 67576, "grantee_address": "0xabc", "grantee_user_id": 1}`,
+				),
+			},
+		},
+	}
+
+	database.Seed(app.pool.Replicas[0], fixtures)
+
+	status, body := testGet(
+		t,
+		app,
+		"/v1/notifications/"+
+			trashid.MustEncodeHashID(recipientUserID)+
+			"?types=request_manager",
+	)
+	assert.Equal(t, 200, status)
+
+	jsonAssert(t, body, map[string]any{
+		"data.notifications.#":                                1,
+		"data.notifications.0.type":                           "request_manager",
+		"data.notifications.0.actions.0.specifier":            trashid.MustEncodeHashID(lowScoreGrantorUserID),
+		"data.notifications.0.actions.0.data.user_id":         trashid.MustEncodeHashID(lowScoreGrantorUserID),
+		"data.notifications.0.actions.0.data.grantee_user_id": trashid.MustEncodeHashID(recipientUserID),
+	})
+}
+
 func TestV1Notifications_UnlistedTrack(t *testing.T) {
 	app := emptyTestApp(t)
 


### PR DESCRIPTION
## Summary
- allow private manager request notification types to bypass the aggregate-user score cutoff while still requiring the referenced user to be current and active
- add a regression test for request_manager notifications from low-score grantor accounts

## Prod evidence
- pending grant exists for @ray62926 -> @rayjacobson at block 120202429
- raw notification row exists for user id 1 with type request_manager
- /v1/notifications/7eP5n?types=request_manager currently returns empty because @ray62926 has aggregate_user.score = -111

## Tests
- go test ./api -run TestV1Notifications
- go test ./api