### PR TITLE
fix: don't sign media links with an empty cid

### DIFF
--- a/api/dbv1/tracks.go
+++ b/api/dbv1/tracks.go
@@ -196,8 +196,13 @@ func (q *Queries) TracksKeyed(ctx context.Context, arg TracksParams) (map[int32]
 			}
 		}
 
+		// A track row can have empty cid columns (e.g. an upload-v2 row whose
+		// track_cid/orig_file_cid backfill never ran). Signing an empty cid
+		// produces a content-node URL that is guaranteed to 404, so leave the
+		// media link nil instead and let the endpoints report the track as
+		// unavailable.
 		var stream *MediaLink
-		if access.Stream {
+		if access.Stream && rawTrack.TrackCid.String != "" {
 			stream, err = mediaLink(rawTrack.TrackCid.String, rawTrack.TrackID, arg.MyID.(int32), id3Tags)
 			if err != nil {
 				return nil, err
@@ -210,9 +215,11 @@ func (q *Queries) TracksKeyed(ctx context.Context, arg TracksParams) (map[int32]
 			if cid == "" {
 				cid = rawTrack.TrackCid.String
 			}
-			download, err = mediaLink(cid, rawTrack.TrackID, arg.MyID.(int32), nil)
-			if err != nil {
-				return nil, err
+			if cid != "" {
+				download, err = mediaLink(cid, rawTrack.TrackID, arg.MyID.(int32), nil)
+				if err != nil {
+					return nil, err
+				}
 			}
 		}
 

--- a/api/testdata/track_fixtures.go
+++ b/api/testdata/track_fixtures.go
@@ -1,10 +1,10 @@
 package testdata
 
 var TrackFixtures = []map[string]any{
-	{"track_id": 100, "genre": "Electronic", "owner_id": 1, "title": "T1", "is_unlisted": "f", "is_downloadable": "t"},
+	{"track_id": 100, "genre": "Electronic", "owner_id": 1, "title": "T1", "is_unlisted": "f", "is_downloadable": "t", "track_cid": "QmT1TrackCid"},
 	{"track_id": 101, "genre": "Alternative", "owner_id": 1, "title": "T2", "is_unlisted": "f", "is_downloadable": "f"},
 	{"track_id": 102, "genre": "Alternative", "owner_id": 2, "title": "T3", "is_unlisted": "f", "is_downloadable": "f"},
-	{"track_id": 200, "genre": "Electronic", "owner_id": 2, "title": "Culca Canyon", "is_unlisted": "f", "is_downloadable": "f"},
+	{"track_id": 200, "genre": "Electronic", "owner_id": 2, "title": "Culca Canyon", "is_unlisted": "f", "is_downloadable": "f", "track_cid": "QmCulcaCanyonCid"},
 	{"track_id": 201, "genre": "Alternative", "owner_id": 2, "title": "Turkey Time DEMO", "is_unlisted": "t", "is_downloadable": "f"},
 	{"track_id": 202, "genre": "Alternative", "owner_id": 2, "title": "Turkey Time (live)", "is_unlisted": "f", "is_downloadable": "f"},
 	{"track_id": 300, "genre": "Electronic", "owner_id": 3, "title": "Follow Gated Download", "is_unlisted": "f",

--- a/api/v1_track_download_test.go
+++ b/api/v1_track_download_test.go
@@ -14,8 +14,37 @@ func TestGetTrackDownload(t *testing.T) {
 	req := httptest.NewRequest("GET", "/v1/tracks/eYZmn/download", nil)
 	res, err := app.Test(req, -1)
 	assert.NoError(t, err)
-	assert.Contains(t, res.Header.Get("Location"), "signature=%7B%22data%22%3A%22%7B%5C%22cid%5C%22%3A%5C%22%5C%22%2C%5C%22timestamp%5C%22%3")
+	assert.Contains(t, res.Header.Get("Location"), "tracks/cidstream/QmT1TrackCid")
+	assert.Contains(t, res.Header.Get("Location"), "signature=%7B%22data%22%3A%22%7B%5C%22cid%5C%22%3A%5C%22QmT1TrackCid%5C%22%2C%5C%22timestamp%5C%22%3")
 	assert.Contains(t, res.Header.Get("Location"), "filename=T1.mp3")
+}
+
+// A downloadable track whose row has no orig_file_cid or track_cid (e.g. an
+// upload-v2 row that never got its cid backfill) must 404 rather than
+// redirect to a signed URL with an empty cid, which content nodes reject.
+func TestGetTrackDownload_NoCid(t *testing.T) {
+	app := emptyTestApp(t)
+	fixtures := database.FixtureMap{
+		"tracks": []map[string]any{
+			{
+				"track_id":        1,
+				"owner_id":        1,
+				"title":           "No Cid",
+				"is_downloadable": true,
+			},
+		},
+		"users": []map[string]any{
+			{
+				"user_id": 1,
+				"handle":  "testuser1",
+			},
+		},
+	}
+	database.Seed(app.pool.Replicas[0], fixtures)
+	req := httptest.NewRequest("GET", "/v1/tracks/"+trashid.MustEncodeHashID(1)+"/download", nil)
+	res, err := app.Test(req, -1)
+	assert.NoError(t, err)
+	assert.Equal(t, 404, res.StatusCode)
 }
 
 func TestGetTrackDownload_Original(t *testing.T) {

--- a/api/v1_track_stream.go
+++ b/api/v1_track_stream.go
@@ -30,6 +30,11 @@ func (app *ApiServer) v1TrackStream(c *fiber.Ctx) error {
 	track := tracks[0]
 
 	if track.Access.Stream {
+		// Stream is nil when the track row has no cid to sign (e.g. an
+		// upload-v2 row that never got its track_cid backfilled).
+		if track.Stream == nil {
+			return fiber.NewError(fiber.StatusNotFound, "track audio is unavailable")
+		}
 		return app.redirectToStream(c, track.Stream)
 	}
 

--- a/api/v1_track_stream_test.go
+++ b/api/v1_track_stream_test.go
@@ -4,6 +4,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"api.audius.co/database"
+	"api.audius.co/trashid"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -19,6 +21,33 @@ func TestGetTrackStream(t *testing.T) {
 	assert.NotContains(t, location, "id3=true")
 	assert.NotContains(t, location, "id3_artist=")
 	assert.NotContains(t, location, "id3_title=")
+}
+
+// A streamable track whose row has no track_cid (e.g. an upload-v2 row that
+// never got its cid backfill) must 404 rather than redirect to a signed URL
+// with an empty cid, which content nodes reject.
+func TestGetTrackStream_NoCid(t *testing.T) {
+	app := emptyTestApp(t)
+	fixtures := database.FixtureMap{
+		"tracks": []map[string]any{
+			{
+				"track_id": 1,
+				"owner_id": 1,
+				"title":    "No Cid",
+			},
+		},
+		"users": []map[string]any{
+			{
+				"user_id": 1,
+				"handle":  "testuser1",
+			},
+		},
+	}
+	database.Seed(app.pool.Replicas[0], fixtures)
+	req := httptest.NewRequest("GET", "/v1/tracks/"+trashid.MustEncodeHashID(1)+"/stream", nil)
+	res, err := app.Test(req, -1)
+	assert.NoError(t, err)
+	assert.Equal(t, 404, res.StatusCode)
 }
 
 func TestGetTrackStreamWithID3(t *testing.T) {


### PR DESCRIPTION
## Problem

BURKO stems downloads were failing (incident 2026-07-16, ~20:22 UTC). The parent track `qJ0RAXE` (1960897973) has `track_cid = null` and `orig_file_cid = null` — an upload-v2 row whose cid backfill never ran (`audio_upload_id` is set and the mediorum upload record is complete). The Tracks hydrator signed whatever cid it was given, so `/v1/tracks/{id}/download` and `/stream` 302'd to `tracks/cidstream/` with an **empty cid** in the signed payload, which every validator node 404s. That fed the archiver a guaranteed-404 URL and also silently broke playback for such tracks.

## Fix

- `dbv1/tracks.go`: skip building the `stream`/`download` MediaLink when there is no cid to sign — the links are now `null` in track responses instead of pointing at a 404.
- `v1_track_stream.go`: nil-guard before `redirectToStream` (which would nil-deref in `tryFindWorkingUrl`); returns 404 "track audio is unavailable". `/download` already 404s on a nil link.
- Tests: fixture tracks 100/200 get a `track_cid` (previously every fixture signed an empty cid — `TestGetTrackDownload` was asserting the buggy URL); new `TestGetTrackDownload_NoCid` and `TestGetTrackStream_NoCid` cover the empty-cid → 404 behavior.

Full `go test ./api/...` passes.

## Related

- pedalboard#75 (already deployed) makes the archiver treat the parent track as best-effort, so stems archives survive a broken parent.
- Follow-up needed: backfill `track_cid`/`orig_file_cid` for track 1960897973 from its mediorum upload record (`1cc9774d05f78bf91272c59080246ef8`) — until then the track can't stream or download at all (this PR just makes the failure honest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)