### PR TITLE
fix(ddl): backfill album saves and reposts to playlist

### DIFF
--- a/ddl/migrations/0236_saves_reposts_album_to_playlist.sql
+++ b/ddl/migrations/0236_saves_reposts_album_to_playlist.sql
@@ -1,0 +1,57 @@
+-- Collapse save_type / repost_type 'album' back into 'playlist'.
+--
+-- An album is a playlist with is_album = true. The indexer briefly derived a
+-- separate 'album' type by reading playlists.is_album at index time; it was
+-- introduced as a side effect of a fix for entity-id collisions (the real bug
+-- there was falling through to track inference when the chain said "Playlist")
+-- and went live on 2026-05-28. The indexer no longer does this. Two problems
+-- with the derived value:
+--
+--   * is_album is mutable, but save_type is written once and is part of the
+--     saves / reposts primary key. Replaying the same chain history at a
+--     different time therefore produced different rows.
+--   * handle_save / handle_repost build the notification group_id from the
+--     type ('save:<id>:type:<save_type>'), so the same favourite could notify
+--     twice under two different group_ids.
+--
+-- Nothing reads the distinction: every consumer is track / not-track, or ORs
+-- the two together (get_account_playlists, reconcile_aggregates). Callers that
+-- need to know read playlists.is_album at query time, which is what the
+-- notification triggers already do.
+--
+-- Affected rows at time of writing: 670 saves, 528 reposts. There are no
+-- primary-key collisions — no (user_id, item_id, txhash) has both a 'playlist'
+-- and an 'album' row — so this is a straight UPDATE.
+--
+-- on_save / on_repost are disabled for the backfill so it does not emit a
+-- second round of favourite/repost notifications or re-run milestone checks.
+-- Aggregate counts are unaffected either way: handle_save's delta is
+-- transition-aware and evaluates to 0 when is_delete does not change.
+-- trg_saves / trg_reposts stay enabled so the search indexer still sees the
+-- rows change.
+--
+-- Each table gets its own transaction to keep the ACCESS EXCLUSIVE lock taken
+-- by ALTER TABLE ... DISABLE TRIGGER as short as possible. Re-running is a
+-- no-op once no 'album' rows remain.
+--
+-- The 'album' label is deliberately left in the savetype / reposttype enums:
+-- Postgres cannot drop an enum value without rebuilding the type, and the
+-- indexer no longer writes it.
+
+BEGIN;
+SET LOCAL lock_timeout = '5s';
+
+ALTER TABLE saves DISABLE TRIGGER on_save;
+UPDATE saves SET save_type = 'playlist' WHERE save_type = 'album';
+ALTER TABLE saves ENABLE TRIGGER on_save;
+
+COMMIT;
+
+BEGIN;
+SET LOCAL lock_timeout = '5s';
+
+ALTER TABLE reposts DISABLE TRIGGER on_repost;
+UPDATE reposts SET repost_type = 'playlist' WHERE repost_type = 'album';
+ALTER TABLE reposts ENABLE TRIGGER on_repost;
+
+COMMIT;


### PR DESCRIPTION
## What

Collapses `save_type` / `repost_type` `'album'` back into `'playlist'` — **670 saves and 528 reposts**.

Pairs with **OpenAudio/go-openaudio#428**, which stops the indexer writing `'album'`. **These ship together**: this backfill alone would be re-broken by the current indexer.

## Why

An album is a playlist with `is_album = true`. The indexer briefly derived a separate `'album'` type by reading `playlists.is_album` at index time — a side effect of an entity-id collision fix, not a deliberate convention. It first appears in prod `saves` *and* `reposts` on the same day, 2026-05-28, after seven years with zero.

`is_album` is mutable, but `save_type` is written once and is part of the primary key `(user_id, save_item_id, save_type, txhash)` — so the same chain history indexed at different times produced different rows. Nothing reads the distinction: every consumer is `track` / `!= track`, or ORs the two together (`get_account_playlists`, `reconcile_aggregates`). The notification triggers already derive album from `is_album` at read time.

## Two hazards, and how they're handled

**Duplicate notifications.** `on_save` / `on_repost` fire on `AFTER INSERT OR UPDATE`, and the notification `group_id` embeds the type (`'save:<id>:type:<save_type>'`). A plain UPDATE would mint a *second* favourite notification per row under a new group_id. Those two triggers are disabled for the backfill; `trg_saves` / `trg_reposts` (the `pg_notify` → search indexer) stay enabled so ES still sees the change.

**Primary key.** The type is part of the PK. Verified against prod data that **no** `(user_id, item_id, txhash)` has both a `'playlist'` and an `'album'` row, so this is a straight UPDATE with no conflict handling.

Aggregate counts are unaffected either way — `handle_save`'s `delta` is transition-aware and evaluates to `0` when `is_delete` does not change.

## Verification

Applied against a fixture mirroring the real wiring (enums, 4-column PK, all four triggers):

- all `album` → `playlist`; `track` untouched
- **0** `on_save` / `on_repost` firings
- `pg_notify` fired exactly once per updated row
- a row that had *both* a `playlist` and an `album` version kept both (different `txhash`)
- all triggers re-enabled (`tgenabled = 'O'`) afterwards

⚠️ Not run against a real database. The repo's migration set can't be built from scratch locally (it assumes base tables created outside this repo), so the fixture covers the mechanism rather than the full schema.

## Notes

- Each table gets its own transaction with `lock_timeout` to keep the `ACCESS EXCLUSIVE` lock from `ALTER TABLE ... DISABLE TRIGGER` as short as possible. ~1.2k rows, so it should be milliseconds.
- Re-running is a no-op once no `'album'` rows remain.
- `'album'` is deliberately left in the `savetype` / `reposttype` enums — Postgres can't drop an enum value without rebuilding the type, and the indexer no longer writes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)