### PR TITLE
deps: pin pkg/etl v1.6.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/AlecAivazis/survey/v2 v2.3.7
 	github.com/Doist/unfurlist v0.0.0-20250409100812-515f2735f8e5
 	github.com/OpenAudio/go-openaudio v1.8.2-0.20260727214803-1d9f69772e87
-	github.com/OpenAudio/go-openaudio/pkg/etl v1.6.3-0.20260727214803-1d9f69772e87
+	github.com/OpenAudio/go-openaudio/pkg/etl v1.6.3
 	github.com/aquasecurity/esquery v0.2.0
 	github.com/axiomhq/axiom-go v0.23.0
 	github.com/axiomhq/hyperloglog v0.2.5
@@ -45,6 +45,7 @@ require (
 	github.com/urfave/cli/v3 v3.5.0
 	go.uber.org/zap v1.27.0
 	golang.org/x/crypto v0.48.0
+	golang.org/x/net v0.50.0
 	golang.org/x/sync v0.19.0
 	google.golang.org/grpc v1.71.1
 	google.golang.org/protobuf v1.36.11
@@ -219,7 +220,6 @@ require (
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/ratelimit v0.2.0 // indirect
 	golang.org/x/exp v0.0.0-20250408133849-7e4ce0ab07d0 // indirect
-	golang.org/x/net v0.50.0 // indirect
 	golang.org/x/sys v0.41.0 // indirect
 	golang.org/x/term v0.40.0 // indirect
 	golang.org/x/text v0.34.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5 h1:TngWCqHvy9oXAN6lEV
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5/go.mod h1:lmUJ/7eu/Q8D7ML55dXQrVaamCz2vxCfdQBasLZfHKk=
 github.com/OpenAudio/go-openaudio v1.8.2-0.20260727214803-1d9f69772e87 h1:HiLw4qrUkVWRADJjGsdHLlFMdJjhU5WCVNAfeKfww4s=
 github.com/OpenAudio/go-openaudio v1.8.2-0.20260727214803-1d9f69772e87/go.mod h1:lLRvUF5oWkxOyZx8rp/ecqxuMo3yzPvuvJbLSfvxguQ=
-github.com/OpenAudio/go-openaudio/pkg/etl v1.6.3-0.20260727214803-1d9f69772e87 h1:E3HoYAxTNrZ0x1H+PJ+sijy1yh3jMtnO6JTyZqWHJ9U=
-github.com/OpenAudio/go-openaudio/pkg/etl v1.6.3-0.20260727214803-1d9f69772e87/go.mod h1:6MIJhF06djJvPl6sfv3Vqp0f4IsyBsWPB4F+BsIamTc=
+github.com/OpenAudio/go-openaudio/pkg/etl v1.6.3 h1:s18nVxVRM1QW8mDmey7HKWI3/e7OrmnQrtd3o1OJLfs=
+github.com/OpenAudio/go-openaudio/pkg/etl v1.6.3/go.mod h1:iSy5fh/o7m7F/tUQ26ezbKTBJ8HjZz37eJrV+A2362U=
 github.com/StackExchange/wmi v1.2.1 h1:VIkavFPXSjcnS+O8yTq7NI32k0R5Aj+v39y29VYDOSA=
 github.com/StackExchange/wmi v1.2.1/go.mod h1:rcmrprowKIVzvc+NUiLncP2uuArMWLCbu9SBzvHz7e8=
 github.com/VictoriaMetrics/fastcache v1.12.2 h1:N0y9ASrJ0F6h0QaC3o6uJb3NIZ9VKLjCM7NQbSmF7WI=

--- a/indexer/indexer.go
+++ b/indexer/indexer.go
@@ -53,12 +53,19 @@ func NewIndexer(cfg config.Config) *CoreIndexer {
 	aggregatesCalculator := NewAggregatesCalculator(cfg)
 
 	// ETL needs the Connect/gRPC Core client (for block fetching) and a DB URL.
-	// SkipMigrations stays false (default): ETL's migrations are idempotent
-	// against api/'s schema — every migration uses CREATE TABLE IF NOT EXISTS /
-	// ADD COLUMN IF NOT EXISTS, and tracks state in its own `etl_db_migrations`
-	// table separate from api/'s `schema_version`. Verified by applying all 21
-	// current ETL migrations to a fresh DB seeded with api/'s schema: zero
-	// errors, only NOTICE messages for already-existing relations.
+	// SkipMigrations stays false (default), so bumping the pkg/etl module runs
+	// whatever migrations it brought with it against api/'s database, on the
+	// next indexer start. They track state in their own `etl_db_migrations`
+	// table, separate from api/'s `schema_version`, and only up-migrations run
+	// (RunDownMigrations is left false).
+	//
+	// That was originally justified by the migrations being purely additive —
+	// CREATE TABLE IF NOT EXISTS / ADD COLUMN IF NOT EXISTS, verified against a
+	// fresh DB seeded with api/'s schema. 0035 is the first one that is not: it
+	// deletes duplicate is_current rows from users before adding a unique index
+	// over them. Still idempotent, and intended to run here — but a pkg/etl bump
+	// is now a thing that can modify production data, so read the migrations a
+	// version brings before bumping.
 	//
 	// Two optional ETL components are disabled here because they don't fit
 	// api/'s deployment:


### PR DESCRIPTION
> [!IMPORTANT]
> **Blocked: repin to `v1.6.4` before merging.**
>
> `v1.6.3` still contains the delete-and-index version of ETL migration `0035`, so merging this as-is would ship a data-deleting ETL migration to production — the exact thing OpenAudio/go-openaudio#433 exists to prevent. The pre-roll backfill (#1010) would make that delete a no-op, but a `go get` still should not be able to remove rows at all.
>
> Sequence:
> 1. merge OpenAudio/go-openaudio#433 (and #429 / #431 if ready)
> 2. merge the resulting `chore(pkg/etl): release 1.6.4` PR
> 3. repin this PR to `v1.6.4`
> 4. merge alongside #1010

Moves off the 2026-07-27 pseudo-version onto the real tag.

```diff
-github.com/OpenAudio/go-openaudio/pkg/etl v1.6.3-0.20260727214803-1d9f69772e87
+github.com/OpenAudio/go-openaudio/pkg/etl v1.6.3
```

Both changes it brings are `pkg/etl`-only, so the root module pin is untouched. (`golang.org/x/net` moves between the direct and indirect blocks — same version, a `go mod tidy` reclassification.)

## What it brings

**OpenAudio/go-openaudio#428** — album saves/reposts record `save_type`/`repost_type` as `'playlist'` instead of deriving `'album'` from the mutable `playlists.is_album` at index time. Pairs with #1008, which backfills the 670 saves and 528 reposts already written as `'album'`.

**OpenAudio/go-openaudio#425** — one current row per user is enforced, and genesis-writer's fifteen `DISTINCT ON` dedupe subqueries collapse to plain joins.

## ⚠️ This bump modifies production data

`SkipMigrations` is left `false`, so bumping the module runs the migrations it brought against api's database on the next **indexer** start (`etl_db_migrations`, separate from `schema_version`; up-migrations only).

Until now that was benign — every ETL migration was additive `IF NOT EXISTS` DDL, and the comment at the call site said so. **`0035` is the first that is not**: it deletes duplicate `is_current` rows from `users` before adding a unique index over them (5 rows on a production clone of 3.15M). Still idempotent, and this is intended — it is why **no separate api migration is needed** to purge the duplicates — but the comment is now corrected to say a `pkg/etl` bump can modify production data.

`0035` builds a unique index on `users` non-concurrently (golang-migrate wraps each migration in a transaction), so expect a brief lock on `users` at the next indexer start.

## Ordering with #1008

**Merge this before or with #1008.** #1008 backfills `album` → `playlist`; if the old indexer is still deployed it re-derives `album` and undoes the backfill. The reverse order is fine — this bump alone just stops new `album` rows being written.

The two touch different tables (`0035`: users, `0236`: saves/reposts) and run from different processes (indexer start vs api server start), so there is no interaction between them.

## Verified

- `go build ./...` and `go vet ./indexer/` clean.
- Resolved module contains the fix (`resolveSaveType` no longer reads `is_album`) and ships `0035_users_one_current_row.{up,down}.sql`.
- `pkg/etl/v1.6.3` contains both #425 and #428 (checked by ancestry, not by changelog).

## Unrelated oddity spotted

`pkg/etl/go.mod` declares `require github.com/OpenAudio/go-openaudio v1.6.3 // x-release-please-version` — release-please rewrites that line with the **pkg/etl** version, so it points at an unrelated old root release. MVS resolves upward to our root pin so nothing breaks, but the declared requirement is meaningless. Worth fixing upstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
