### PR TITLE
Reduce API read-replica recovery conflict storms

### DIFF
--- a/api/dbv1/db_replicas.go
+++ b/api/dbv1/db_replicas.go
@@ -19,14 +19,17 @@ type DBPools struct {
 
 // NewDBPools creates a new DBPools struct from a list of database connection strings.
 // It parses each connection string, configures SQL logging if not in test environment,
-// and creates connection pools for each replica.
-func NewDBPools(connectionStrings []string, logger *zap.Logger, env string, zapLevel zapcore.Level) (*DBPools, error) {
+// applies an optional per-replica connection limit, and creates connection pools.
+func NewDBPools(connectionStrings []string, maxConns int32, logger *zap.Logger, env string, zapLevel zapcore.Level) (*DBPools, error) {
 	var pools []*pgxpool.Pool
 
 	for _, connStr := range connectionStrings {
 		connConfig, err := pgxpool.ParseConfig(connStr)
 		if err != nil {
 			return nil, err
+		}
+		if maxConns > 0 {
+			connConfig.MaxConns = maxConns
 		}
 
 		// Configure SQL logging if not in test environment

--- a/api/dbv1/db_replicas_test.go
+++ b/api/dbv1/db_replicas_test.go
@@ -14,7 +14,7 @@ func TestNewDBPools(t *testing.T) {
 	logger := zap.NewNop()
 
 	// Test with empty connection strings
-	pools, err := NewDBPools([]string{}, logger, "test", zapcore.InfoLevel)
+	pools, err := NewDBPools([]string{}, 0, logger, "test", zapcore.InfoLevel)
 	if err != nil {
 		t.Fatalf("Expected no error for empty connection strings, got: %v", err)
 	}
@@ -23,9 +23,24 @@ func TestNewDBPools(t *testing.T) {
 	}
 
 	// Test with invalid connection string
-	_, err = NewDBPools([]string{"invalid://connection"}, logger, "test", zapcore.InfoLevel)
+	_, err = NewDBPools([]string{"invalid://connection"}, 0, logger, "test", zapcore.InfoLevel)
 	if err == nil {
 		t.Error("Expected error for invalid connection string, got nil")
+	}
+
+	pools, err = NewDBPools(
+		[]string{"postgresql://user:password@localhost/database"},
+		8,
+		logger,
+		"test",
+		zapcore.InfoLevel,
+	)
+	if err != nil {
+		t.Fatalf("Expected no error for valid connection string, got: %v", err)
+	}
+	defer pools.Close()
+	if got := pools.Replicas[0].Config().MaxConns; got != 8 {
+		t.Errorf("Expected max connections to be 8, got %d", got)
 	}
 }
 

--- a/api/server.go
+++ b/api/server.go
@@ -72,7 +72,7 @@ func NewApiServer(config config.Config) *ApiServer {
 		connectionStrings = []string{config.ReadDbUrl}
 	}
 
-	pool, err := dbv1.NewDBPools(connectionStrings, logger, config.Env, config.ZapLevel)
+	pool, err := dbv1.NewDBPools(connectionStrings, config.ReadDbMaxConns, logger, config.Env, config.ZapLevel)
 	if err != nil {
 		logger.Fatal("read db connect failed", zap.Error(err))
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -20,6 +20,7 @@ type Config struct {
 	ZapLevel                       zapcore.Level
 	ReadDbUrl                      string
 	ReadDbReplicas                 []string
+	ReadDbMaxConns                 int32
 	WriteDbUrl                     string
 	RunMigrations                  bool
 	EsUrl                          string
@@ -54,15 +55,15 @@ type Config struct {
 	// Audius DelegateManager address — used to read
 	// getTotalDelegatorStake(holder).
 	EthDelegateManagerContractAddress string
-	SolanaIndexerWorkers         int
-	SolanaIndexerRetryInterval   time.Duration
-	CommsMessagePush             bool
-	AudiusdChainID               uint
-	AudiusdEntityManagerAddress  string
-	AudiusAppUrl                 string
-	RewardCodeAuthorizedKeys     []string
-	LaunchpadDeterministicSecret string
-	UnsplashKeys                 []string
+	SolanaIndexerWorkers              int
+	SolanaIndexerRetryInterval        time.Duration
+	CommsMessagePush                  bool
+	AudiusdChainID                    uint
+	AudiusdEntityManagerAddress       string
+	AudiusAppUrl                      string
+	RewardCodeAuthorizedKeys          []string
+	LaunchpadDeterministicSecret      string
+	UnsplashKeys                      []string
 	// Nodes that volunteer as STORE_ALL nodes and are always included in mirrors lists
 	StoreAllNodes []string
 	// Nodes that are truly dead and should not be included in rendezvous
@@ -102,6 +103,7 @@ var Cfg = Config{
 	LogLevel:                              os.Getenv("logLevel"),
 	ReadDbUrl:                             os.Getenv("readDbUrl"),
 	ReadDbReplicas:                        strings.Split(os.Getenv("readDbReplicas"), ","),
+	ReadDbMaxConns:                        8,
 	WriteDbUrl:                            os.Getenv("writeDbUrl"),
 	RunMigrations:                         os.Getenv("runMigrations") == "true",
 	EsUrl:                                 os.Getenv("elasticsearchUrl"),
@@ -309,6 +311,14 @@ func init() {
 			log.Fatalf("Invalid commsMessagePush: %s", err)
 		}
 		Cfg.CommsMessagePush = commsMessagePushEnabled
+	}
+
+	if v := os.Getenv("readDbMaxConns"); v != "" {
+		parsed, err := strconv.ParseInt(v, 10, 32)
+		if err != nil || parsed <= 0 {
+			log.Fatalf("Invalid readDbMaxConns %q: must be a positive integer", v)
+		}
+		Cfg.ReadDbMaxConns = int32(parsed)
 	}
 
 	// Solana indexer config

--- a/ddl/migrations/0233_comments_track_entity_created_at_idx.sql
+++ b/ddl/migrations/0233_comments_track_entity_created_at_idx.sql
@@ -1,0 +1,15 @@
+-- Supports track comment listing and counts:
+--
+--   WHERE entity_id = ?
+--     AND entity_type = 'Track'
+--     AND is_delete = false
+--   ORDER BY created_at DESC
+--
+-- These endpoints otherwise scan the full comments table for each track. The
+-- included columns cover the comment fields used before moderation joins and
+-- keep this partial index small enough for the serving read path.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS comments_track_entity_created_at_idx
+    ON public.comments USING btree (entity_id, created_at DESC)
+    INCLUDE (comment_id, user_id)
+    WHERE entity_type = 'Track'
+      AND is_delete = false;

--- a/indexer/aggregates_calculator.go
+++ b/indexer/aggregates_calculator.go
@@ -24,7 +24,7 @@ const aggregateScoreUpdateInterval = 10 * time.Minute
 
 func NewAggregatesCalculator(config config.Config) *AggregatesCalculator {
 	logger := logging.NewZapLogger(config).Named("AggregatesCalculator")
-	readPool, err := dbv1.NewDBPools([]string{config.ReadDbUrl}, logger, config.Env, config.ZapLevel)
+	readPool, err := dbv1.NewDBPools([]string{config.ReadDbUrl}, config.ReadDbMaxConns, logger, config.Env, config.ZapLevel)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
## Summary

- cap each read-replica pool at 8 connections by default, configurable with `readDbMaxConns`
- add a concurrent partial covering index for track comment list and count reads

## Why

The [production latency monitor](https://app.axiom.co/audius-Lu52/monitors/view/4i6SXp0yw4TURA09FW) is flapping because the sole read replica cancels waves of queries with:

```
canceling statement due to conflict with recovery (SQLSTATE 40001)
```

An Axiom query for 2026-08-03 15:42 UTC found 156 recovery-conflict cancellations in one minute. The corresponding 500s affected unrelated routes, which points to shared replica pressure rather than an individual handler. Track comment reads were the largest visible amplifier in that window:

- `/v1/tracks/:trackId/comment_count`: 54 errors
- `/v1/tracks/:trackId/comments`: 38 errors
- all other routes combined: 64 errors

Production currently has three bridge pods and one four-vCPU read replica. Without an explicit limit, pgx sizes each pool from the 16 CPUs visible to the pod, allowing up to 48 concurrent request reads. This change halves that connection budget to 24 while retaining an environment override.

The comments table has no index beginning with `entity_id`, so both high-volume track comment routes scan the table before their moderation joins. The new partial index supports both the filter and the default timestamp order without blocking writes during creation.

## Validation

- `go test ./api/dbv1 -run 'Test(NewDBPools|ChooseReplica|DBPoolsProxyMethods)$' -count=1`
- `go test ./config -count=1`
- `go test ./indexer -run '^$' -count=1`
- `go test ./api -run '^$' -count=1`
- applied the migration twice against the checked-in schema to verify idempotency
- verified PostgreSQL selects the new index for track comment list and count predicates

## Rollout

The connection cap can be changed without another code change by setting `readDbMaxConns`. Pool wait time and replica CPU should be watched during rollout. The expected tradeoff is bounded application-side queuing instead of allowing enough concurrent work to saturate the replica and trigger a recovery-conflict wave.

## Non-goals

This PR does not change standby feedback, statement timeouts, query retry behavior, replica capacity, or Kubernetes resources. Those have broader operational tradeoffs and should be reviewed separately.
