### PR TITLE
chore: bump go-openaudio ETL deactivation fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,8 +6,8 @@ require (
 	connectrpc.com/connect v1.18.1
 	github.com/AlecAivazis/survey/v2 v2.3.7
 	github.com/Doist/unfurlist v0.0.0-20250409100812-515f2735f8e5
-	github.com/OpenAudio/go-openaudio v1.5.1-0.20260629214354-ad45fd6ad456
-	github.com/OpenAudio/go-openaudio/pkg/etl v1.5.1-0.20260629214354-ad45fd6ad456
+	github.com/OpenAudio/go-openaudio v1.5.1-0.20260701053044-b75c8bb6f8c5
+	github.com/OpenAudio/go-openaudio/pkg/etl v1.5.1-0.20260701053044-b75c8bb6f8c5
 	github.com/aquasecurity/esquery v0.2.0
 	github.com/axiomhq/axiom-go v0.23.0
 	github.com/axiomhq/hyperloglog v0.2.5

--- a/go.sum
+++ b/go.sum
@@ -26,12 +26,16 @@ github.com/OpenAudio/go-openaudio v1.5.1-0.20260629182311-eb976ab7d10a h1:Rmk8Xr
 github.com/OpenAudio/go-openaudio v1.5.1-0.20260629182311-eb976ab7d10a/go.mod h1:lLRvUF5oWkxOyZx8rp/ecqxuMo3yzPvuvJbLSfvxguQ=
 github.com/OpenAudio/go-openaudio v1.5.1-0.20260629214354-ad45fd6ad456 h1:cyZrZPClM98kQbV2HCyJZHqEy+8Rp0e3CzSt98Qydb8=
 github.com/OpenAudio/go-openaudio v1.5.1-0.20260629214354-ad45fd6ad456/go.mod h1:lLRvUF5oWkxOyZx8rp/ecqxuMo3yzPvuvJbLSfvxguQ=
+github.com/OpenAudio/go-openaudio v1.5.1-0.20260701053044-b75c8bb6f8c5 h1:Xxf3vrnI8NhaT0FAcmt71NlNOfQhnwlXTmKgeFUuM1k=
+github.com/OpenAudio/go-openaudio v1.5.1-0.20260701053044-b75c8bb6f8c5/go.mod h1:lLRvUF5oWkxOyZx8rp/ecqxuMo3yzPvuvJbLSfvxguQ=
 github.com/OpenAudio/go-openaudio/pkg/etl v1.4.1-0.20260618012656-5aa118b67bc1 h1:DeKyFpz5BFelTSFRqSnu58RfDDwn38BCtYfBsoUg3gg=
 github.com/OpenAudio/go-openaudio/pkg/etl v1.4.1-0.20260618012656-5aa118b67bc1/go.mod h1:qOtZr4+Xkp/Zp+yM4axDcKdYF03+xA98PjhwjFQMGvg=
 github.com/OpenAudio/go-openaudio/pkg/etl v1.5.1-0.20260629182311-eb976ab7d10a h1:brZAgN0X5AWXgnoXywusHFCQ28H3lxIDNw4llsY89JQ=
 github.com/OpenAudio/go-openaudio/pkg/etl v1.5.1-0.20260629182311-eb976ab7d10a/go.mod h1:GOtIlg6gDySPB0ekNVP1SPrlky6EfIigP2MGZ9g+ih4=
 github.com/OpenAudio/go-openaudio/pkg/etl v1.5.1-0.20260629214354-ad45fd6ad456 h1:SLIEnfT7ah+w4Y+ORU9M2OZ2HV1HR3cSlXQBlJg5AGk=
 github.com/OpenAudio/go-openaudio/pkg/etl v1.5.1-0.20260629214354-ad45fd6ad456/go.mod h1:GOtIlg6gDySPB0ekNVP1SPrlky6EfIigP2MGZ9g+ih4=
+github.com/OpenAudio/go-openaudio/pkg/etl v1.5.1-0.20260701053044-b75c8bb6f8c5 h1:Sa9tQeYMTW41L0fhYB1HQdHKc2GdTuyVwHMjpHW/YTI=
+github.com/OpenAudio/go-openaudio/pkg/etl v1.5.1-0.20260701053044-b75c8bb6f8c5/go.mod h1:GOtIlg6gDySPB0ekNVP1SPrlky6EfIigP2MGZ9g+ih4=
 github.com/StackExchange/wmi v1.2.1 h1:VIkavFPXSjcnS+O8yTq7NI32k0R5Aj+v39y29VYDOSA=
 github.com/StackExchange/wmi v1.2.1/go.mod h1:rcmrprowKIVzvc+NUiLncP2uuArMWLCbu9SBzvHz7e8=
 github.com/VictoriaMetrics/fastcache v1.12.2 h1:N0y9ASrJ0F6h0QaC3o6uJb3NIZ9VKLjCM7NQbSmF7WI=


### PR DESCRIPTION
## Summary
- bump `github.com/OpenAudio/go-openaudio` to `v1.5.1-0.20260701053044-b75c8bb6f8c5`
- bump `github.com/OpenAudio/go-openaudio/pkg/etl` to the same merged commit
- consumes OpenAudio/go-openaudio#394 so API core-indexer gets the User Update `is_deactivated` materialization fix

## Test plan
- `docker compose up -d --wait db elasticsearch-test`
- `make test`
- reverted unrelated `sqlc generate` drift from `make test`, leaving only `go.mod`/`go.sum`
- `docker compose up -d --wait db elasticsearch-test`
- `go test -count=1 -cover ./...`
