### PR TITLE
fix(coins): drop totalVolumeUSD from /v1/coins response and spec

### DIFF
--- a/api/swagger/swagger-v1.yaml
+++ b/api/swagger/swagger-v1.yaml
@@ -11829,9 +11829,6 @@ components:
         marketCap:
           type: number
           description: Market capitalization in USD
-        totalVolumeUSD:
-          type: number
-          description: Total volume traded in USD (all time)
         holder:
           type: integer
           description: Number of holders

--- a/api/v1_coins.go
+++ b/api/v1_coins.go
@@ -67,7 +67,6 @@ type ArtistCoin struct {
 	VSell24hChangePercent        float64 `json:"vSell24hChangePercent" db:"v_sell_24h_change_percent"`
 	NumberMarkets                int     `json:"numberMarkets" db:"number_markets"`
 	TotalVolume                  float64 `json:"totalVolume" db:"total_volume"`
-	TotalVolumeUSD               float64 `json:"totalVolumeUSD" db:"total_volume_usd"`
 	VolumeBuyUSD                 float64 `json:"volumeBuyUSD" db:"volume_buy_usd"`
 	VolumeSellUSD                float64 `json:"volumeSellUSD" db:"volume_sell_usd"`
 	VolumeBuy                    float64 `json:"volumeBuy" db:"volume_buy"`
@@ -162,7 +161,6 @@ const sharedSelectCoinSql = `
 			COALESCE(artist_coin_stats.v_sell_24h_change_percent, 0) as v_sell_24h_change_percent,
 			COALESCE(artist_coin_stats.number_markets, 0) as number_markets,
 			COALESCE(artist_coin_stats.total_volume, 0) as total_volume,
-			COALESCE(artist_coin_stats.total_volume_usd, 0) as total_volume_usd,
 			COALESCE(artist_coin_stats.volume_buy, 0) as volume_buy,
 			COALESCE(artist_coin_stats.volume_buy_usd, 0) as volume_buy_usd,
 			COALESCE(artist_coin_stats.volume_sell, 0) as volume_sell,


### PR DESCRIPTION
## What
Removes `totalVolumeUSD` from the `/v1/coins` response — the Go `coin` response struct field, its `SELECT` column, and the `coin` schema in the embedded swagger.

## Why
The all-time volume stat was removed from the product (AudiusProject/apps#14542) as an unverifiable figure no other aggregator reports. Stop returning a value we don't stand behind.

## Notes
- **Breaking change** to the public `/v1/coins` response. Because the SDK is generated from the live `/v1/swagger.yaml`, the **generated `Coin` model must be regenerated after this deploys** (separate SDK PR).
- The `artist_coin_stats.total_volume_usd` column is untouched (still written by the Birdeye `CoinStatsJob`), so the existing `volume` sort still functions — it orders by the joined column.
- `coin_insights` still exposes the field: its handler uses `SELECT artist_coin_stats.*` + `RowToStructByName`, so removing it there means dropping/renaming the column or changing the query, and the column is still populated by Birdeye. Left for a separate change once `CoinStatsJob` is retired.

## Test
`go build ./api/...` and `go test -run Coins ./api/` pass; swagger validates as YAML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)