### PR TITLE
chore: bump go-openaudio to pick up ETL stem fixes (OpenAudio/go-openaudio#421)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,8 +6,8 @@ require (
 	connectrpc.com/connect v1.18.1
 	github.com/AlecAivazis/survey/v2 v2.3.7
 	github.com/Doist/unfurlist v0.0.0-20250409100812-515f2735f8e5
-	github.com/OpenAudio/go-openaudio v1.7.2-0.20260716210752-b4a5ebe0698f
-	github.com/OpenAudio/go-openaudio/pkg/etl v1.6.2-0.20260716210752-b4a5ebe0698f
+	github.com/OpenAudio/go-openaudio v1.8.2-0.20260727214803-1d9f69772e87
+	github.com/OpenAudio/go-openaudio/pkg/etl v1.6.3-0.20260727214803-1d9f69772e87
 	github.com/aquasecurity/esquery v0.2.0
 	github.com/axiomhq/axiom-go v0.23.0
 	github.com/axiomhq/hyperloglog v0.2.5

--- a/go.sum
+++ b/go.sum
@@ -20,10 +20,10 @@ github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2 h1:+vx7roKuyA63n
 github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2/go.mod h1:HBCaDeC1lPdgDeDbhX8XFpy1jqjK0IBG8W5K+xYqA0w=
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5 h1:TngWCqHvy9oXAN6lEVMRuU21PR1EtLVZJmdB18Gu3Rw=
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5/go.mod h1:lmUJ/7eu/Q8D7ML55dXQrVaamCz2vxCfdQBasLZfHKk=
-github.com/OpenAudio/go-openaudio v1.7.2-0.20260716210752-b4a5ebe0698f h1:/PZxrTYuQLj5r5IxnBDAvnxnNHIEP99l+dzp/WfbN+Y=
-github.com/OpenAudio/go-openaudio v1.7.2-0.20260716210752-b4a5ebe0698f/go.mod h1:lLRvUF5oWkxOyZx8rp/ecqxuMo3yzPvuvJbLSfvxguQ=
-github.com/OpenAudio/go-openaudio/pkg/etl v1.6.2-0.20260716210752-b4a5ebe0698f h1:FJipvk68kC4jUzw6fNL5b7dGnvwjLXXX7ji4kwpZGcM=
-github.com/OpenAudio/go-openaudio/pkg/etl v1.6.2-0.20260716210752-b4a5ebe0698f/go.mod h1:fJwk0l/TUbbwT/sgYUqFu8ZYtvxS2ski/RWv6FhRMS4=
+github.com/OpenAudio/go-openaudio v1.8.2-0.20260727214803-1d9f69772e87 h1:HiLw4qrUkVWRADJjGsdHLlFMdJjhU5WCVNAfeKfww4s=
+github.com/OpenAudio/go-openaudio v1.8.2-0.20260727214803-1d9f69772e87/go.mod h1:lLRvUF5oWkxOyZx8rp/ecqxuMo3yzPvuvJbLSfvxguQ=
+github.com/OpenAudio/go-openaudio/pkg/etl v1.6.3-0.20260727214803-1d9f69772e87 h1:E3HoYAxTNrZ0x1H+PJ+sijy1yh3jMtnO6JTyZqWHJ9U=
+github.com/OpenAudio/go-openaudio/pkg/etl v1.6.3-0.20260727214803-1d9f69772e87/go.mod h1:6MIJhF06djJvPl6sfv3Vqp0f4IsyBsWPB4F+BsIamTc=
 github.com/StackExchange/wmi v1.2.1 h1:VIkavFPXSjcnS+O8yTq7NI32k0R5Aj+v39y29VYDOSA=
 github.com/StackExchange/wmi v1.2.1/go.mod h1:rcmrprowKIVzvc+NUiLncP2uuArMWLCbu9SBzvHz7e8=
 github.com/VictoriaMetrics/fastcache v1.12.2 h1:N0y9ASrJ0F6h0QaC3o6uJb3NIZ9VKLjCM7NQbSmF7WI=


### PR DESCRIPTION
Bumps both `github.com/OpenAudio/go-openaudio` and `.../pkg/etl` pins from `b4a5ebe` (2026-07-16) to `1d9f697` — the merge of **OpenAudio/go-openaudio#421**, same flow as #994 did for the #410 CID fix.

## What the new pin brings (ETL / entity manager)

- Persist `orig_filename` on track create/update (never-clear, like the CIDs) — new stem rows no longer rely on the `/stems` endpoint's title fallback
- Ignore explicit `"stem_of": null` on track updates so client edits can't unlink a stem from its parent (#410 failure class)
- Upsert the `stems` join row when an update carries `stem_of` (on-chain repair path for lost links)

Intervening upstream commits also included (library-only for api): mediorum transcode/retry fixes (#338, #417–#419) and core/logging spam guards (#420). Nothing release- or mainnet-config-related.

## Relation to #995

#995 is the unblocking change (endpoint tolerates NULLs already in the DB); this bump prevents recurrence at the write path. Both trace back to the July stems-invisible incident (Andrew Lux's "Alone" remix contest).

Verified locally: `go build ./...`, stems endpoint tests, and `go test ./indexer/...` all pass on the new pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)