### PR TITLE
deps: pin pkg/etl v1.6.4 and backfill users + save/repost types

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,8 +41,8 @@ apidiff::
 	open http://localhost:1323/apidiff.html
 
 test-schema::
-	@set -a; \
-	writeDbUrl=postgresql://postgres:example@localhost:21300/postgres; \
+	@set -a -e; \
+	writeDbUrl='postgresql://postgres:example@localhost:21300/postgres?sslmode=disable'; \
 	echo "\033[0;32mBringing down any existing containers to start fresh...\033[0m"; \
 	docker compose down --volumes; \
 	docker compose up -d --wait; \

--- a/ddl/migrations/0236_saves_reposts_album_to_playlist.sql
+++ b/ddl/migrations/0236_saves_reposts_album_to_playlist.sql
@@ -1,0 +1,57 @@
+-- Collapse save_type / repost_type 'album' back into 'playlist'.
+--
+-- An album is a playlist with is_album = true. The indexer briefly derived a
+-- separate 'album' type by reading playlists.is_album at index time; it was
+-- introduced as a side effect of a fix for entity-id collisions (the real bug
+-- there was falling through to track inference when the chain said "Playlist")
+-- and went live on 2026-05-28. The indexer no longer does this. Two problems
+-- with the derived value:
+--
+--   * is_album is mutable, but save_type is written once and is part of the
+--     saves / reposts primary key. Replaying the same chain history at a
+--     different time therefore produced different rows.
+--   * handle_save / handle_repost build the notification group_id from the
+--     type ('save:<id>:type:<save_type>'), so the same favourite could notify
+--     twice under two different group_ids.
+--
+-- Nothing reads the distinction: every consumer is track / not-track, or ORs
+-- the two together (get_account_playlists, reconcile_aggregates). Callers that
+-- need to know read playlists.is_album at query time, which is what the
+-- notification triggers already do.
+--
+-- Affected rows at time of writing: 670 saves, 528 reposts. There are no
+-- primary-key collisions — no (user_id, item_id, txhash) has both a 'playlist'
+-- and an 'album' row — so this is a straight UPDATE.
+--
+-- on_save / on_repost are disabled for the backfill so it does not emit a
+-- second round of favourite/repost notifications or re-run milestone checks.
+-- Aggregate counts are unaffected either way: handle_save's delta is
+-- transition-aware and evaluates to 0 when is_delete does not change.
+-- trg_saves / trg_reposts stay enabled so the search indexer still sees the
+-- rows change.
+--
+-- Each table gets its own transaction to keep the ACCESS EXCLUSIVE lock taken
+-- by ALTER TABLE ... DISABLE TRIGGER as short as possible. Re-running is a
+-- no-op once no 'album' rows remain.
+--
+-- The 'album' label is deliberately left in the savetype / reposttype enums:
+-- Postgres cannot drop an enum value without rebuilding the type, and the
+-- indexer no longer writes it.
+
+BEGIN;
+SET LOCAL lock_timeout = '5s';
+
+ALTER TABLE saves DISABLE TRIGGER on_save;
+UPDATE saves SET save_type = 'playlist' WHERE save_type = 'album';
+ALTER TABLE saves ENABLE TRIGGER on_save;
+
+COMMIT;
+
+BEGIN;
+SET LOCAL lock_timeout = '5s';
+
+ALTER TABLE reposts DISABLE TRIGGER on_repost;
+UPDATE reposts SET repost_type = 'playlist' WHERE repost_type = 'album';
+ALTER TABLE reposts ENABLE TRIGGER on_repost;
+
+COMMIT;

--- a/ddl/migrations/0236_saves_reposts_album_to_playlist.sql
+++ b/ddl/migrations/0236_saves_reposts_album_to_playlist.sql
@@ -1,57 +1,164 @@
 -- Collapse save_type / repost_type 'album' back into 'playlist'.
 --
 -- An album is a playlist with is_album = true. The indexer briefly derived a
--- separate 'album' type by reading playlists.is_album at index time; it was
--- introduced as a side effect of a fix for entity-id collisions (the real bug
--- there was falling through to track inference when the chain said "Playlist")
--- and went live on 2026-05-28. The indexer no longer does this. Two problems
--- with the derived value:
+-- separate 'album' type by reading playlists.is_album at index time — a side
+-- effect of a fix for entity-id collisions, live from 2026-05-28. It no longer
+-- does (OpenAudio/go-openaudio#428). is_album is mutable while save_type is
+-- written once, so the same chain history indexed at different times produced
+-- different rows. Nothing reads the distinction: every consumer is
+-- track / not-track, or ORs the two together.
 --
---   * is_album is mutable, but save_type is written once and is part of the
---     saves / reposts primary key. Replaying the same chain history at a
---     different time therefore produced different rows.
---   * handle_save / handle_repost build the notification group_id from the
---     type ('save:<id>:type:<save_type>'), so the same favourite could notify
---     twice under two different group_ids.
+-- THE BINDING CONSTRAINT IS NOT THE PRIMARY KEY. saves_pkey is
+-- (user_id, save_item_id, save_type, txhash) and no two rows collide on it. But
+-- pkg/etl migration 0030 also added
 --
--- Nothing reads the distinction: every consumer is track / not-track, or ORs
--- the two together (get_account_playlists, reconcile_aggregates). Callers that
--- need to know read playlists.is_album at query time, which is what the
--- notification triggers already do.
+--   saves_current_uniq_idx    ON saves   (user_id, save_item_id, save_type)     WHERE is_current
+--   reposts_current_uniq_idx  ON reposts (user_id, repost_item_id, repost_type) WHERE is_current
 --
--- Affected rows at time of writing: 670 saves, 528 reposts. There are no
--- primary-key collisions — no (user_id, item_id, txhash) has both a 'playlist'
--- and an 'album' row — so this is a straight UPDATE.
+-- which carry no txhash. Two current rows for the same (user, item) are legal
+-- today precisely because one is 'album' and one is 'playlist'; collapsing the
+-- type makes them duplicates. A blind UPDATE therefore aborts with
 --
--- on_save / on_repost are disabled for the backfill so it does not emit a
--- second round of favourite/repost notifications or re-run milestone checks.
--- Aggregate counts are unaffected either way: handle_save's delta is
--- transition-aware and evaluates to 0 when is_delete does not change.
--- trg_saves / trg_reposts stay enabled so the search indexer still sees the
--- rows change.
+--   duplicate key value violates unique constraint "saves_current_uniq_idx"
 --
--- Each table gets its own transaction to keep the ACCESS EXCLUSIVE lock taken
--- by ALTER TABLE ... DISABLE TRIGGER as short as possible. Re-running is a
--- no-op once no 'album' rows remain.
+-- taking the whole pre-roll migrate Job with it. 43 save pairs and 34 repost
+-- pairs collide this way, so the pairs are resolved first and the remainder
+-- retyped.
 --
--- The 'album' label is deliberately left in the savetype / reposttype enums:
--- Postgres cannot drop an enum value without rebuilding the type, and the
--- indexer no longer writes it.
+-- Winner is the highest blocknumber. Verified against a production clone that
+-- this is decidable wherever it matters: of the 43 save pairs, 38 agree on
+-- is_delete (either row would do) and 5 disagree — and in every disagreeing
+-- pair the blocknumbers differ, with the later row holding the correct state
+-- (e.g. user 9014 unfavourited item 613011280 in 2026; the newer row is the
+-- delete). Blocknumber ties occur only among pairs that agree, where the choice
+-- is immaterial: zero rows both disagree and tie. Reposts are the same shape —
+-- 33 agree, 1 disagrees, no tie coincides with a disagreement. The created_at /
+-- type tiebreaks below are therefore never load-bearing; they exist only to
+-- make the statement deterministic.
+--
+-- Losers are demoted, not deleted: unlike users these tables do keep superseded
+-- history (344 saves, 161 reposts on the clone), so is_current = false is the
+-- shape they already use.
+--
+-- Aggregates: this is a net correction. reconcile_aggregates counts these rows
+-- with count(*) and ORs both types, so every colliding pair has been
+-- double-counting aggregate_playlist.save_count / repost_count.
+--
+-- Triggers: on_save / on_repost are suppressed for the whole operation. Their
+-- notification group_id embeds the type ('save:<id>:type:<save_type>'), so both
+-- the demote and the retype would emit fresh favourite/repost notifications
+-- that ON CONFLICT could not dedupe against the existing ':type:album' rows.
+-- trg_saves / trg_reposts stay enabled so the search indexer sees the change.
+-- Aggregate counts are unaffected by the retype either way: handle_save's delta
+-- is transition-aware and evaluates to 0 when is_delete does not change.
+--
+-- ALTER TABLE ... DISABLE TRIGGER takes ShareRowExclusiveLock — it blocks
+-- concurrent writes but not reads, and is held until commit. Blocking writers
+-- is the property we want: they wait rather than silently running trigger-free.
+-- Each table gets its own transaction so the two locks are never held at once.
+--
+-- The DO blocks guard on the trigger existing: pg_migrate.sh applies
+-- migrations/ before functions/, so on a database bootstrapped from ddl/ alone
+-- these triggers do not exist yet.
+--
+-- Re-running is a no-op once no 'album' rows remain.
 
 BEGIN;
 SET LOCAL lock_timeout = '5s';
 
-ALTER TABLE saves DISABLE TRIGGER on_save;
-UPDATE saves SET save_type = 'playlist' WHERE save_type = 'album';
-ALTER TABLE saves ENABLE TRIGGER on_save;
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_trigger
+               WHERE tgrelid = 'saves'::regclass AND tgname = 'on_save' AND NOT tgisinternal) THEN
+        ALTER TABLE saves DISABLE TRIGGER on_save;
+    END IF;
+END $$;
+
+-- 1. demote the older row of each (user, item) pair holding both types
+WITH ranked AS (
+    SELECT
+        user_id, save_item_id, save_type, txhash,
+        row_number() OVER (
+            PARTITION BY user_id, save_item_id
+            ORDER BY blocknumber DESC NULLS LAST, created_at DESC NULLS LAST, save_type DESC
+        ) AS rn
+    FROM saves
+    WHERE is_current = true
+      AND save_type IN ('playlist', 'album')
+      AND (user_id, save_item_id) IN (
+          SELECT user_id, save_item_id FROM saves
+          WHERE is_current = true AND save_type IN ('playlist', 'album')
+          GROUP BY user_id, save_item_id
+          HAVING count(DISTINCT save_type) > 1
+      )
+)
+UPDATE saves s
+SET is_current = false
+FROM ranked r
+WHERE s.user_id = r.user_id
+  AND s.save_item_id = r.save_item_id
+  AND s.save_type = r.save_type
+  AND s.txhash = r.txhash
+  AND r.rn > 1;
+
+-- 2. retype the survivors
+UPDATE saves SET save_type = 'playlist' WHERE is_current = true AND save_type = 'album';
+
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_trigger
+               WHERE tgrelid = 'saves'::regclass AND tgname = 'on_save' AND NOT tgisinternal) THEN
+        ALTER TABLE saves ENABLE TRIGGER on_save;
+    END IF;
+END $$;
 
 COMMIT;
 
 BEGIN;
 SET LOCAL lock_timeout = '5s';
 
-ALTER TABLE reposts DISABLE TRIGGER on_repost;
-UPDATE reposts SET repost_type = 'playlist' WHERE repost_type = 'album';
-ALTER TABLE reposts ENABLE TRIGGER on_repost;
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_trigger
+               WHERE tgrelid = 'reposts'::regclass AND tgname = 'on_repost' AND NOT tgisinternal) THEN
+        ALTER TABLE reposts DISABLE TRIGGER on_repost;
+    END IF;
+END $$;
+
+WITH ranked AS (
+    SELECT
+        user_id, repost_item_id, repost_type, txhash,
+        row_number() OVER (
+            PARTITION BY user_id, repost_item_id
+            ORDER BY blocknumber DESC NULLS LAST, created_at DESC NULLS LAST, repost_type DESC
+        ) AS rn
+    FROM reposts
+    WHERE is_current = true
+      AND repost_type IN ('playlist', 'album')
+      AND (user_id, repost_item_id) IN (
+          SELECT user_id, repost_item_id FROM reposts
+          WHERE is_current = true AND repost_type IN ('playlist', 'album')
+          GROUP BY user_id, repost_item_id
+          HAVING count(DISTINCT repost_type) > 1
+      )
+)
+UPDATE reposts s
+SET is_current = false
+FROM ranked r
+WHERE s.user_id = r.user_id
+  AND s.repost_item_id = r.repost_item_id
+  AND s.repost_type = r.repost_type
+  AND s.txhash = r.txhash
+  AND r.rn > 1;
+
+UPDATE reposts SET repost_type = 'playlist' WHERE is_current = true AND repost_type = 'album';
+
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_trigger
+               WHERE tgrelid = 'reposts'::regclass AND tgname = 'on_repost' AND NOT tgisinternal) THEN
+        ALTER TABLE reposts ENABLE TRIGGER on_repost;
+    END IF;
+END $$;
 
 COMMIT;

--- a/ddl/migrations/0237_users_one_current_row_backfill.sql
+++ b/ddl/migrations/0237_users_one_current_row_backfill.sql
@@ -38,16 +38,35 @@
 BEGIN;
 SET LOCAL lock_timeout = '5s';
 
-WITH ranked AS (
+-- Restricted to the offending user_ids so row_number() is computed over a
+-- handful of rows rather than all 3.15M current ones. Identifying them still
+-- costs a scan of users: this runs before users_current_uniq_idx exists (that
+-- is pkg/etl 0035, which runs later, at indexer start) and no other index
+-- covers is_current. A few seconds in a one-time pre-roll migration, and it
+-- takes only RowExclusiveLock, so concurrent DML is not blocked.
+--
+-- txhash is compared under the C collation so the tiebreak cannot vary with
+-- database collation. It never fires in practice — blocknumber decides every
+-- real case — but should be deterministic if it ever does.
+WITH dupes AS MATERIALIZED (
+    SELECT user_id
+    FROM users
+    WHERE is_current = true
+    GROUP BY user_id
+    HAVING count(*) > 1
+),
+ranked AS (
     SELECT
         user_id,
         txhash,
         row_number() OVER (
             PARTITION BY user_id
-            ORDER BY blocknumber DESC NULLS LAST, updated_at DESC NULLS LAST, txhash DESC
+            ORDER BY blocknumber DESC NULLS LAST, updated_at DESC NULLS LAST,
+                     txhash COLLATE "C" DESC
         ) AS rn
     FROM users
     WHERE is_current = true
+      AND user_id IN (SELECT user_id FROM dupes)
 )
 DELETE FROM users u
 USING ranked r

--- a/ddl/migrations/0237_users_one_current_row_backfill.sql
+++ b/ddl/migrations/0237_users_one_current_row_backfill.sql
@@ -1,0 +1,58 @@
+-- Remove duplicate is_current rows from users.
+--
+-- users_pkey is (user_id, txhash), which admits a second is_current row under a
+-- different txhash. Five users have one, spread from 2025-06 to 2026-06 — a
+-- slow drip, not a one-off. Each pair shares created_at and sits a few blocks
+-- apart.
+--
+-- How is not established. Both indexer create paths reject an existing user
+-- (validateUserCreate and migratedUserCreateHandler both call userExists, which
+-- tests is_current), so a single writer cannot produce these: its check and its
+-- insert share a transaction. A second writer can, since check-then-act is not
+-- atomic across transactions. Three of the five pairs put a bare-hex txhash
+-- next to a 0x-prefixed one, which fits that reading without proving it.
+--
+-- Five rows, but the blast radius is not five rows: anything joining an entity
+-- to its owner's wallet fans out and silently duplicates every entity those
+-- users own — measured at 18 extra tracks and 787 extra follows on a clone.
+--
+-- This is the backfill half of pkg/etl migration 0035, which adds
+-- users_current_uniq_idx to stop it recurring. That index cannot be created
+-- while duplicates exist, so this must run first. It does: ddl migrations run
+-- in the pre-roll `migrate` Job that every serving Deployment depends on, while
+-- the ETL's run at indexer start, after the Job has completed. The delete lives
+-- here rather than in the ETL migration so that bumping a Go module can never
+-- silently remove rows from this database.
+--
+-- Deleted rather than demoted: users keeps no versioned history — the indexer
+-- writes it in place, and production has zero is_current = false rows — so
+-- demoting would leave a category of row nothing reads. Deleting is safe here:
+-- no foreign key references users, and its triggers are INSERT (on_user) or
+-- INSERT OR UPDATE (trg_users), so neither fires.
+--
+-- Winner is the highest blocknumber, matching how consumers already pick the
+-- live row. Verified against a production clone: in all five cases blocknumber
+-- and updated_at agree, and for user 666149592 it keeps is_deactivated = true,
+-- the later of that pair's two states. Re-running is a no-op.
+
+BEGIN;
+SET LOCAL lock_timeout = '5s';
+
+WITH ranked AS (
+    SELECT
+        user_id,
+        txhash,
+        row_number() OVER (
+            PARTITION BY user_id
+            ORDER BY blocknumber DESC NULLS LAST, updated_at DESC NULLS LAST, txhash DESC
+        ) AS rn
+    FROM users
+    WHERE is_current = true
+)
+DELETE FROM users u
+USING ranked r
+WHERE u.user_id = r.user_id
+  AND u.txhash = r.txhash
+  AND r.rn > 1;
+
+COMMIT;

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/AlecAivazis/survey/v2 v2.3.7
 	github.com/Doist/unfurlist v0.0.0-20250409100812-515f2735f8e5
 	github.com/OpenAudio/go-openaudio v1.8.2-0.20260727214803-1d9f69772e87
-	github.com/OpenAudio/go-openaudio/pkg/etl v1.6.3-0.20260727214803-1d9f69772e87
+	github.com/OpenAudio/go-openaudio/pkg/etl v1.6.4
 	github.com/aquasecurity/esquery v0.2.0
 	github.com/axiomhq/axiom-go v0.23.0
 	github.com/axiomhq/hyperloglog v0.2.5
@@ -45,6 +45,7 @@ require (
 	github.com/urfave/cli/v3 v3.5.0
 	go.uber.org/zap v1.27.0
 	golang.org/x/crypto v0.48.0
+	golang.org/x/net v0.50.0
 	golang.org/x/sync v0.19.0
 	google.golang.org/grpc v1.71.1
 	google.golang.org/protobuf v1.36.11
@@ -219,7 +220,6 @@ require (
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/ratelimit v0.2.0 // indirect
 	golang.org/x/exp v0.0.0-20250408133849-7e4ce0ab07d0 // indirect
-	golang.org/x/net v0.50.0 // indirect
 	golang.org/x/sys v0.41.0 // indirect
 	golang.org/x/term v0.40.0 // indirect
 	golang.org/x/text v0.34.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5 h1:TngWCqHvy9oXAN6lEV
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5/go.mod h1:lmUJ/7eu/Q8D7ML55dXQrVaamCz2vxCfdQBasLZfHKk=
 github.com/OpenAudio/go-openaudio v1.8.2-0.20260727214803-1d9f69772e87 h1:HiLw4qrUkVWRADJjGsdHLlFMdJjhU5WCVNAfeKfww4s=
 github.com/OpenAudio/go-openaudio v1.8.2-0.20260727214803-1d9f69772e87/go.mod h1:lLRvUF5oWkxOyZx8rp/ecqxuMo3yzPvuvJbLSfvxguQ=
-github.com/OpenAudio/go-openaudio/pkg/etl v1.6.3-0.20260727214803-1d9f69772e87 h1:E3HoYAxTNrZ0x1H+PJ+sijy1yh3jMtnO6JTyZqWHJ9U=
-github.com/OpenAudio/go-openaudio/pkg/etl v1.6.3-0.20260727214803-1d9f69772e87/go.mod h1:6MIJhF06djJvPl6sfv3Vqp0f4IsyBsWPB4F+BsIamTc=
+github.com/OpenAudio/go-openaudio/pkg/etl v1.6.4 h1:SkKNhfvPWOlEGBw6i1LvAF1iNA0Gdf5rf/9izr2Kbro=
+github.com/OpenAudio/go-openaudio/pkg/etl v1.6.4/go.mod h1:z7X/5RziXEpASGTz7tD+P3pg4W5iCA1cKW7ogw8GShY=
 github.com/StackExchange/wmi v1.2.1 h1:VIkavFPXSjcnS+O8yTq7NI32k0R5Aj+v39y29VYDOSA=
 github.com/StackExchange/wmi v1.2.1/go.mod h1:rcmrprowKIVzvc+NUiLncP2uuArMWLCbu9SBzvHz7e8=
 github.com/VictoriaMetrics/fastcache v1.12.2 h1:N0y9ASrJ0F6h0QaC3o6uJb3NIZ9VKLjCM7NQbSmF7WI=

--- a/indexer/indexer.go
+++ b/indexer/indexer.go
@@ -53,12 +53,25 @@ func NewIndexer(cfg config.Config) *CoreIndexer {
 	aggregatesCalculator := NewAggregatesCalculator(cfg)
 
 	// ETL needs the Connect/gRPC Core client (for block fetching) and a DB URL.
-	// SkipMigrations stays false (default): ETL's migrations are idempotent
-	// against api/'s schema — every migration uses CREATE TABLE IF NOT EXISTS /
-	// ADD COLUMN IF NOT EXISTS, and tracks state in its own `etl_db_migrations`
-	// table separate from api/'s `schema_version`. Verified by applying all 21
-	// current ETL migrations to a fresh DB seeded with api/'s schema: zero
-	// errors, only NOTICE messages for already-existing relations.
+	// SkipMigrations stays false (default), so bumping the pkg/etl module runs
+	// whatever migrations it brought with it against api/'s database, on the
+	// next indexer start. They track state in their own `etl_db_migrations`
+	// table, separate from api/'s `schema_version`, and only up-migrations run
+	// (RunDownMigrations is left false).
+	//
+	// They are all additive DDL — CREATE TABLE IF NOT EXISTS / ADD COLUMN IF
+	// NOT EXISTS / CREATE INDEX — and none of them touches row data. That is a
+	// deliberate line rather than a coincidence: a module bump reaches this
+	// database automatically, so anything that repairs data belongs in ddl/,
+	// where it goes through review and the pre-roll migrate Job. 0035 is the
+	// worked example — it adds users_current_uniq_idx, while the delete that
+	// makes that index creatable lives in ddl 0237.
+	//
+	// The corollary is that an ETL migration can depend on a ddl one having
+	// run. 0035 fails with a unique violation if ddl 0237 has not removed the
+	// duplicates yet, which would stop the indexer starting. That ordering
+	// holds because ddl migrations run in the pre-roll Job that every serving
+	// Deployment depends on, and the ETL's run later, at indexer start.
 	//
 	// Two optional ETL components are disabled here because they don't fit
 	// api/'s deployment:

--- a/indexer/indexer.go
+++ b/indexer/indexer.go
@@ -59,13 +59,15 @@ func NewIndexer(cfg config.Config) *CoreIndexer {
 	// table, separate from api/'s `schema_version`, and only up-migrations run
 	// (RunDownMigrations is left false).
 	//
-	// They are all additive DDL — CREATE TABLE IF NOT EXISTS / ADD COLUMN IF
-	// NOT EXISTS / CREATE INDEX — and none of them touches row data. That is a
-	// deliberate line rather than a coincidence: a module bump reaches this
-	// database automatically, so anything that repairs data belongs in ddl/,
-	// where it goes through review and the pre-roll migrate Job. 0035 is the
-	// worked example — it adds users_current_uniq_idx, while the delete that
-	// makes that index creatable lives in ddl 0237.
+	// None of them touches row data, which is the line being held: a module bump
+	// reaches this database automatically, so anything that repairs data belongs
+	// in ddl/, where it goes through review and the pre-roll migrate Job. 0035
+	// is the worked example — it adds users_current_uniq_idx, while the delete
+	// that makes that index creatable lives in ddl 0237.
+	//
+	// They are not, however, purely additive: 0026 drops a constraint and 0027
+	// drops and recreates playlist_seen's primary key. A bump can alter the
+	// schema here, so read what a version brings before taking it.
 	//
 	// The corollary is that an ETL migration can depend on a ddl one having
 	// run. 0035 fails with a unique violation if ddl 0237 has not removed the

--- a/main.go
+++ b/main.go
@@ -15,7 +15,9 @@ import (
 	"api.audius.co/esindexer"
 	eth_indexer "api.audius.co/eth/indexer"
 	core_indexer "api.audius.co/indexer"
+	"api.audius.co/logging"
 	solana_indexer "api.audius.co/solana/indexer"
+	etldb "github.com/OpenAudio/go-openaudio/pkg/etl/db"
 )
 
 func main() {
@@ -108,7 +110,29 @@ func main() {
 		}
 	case "migrate":
 		{
-			// no-op, handled prior to switch/case
+			// ddl migrations already ran above. Apply the ETL module's too, so a
+			// database migrated by this command matches a deployed one.
+			//
+			// They are otherwise only ever applied at indexer start, which left
+			// `make test-schema` unable to produce them: that target seeds from
+			// sql/01_schema.sql, runs this command, and dumps the result, so
+			// ETL-created objects could never enter the loop no matter how often
+			// it was regenerated. The four partial unique indexes from pkg/etl
+			// 0030 were consequently absent under test while present in every
+			// deployment — which is how ddl 0236 came to be written against the
+			// wrong constraint and still passed CI.
+			//
+			// Ordering is the useful side effect: ddl migrations run before these,
+			// in one process, so a ddl migration that has to precede an ETL one
+			// (0237 before 0035) is sequenced here rather than across two pods.
+			//
+			// Idempotent and tracked separately in etl_db_migrations, so the
+			// indexer applying them again at startup is a no-op.
+			logger := logging.NewZapLogger(config.Cfg).Named("migrate")
+			if err := etldb.RunMigrations(logger, config.Cfg.WriteDbUrl, false); err != nil {
+				fmt.Println("etl migration failed:", err)
+				os.Exit(1)
+			}
 			os.Exit(0)
 		}
 	default:

--- a/sql/01_schema.sql
+++ b/sql/01_schema.sql
@@ -130,6 +130,17 @@ CREATE TYPE public.delist_user_reason AS ENUM (
 
 
 --
+-- Name: etl_proof_status; Type: TYPE; Schema: public; Owner: -
+--
+
+CREATE TYPE public.etl_proof_status AS ENUM (
+    'unresolved',
+    'pass',
+    'fail'
+);
+
+
+--
 -- Name: event_entity_type; Type: TYPE; Schema: public; Owner: -
 --
 
@@ -5811,6 +5822,44 @@ $$;
 
 
 --
+-- Name: notify_new_block(); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.notify_new_block() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+begin
+  perform pg_notify('new_block', json_build_object(
+    'block_height', new.block_height,
+    'proposer_address', new.proposer_address
+  )::text);
+  return new;
+end;
+$$;
+
+
+--
+-- Name: notify_new_plays(); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.notify_new_plays() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+begin
+  perform pg_notify('new_plays', json_build_object(
+    'user_id', new.user_id,
+    'track_id', new.track_id,
+    'city', new.city,
+    'region', new.region,
+    'country', new.country,
+    'block_height', new.block_height
+  )::text);
+  return new;
+end;
+$$;
+
+
+--
 -- Name: notify_pending_purchase_revalidation(); Type: FUNCTION; Schema: public; Owner: -
 --
 
@@ -8403,6 +8452,489 @@ COMMENT ON TABLE public.eth_wallet_balances IS 'AUDIO ERC-20 balances (in wei) f
 
 
 --
+-- Name: etl_addresses; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.etl_addresses (
+    id integer NOT NULL,
+    address text NOT NULL,
+    pub_key bytea,
+    first_seen_block_height bigint,
+    created_at timestamp without time zone NOT NULL
+);
+
+
+--
+-- Name: etl_addresses_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.etl_addresses_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: etl_addresses_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.etl_addresses_id_seq OWNED BY public.etl_addresses.id;
+
+
+--
+-- Name: etl_blocks; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.etl_blocks (
+    id integer NOT NULL,
+    proposer_address text NOT NULL,
+    block_height bigint NOT NULL,
+    block_time timestamp without time zone NOT NULL
+);
+
+
+--
+-- Name: etl_blocks_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.etl_blocks_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: etl_blocks_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.etl_blocks_id_seq OWNED BY public.etl_blocks.id;
+
+
+--
+-- Name: etl_db_migrations; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.etl_db_migrations (
+    version bigint NOT NULL,
+    dirty boolean NOT NULL
+);
+
+
+--
+-- Name: etl_manage_entities; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.etl_manage_entities (
+    id integer NOT NULL,
+    address text NOT NULL,
+    entity_type text NOT NULL,
+    entity_id bigint NOT NULL,
+    action text NOT NULL,
+    metadata text,
+    signature text NOT NULL,
+    signer text NOT NULL,
+    nonce text NOT NULL,
+    block_height bigint NOT NULL,
+    tx_hash text NOT NULL,
+    created_at timestamp without time zone NOT NULL
+);
+
+
+--
+-- Name: etl_manage_entities_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.etl_manage_entities_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: etl_manage_entities_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.etl_manage_entities_id_seq OWNED BY public.etl_manage_entities.id;
+
+
+--
+-- Name: etl_plays; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.etl_plays (
+    id integer NOT NULL,
+    user_id text NOT NULL,
+    track_id text NOT NULL,
+    city text NOT NULL,
+    region text NOT NULL,
+    country text NOT NULL,
+    played_at timestamp without time zone NOT NULL,
+    block_height bigint NOT NULL,
+    tx_hash text NOT NULL,
+    listened_at timestamp without time zone NOT NULL,
+    recorded_at timestamp without time zone NOT NULL
+);
+
+
+--
+-- Name: etl_plays_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.etl_plays_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: etl_plays_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.etl_plays_id_seq OWNED BY public.etl_plays.id;
+
+
+--
+-- Name: etl_sla_node_reports; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.etl_sla_node_reports (
+    id integer NOT NULL,
+    sla_rollup_id integer NOT NULL,
+    address text NOT NULL,
+    num_blocks_proposed integer NOT NULL,
+    challenges_received integer NOT NULL,
+    challenges_failed integer NOT NULL,
+    block_height bigint NOT NULL,
+    tx_hash text NOT NULL,
+    created_at timestamp without time zone NOT NULL
+);
+
+
+--
+-- Name: etl_sla_node_reports_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.etl_sla_node_reports_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: etl_sla_node_reports_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.etl_sla_node_reports_id_seq OWNED BY public.etl_sla_node_reports.id;
+
+
+--
+-- Name: etl_sla_rollups; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.etl_sla_rollups (
+    id integer NOT NULL,
+    block_start bigint NOT NULL,
+    block_end bigint NOT NULL,
+    block_height bigint NOT NULL,
+    validator_count integer NOT NULL,
+    block_quota integer NOT NULL,
+    bps double precision NOT NULL,
+    tps double precision NOT NULL,
+    tx_hash text NOT NULL,
+    created_at timestamp without time zone NOT NULL
+);
+
+
+--
+-- Name: etl_sla_rollups_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.etl_sla_rollups_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: etl_sla_rollups_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.etl_sla_rollups_id_seq OWNED BY public.etl_sla_rollups.id;
+
+
+--
+-- Name: etl_storage_proof_verifications; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.etl_storage_proof_verifications (
+    id integer NOT NULL,
+    height bigint NOT NULL,
+    proof bytea NOT NULL,
+    block_height bigint NOT NULL,
+    tx_hash text NOT NULL,
+    created_at timestamp without time zone NOT NULL
+);
+
+
+--
+-- Name: etl_storage_proof_verifications_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.etl_storage_proof_verifications_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: etl_storage_proof_verifications_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.etl_storage_proof_verifications_id_seq OWNED BY public.etl_storage_proof_verifications.id;
+
+
+--
+-- Name: etl_storage_proofs; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.etl_storage_proofs (
+    id integer NOT NULL,
+    height bigint NOT NULL,
+    address text NOT NULL,
+    prover_addresses text[] NOT NULL,
+    cid text NOT NULL,
+    proof_signature bytea,
+    proof bytea,
+    status public.etl_proof_status DEFAULT 'unresolved'::public.etl_proof_status NOT NULL,
+    block_height bigint NOT NULL,
+    tx_hash text NOT NULL,
+    created_at timestamp without time zone NOT NULL
+);
+
+
+--
+-- Name: etl_storage_proofs_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.etl_storage_proofs_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: etl_storage_proofs_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.etl_storage_proofs_id_seq OWNED BY public.etl_storage_proofs.id;
+
+
+--
+-- Name: etl_transactions; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.etl_transactions (
+    id integer NOT NULL,
+    tx_hash text NOT NULL,
+    block_height bigint NOT NULL,
+    tx_index integer NOT NULL,
+    tx_type text NOT NULL,
+    address text,
+    created_at timestamp without time zone NOT NULL
+);
+
+
+--
+-- Name: etl_transactions_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.etl_transactions_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: etl_transactions_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.etl_transactions_id_seq OWNED BY public.etl_transactions.id;
+
+
+--
+-- Name: etl_validator_deregistrations; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.etl_validator_deregistrations (
+    id integer NOT NULL,
+    comet_address text NOT NULL,
+    comet_pubkey bytea NOT NULL,
+    block_height bigint NOT NULL,
+    tx_hash text NOT NULL
+);
+
+
+--
+-- Name: etl_validator_deregistrations_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.etl_validator_deregistrations_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: etl_validator_deregistrations_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.etl_validator_deregistrations_id_seq OWNED BY public.etl_validator_deregistrations.id;
+
+
+--
+-- Name: etl_validator_misbehavior_deregistrations; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.etl_validator_misbehavior_deregistrations (
+    id integer NOT NULL,
+    comet_address text NOT NULL,
+    pub_key bytea NOT NULL,
+    block_height bigint NOT NULL,
+    tx_hash text NOT NULL,
+    created_at timestamp without time zone NOT NULL
+);
+
+
+--
+-- Name: etl_validator_misbehavior_deregistrations_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.etl_validator_misbehavior_deregistrations_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: etl_validator_misbehavior_deregistrations_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.etl_validator_misbehavior_deregistrations_id_seq OWNED BY public.etl_validator_misbehavior_deregistrations.id;
+
+
+--
+-- Name: etl_validator_registrations; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.etl_validator_registrations (
+    id integer NOT NULL,
+    address text NOT NULL,
+    endpoint text NOT NULL,
+    comet_address text NOT NULL,
+    eth_block text NOT NULL,
+    node_type text NOT NULL,
+    spid text NOT NULL,
+    comet_pubkey bytea NOT NULL,
+    voting_power bigint NOT NULL,
+    block_height bigint NOT NULL,
+    tx_hash text NOT NULL
+);
+
+
+--
+-- Name: etl_validator_registrations_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.etl_validator_registrations_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: etl_validator_registrations_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.etl_validator_registrations_id_seq OWNED BY public.etl_validator_registrations.id;
+
+
+--
+-- Name: etl_validators; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.etl_validators (
+    id integer NOT NULL,
+    address text NOT NULL,
+    endpoint text NOT NULL,
+    comet_address text NOT NULL,
+    node_type text NOT NULL,
+    spid text NOT NULL,
+    voting_power bigint NOT NULL,
+    status text NOT NULL,
+    registered_at bigint NOT NULL,
+    deregistered_at bigint,
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL
+);
+
+
+--
+-- Name: etl_validators_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.etl_validators_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: etl_validators_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.etl_validators_id_seq OWNED BY public.etl_validators.id;
+
+
+--
 -- Name: event_routes; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -8525,6 +9057,108 @@ CREATE TABLE public.muted_users (
 
 
 --
+-- Name: mv_dashboard_transaction_stats; Type: MATERIALIZED VIEW; Schema: public; Owner: -
+--
+
+CREATE MATERIALIZED VIEW public.mv_dashboard_transaction_stats AS
+ WITH latest_block_time AS (
+         SELECT etl_blocks.block_time
+           FROM public.etl_blocks
+          ORDER BY etl_blocks.block_height DESC
+         LIMIT 1
+        ), time_periods AS (
+         SELECT lbt.block_time AS now_time,
+            (lbt.block_time - '24:00:00'::interval) AS h24_ago,
+            (lbt.block_time - '48:00:00'::interval) AS h48_ago,
+            (lbt.block_time - '7 days'::interval) AS d7_ago,
+            (lbt.block_time - '30 days'::interval) AS d30_ago
+           FROM latest_block_time lbt
+        )
+ SELECT count(*) FILTER (WHERE (t.created_at >= tp.h24_ago)) AS transactions_24h,
+    count(*) FILTER (WHERE ((t.created_at >= tp.h48_ago) AND (t.created_at < tp.h24_ago))) AS transactions_previous_24h,
+    count(*) FILTER (WHERE (t.created_at >= tp.d7_ago)) AS transactions_7d,
+    count(*) FILTER (WHERE (t.created_at >= tp.d30_ago)) AS transactions_30d,
+    count(*) AS total_transactions
+   FROM (time_periods tp
+     CROSS JOIN public.etl_transactions t)
+  WHERE (t.created_at <= tp.now_time)
+  WITH NO DATA;
+
+
+--
+-- Name: mv_dashboard_transaction_types; Type: MATERIALIZED VIEW; Schema: public; Owner: -
+--
+
+CREATE MATERIALIZED VIEW public.mv_dashboard_transaction_types AS
+ WITH latest_block_time AS (
+         SELECT etl_blocks.block_time
+           FROM public.etl_blocks
+          ORDER BY etl_blocks.block_height DESC
+         LIMIT 1
+        )
+ SELECT t.tx_type,
+    count(*) AS transaction_count
+   FROM (public.etl_transactions t
+     CROSS JOIN latest_block_time lbt)
+  WHERE (t.created_at <= lbt.block_time)
+  GROUP BY t.tx_type
+  ORDER BY (count(*)) DESC
+  WITH NO DATA;
+
+
+--
+-- Name: new_chain_queue; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.new_chain_queue (
+    id bigint NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    tx_data bytea NOT NULL,
+    confirmed_block bigint
+);
+
+
+--
+-- Name: TABLE new_chain_queue; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON TABLE public.new_chain_queue IS 'Queue of ManageEntity transactions to be forwarded to the new Core chain (audius-mainnet-v2) during genesis migration.';
+
+
+--
+-- Name: COLUMN new_chain_queue.tx_data; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.new_chain_queue.tx_data IS 'Protobuf-serialized ManageEntityLegacy message.';
+
+
+--
+-- Name: COLUMN new_chain_queue.confirmed_block; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.new_chain_queue.confirmed_block IS 'Block height on the old chain where this transaction was confirmed. NULL if confirmation was not recorded (e.g. relay restart).';
+
+
+--
+-- Name: new_chain_queue_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.new_chain_queue_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: new_chain_queue_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.new_chain_queue_id_seq OWNED BY public.new_chain_queue.id;
+
+
+--
 -- Name: notification; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -8558,7 +9192,6 @@ CREATE TABLE public.notification_campaign_push_open (
 --
 
 CREATE SEQUENCE public.notification_id_seq
-    AS bigint
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -11002,6 +11635,104 @@ ALTER TABLE ONLY public.eth_blocks ALTER COLUMN last_scanned_block SET DEFAULT n
 
 
 --
+-- Name: etl_addresses id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.etl_addresses ALTER COLUMN id SET DEFAULT nextval('public.etl_addresses_id_seq'::regclass);
+
+
+--
+-- Name: etl_blocks id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.etl_blocks ALTER COLUMN id SET DEFAULT nextval('public.etl_blocks_id_seq'::regclass);
+
+
+--
+-- Name: etl_manage_entities id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.etl_manage_entities ALTER COLUMN id SET DEFAULT nextval('public.etl_manage_entities_id_seq'::regclass);
+
+
+--
+-- Name: etl_plays id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.etl_plays ALTER COLUMN id SET DEFAULT nextval('public.etl_plays_id_seq'::regclass);
+
+
+--
+-- Name: etl_sla_node_reports id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.etl_sla_node_reports ALTER COLUMN id SET DEFAULT nextval('public.etl_sla_node_reports_id_seq'::regclass);
+
+
+--
+-- Name: etl_sla_rollups id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.etl_sla_rollups ALTER COLUMN id SET DEFAULT nextval('public.etl_sla_rollups_id_seq'::regclass);
+
+
+--
+-- Name: etl_storage_proof_verifications id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.etl_storage_proof_verifications ALTER COLUMN id SET DEFAULT nextval('public.etl_storage_proof_verifications_id_seq'::regclass);
+
+
+--
+-- Name: etl_storage_proofs id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.etl_storage_proofs ALTER COLUMN id SET DEFAULT nextval('public.etl_storage_proofs_id_seq'::regclass);
+
+
+--
+-- Name: etl_transactions id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.etl_transactions ALTER COLUMN id SET DEFAULT nextval('public.etl_transactions_id_seq'::regclass);
+
+
+--
+-- Name: etl_validator_deregistrations id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.etl_validator_deregistrations ALTER COLUMN id SET DEFAULT nextval('public.etl_validator_deregistrations_id_seq'::regclass);
+
+
+--
+-- Name: etl_validator_misbehavior_deregistrations id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.etl_validator_misbehavior_deregistrations ALTER COLUMN id SET DEFAULT nextval('public.etl_validator_misbehavior_deregistrations_id_seq'::regclass);
+
+
+--
+-- Name: etl_validator_registrations id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.etl_validator_registrations ALTER COLUMN id SET DEFAULT nextval('public.etl_validator_registrations_id_seq'::regclass);
+
+
+--
+-- Name: etl_validators id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.etl_validators ALTER COLUMN id SET DEFAULT nextval('public.etl_validators_id_seq'::regclass);
+
+
+--
+-- Name: new_chain_queue id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.new_chain_queue ALTER COLUMN id SET DEFAULT nextval('public.new_chain_queue_id_seq'::regclass);
+
+
+--
 -- Name: notification id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -11576,6 +12307,126 @@ ALTER TABLE ONLY public.eth_wallet_balances
 
 
 --
+-- Name: etl_addresses etl_addresses_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.etl_addresses
+    ADD CONSTRAINT etl_addresses_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: etl_blocks etl_blocks_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.etl_blocks
+    ADD CONSTRAINT etl_blocks_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: etl_db_migrations etl_db_migrations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.etl_db_migrations
+    ADD CONSTRAINT etl_db_migrations_pkey PRIMARY KEY (version);
+
+
+--
+-- Name: etl_manage_entities etl_manage_entities_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.etl_manage_entities
+    ADD CONSTRAINT etl_manage_entities_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: etl_plays etl_plays_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.etl_plays
+    ADD CONSTRAINT etl_plays_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: etl_sla_node_reports etl_sla_node_reports_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.etl_sla_node_reports
+    ADD CONSTRAINT etl_sla_node_reports_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: etl_sla_rollups etl_sla_rollups_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.etl_sla_rollups
+    ADD CONSTRAINT etl_sla_rollups_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: etl_storage_proof_verifications etl_storage_proof_verifications_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.etl_storage_proof_verifications
+    ADD CONSTRAINT etl_storage_proof_verifications_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: etl_storage_proofs etl_storage_proofs_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.etl_storage_proofs
+    ADD CONSTRAINT etl_storage_proofs_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: etl_transactions etl_transactions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.etl_transactions
+    ADD CONSTRAINT etl_transactions_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: etl_validator_deregistrations etl_validator_deregistrations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.etl_validator_deregistrations
+    ADD CONSTRAINT etl_validator_deregistrations_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: etl_validator_misbehavior_deregistrations etl_validator_misbehavior_deregistrations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.etl_validator_misbehavior_deregistrations
+    ADD CONSTRAINT etl_validator_misbehavior_deregistrations_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: etl_validator_registrations etl_validator_registrations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.etl_validator_registrations
+    ADD CONSTRAINT etl_validator_registrations_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: etl_validators etl_validators_endpoint_key; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.etl_validators
+    ADD CONSTRAINT etl_validators_endpoint_key UNIQUE (endpoint);
+
+
+--
+-- Name: etl_validators etl_validators_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.etl_validators
+    ADD CONSTRAINT etl_validators_pkey PRIMARY KEY (id);
+
+
+--
 -- Name: events events_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -11629,6 +12480,14 @@ ALTER TABLE ONLY public.milestones
 
 ALTER TABLE ONLY public.muted_users
     ADD CONSTRAINT muted_users_pkey PRIMARY KEY (muted_user_id, user_id);
+
+
+--
+-- Name: new_chain_queue new_chain_queue_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.new_chain_queue
+    ADD CONSTRAINT new_chain_queue_pkey PRIMARY KEY (id);
 
 
 --
@@ -11716,7 +12575,7 @@ ALTER TABLE ONLY public.playlist_routes
 --
 
 ALTER TABLE ONLY public.playlist_seen
-    ADD CONSTRAINT playlist_seen_pkey PRIMARY KEY (playlist_id, seen_at, user_id);
+    ADD CONSTRAINT playlist_seen_pkey PRIMARY KEY (user_id, playlist_id, seen_at);
 
 
 --
@@ -12256,14 +13115,6 @@ ALTER TABLE ONLY public.trending_results
 
 
 --
--- Name: developer_apps unique_developer_apps_address; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.developer_apps
-    ADD CONSTRAINT unique_developer_apps_address UNIQUE (address);
-
-
---
 -- Name: associated_wallets unique_user_wallet_chain; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -12580,6 +13431,13 @@ COMMENT ON INDEX public.comments_blocknumber_idx IS 'Range scans by blocknumber 
 
 
 --
+-- Name: comments_track_entity_created_at_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX comments_track_entity_created_at_idx ON public.comments USING btree (entity_id, created_at DESC) INCLUDE (comment_id, user_id) WHERE ((entity_type = 'Track'::text) AND (is_delete = false));
+
+
+--
 -- Name: comments_user_track_created_at_idx; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -12601,6 +13459,363 @@ COMMENT ON INDEX public.eth_wallet_balances_updated_at_idx IS 'Supports stalenes
 
 
 --
+-- Name: etl_blocks_block_height_desc_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX etl_blocks_block_height_desc_idx ON public.etl_blocks USING btree (block_height DESC);
+
+
+--
+-- Name: etl_blocks_block_height_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX etl_blocks_block_height_idx ON public.etl_blocks USING btree (block_height);
+
+
+--
+-- Name: etl_blocks_block_time_height_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX etl_blocks_block_time_height_idx ON public.etl_blocks USING btree (block_time DESC, block_height DESC);
+
+
+--
+-- Name: etl_blocks_block_time_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX etl_blocks_block_time_idx ON public.etl_blocks USING btree (block_time);
+
+
+--
+-- Name: etl_blocks_block_time_range_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX etl_blocks_block_time_range_idx ON public.etl_blocks USING btree (block_time, block_height);
+
+
+--
+-- Name: etl_blocks_id_desc_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX etl_blocks_id_desc_idx ON public.etl_blocks USING btree (id DESC);
+
+
+--
+-- Name: etl_manage_entities_cursor_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX etl_manage_entities_cursor_idx ON public.etl_manage_entities USING btree (block_height, id);
+
+
+--
+-- Name: etl_manage_entities_tx_hash_action_entity_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX etl_manage_entities_tx_hash_action_entity_idx ON public.etl_manage_entities USING btree (tx_hash, action, entity_type);
+
+
+--
+-- Name: etl_manage_entities_tx_hash_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX etl_manage_entities_tx_hash_idx ON public.etl_manage_entities USING btree (tx_hash);
+
+
+--
+-- Name: etl_plays_cursor_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX etl_plays_cursor_idx ON public.etl_plays USING btree (block_height, id);
+
+
+--
+-- Name: etl_plays_tx_hash_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX etl_plays_tx_hash_idx ON public.etl_plays USING btree (tx_hash);
+
+
+--
+-- Name: etl_sla_node_reports_address_lower_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX etl_sla_node_reports_address_lower_idx ON public.etl_sla_node_reports USING btree (lower(address));
+
+
+--
+-- Name: etl_sla_node_reports_address_sla_rollup_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX etl_sla_node_reports_address_sla_rollup_idx ON public.etl_sla_node_reports USING btree (address, sla_rollup_id);
+
+
+--
+-- Name: etl_sla_node_reports_cursor_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX etl_sla_node_reports_cursor_idx ON public.etl_sla_node_reports USING btree (block_height, id);
+
+
+--
+-- Name: etl_sla_node_reports_sla_rollup_id_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX etl_sla_node_reports_sla_rollup_id_idx ON public.etl_sla_node_reports USING btree (sla_rollup_id);
+
+
+--
+-- Name: etl_sla_rollups_block_height_desc_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX etl_sla_rollups_block_height_desc_idx ON public.etl_sla_rollups USING btree (block_height DESC, id DESC);
+
+
+--
+-- Name: etl_sla_rollups_cursor_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX etl_sla_rollups_cursor_idx ON public.etl_sla_rollups USING btree (block_height, id);
+
+
+--
+-- Name: etl_sla_rollups_latest_covering_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX etl_sla_rollups_latest_covering_idx ON public.etl_sla_rollups USING btree (block_height DESC, id DESC, block_start, block_end, validator_count, block_quota, bps, tps);
+
+
+--
+-- Name: etl_sla_rollups_tx_hash_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX etl_sla_rollups_tx_hash_idx ON public.etl_sla_rollups USING btree (tx_hash);
+
+
+--
+-- Name: etl_storage_proof_verifications_cursor_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX etl_storage_proof_verifications_cursor_idx ON public.etl_storage_proof_verifications USING btree (block_height, id);
+
+
+--
+-- Name: etl_storage_proof_verifications_tx_hash_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX etl_storage_proof_verifications_tx_hash_idx ON public.etl_storage_proof_verifications USING btree (tx_hash);
+
+
+--
+-- Name: etl_storage_proofs_cursor_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX etl_storage_proofs_cursor_idx ON public.etl_storage_proofs USING btree (block_height, id);
+
+
+--
+-- Name: etl_storage_proofs_height_address_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX etl_storage_proofs_height_address_idx ON public.etl_storage_proofs USING btree (height, address);
+
+
+--
+-- Name: etl_storage_proofs_height_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX etl_storage_proofs_height_idx ON public.etl_storage_proofs USING btree (height);
+
+
+--
+-- Name: etl_storage_proofs_height_range_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX etl_storage_proofs_height_range_idx ON public.etl_storage_proofs USING btree (height, address) WHERE (height >= 0);
+
+
+--
+-- Name: etl_storage_proofs_status_fail_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX etl_storage_proofs_status_fail_idx ON public.etl_storage_proofs USING btree (height, address) WHERE (status = 'fail'::public.etl_proof_status);
+
+
+--
+-- Name: etl_storage_proofs_status_unresolved_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX etl_storage_proofs_status_unresolved_idx ON public.etl_storage_proofs USING btree (height, address) WHERE (status = 'unresolved'::public.etl_proof_status);
+
+
+--
+-- Name: etl_storage_proofs_tx_hash_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX etl_storage_proofs_tx_hash_idx ON public.etl_storage_proofs USING btree (tx_hash);
+
+
+--
+-- Name: etl_transactions_address_filter_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX etl_transactions_address_filter_idx ON public.etl_transactions USING btree (lower(address), tx_type, created_at, block_height DESC, tx_index DESC);
+
+
+--
+-- Name: etl_transactions_address_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX etl_transactions_address_idx ON public.etl_transactions USING btree (address);
+
+
+--
+-- Name: etl_transactions_address_lower_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX etl_transactions_address_lower_idx ON public.etl_transactions USING btree (lower(address));
+
+
+--
+-- Name: etl_transactions_block_height_desc_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX etl_transactions_block_height_desc_idx ON public.etl_transactions USING btree (block_height DESC, tx_index DESC);
+
+
+--
+-- Name: etl_transactions_created_at_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX etl_transactions_created_at_idx ON public.etl_transactions USING btree (created_at);
+
+
+--
+-- Name: etl_transactions_created_at_type_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX etl_transactions_created_at_type_idx ON public.etl_transactions USING btree (created_at, tx_type);
+
+
+--
+-- Name: etl_transactions_cursor_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX etl_transactions_cursor_idx ON public.etl_transactions USING btree (block_height, id);
+
+
+--
+-- Name: etl_transactions_id_desc_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX etl_transactions_id_desc_idx ON public.etl_transactions USING btree (id DESC);
+
+
+--
+-- Name: etl_transactions_tx_hash_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX etl_transactions_tx_hash_idx ON public.etl_transactions USING btree (tx_hash);
+
+
+--
+-- Name: etl_transactions_tx_type_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX etl_transactions_tx_type_idx ON public.etl_transactions USING btree (tx_type);
+
+
+--
+-- Name: etl_validator_deregistrations_comet_address_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX etl_validator_deregistrations_comet_address_idx ON public.etl_validator_deregistrations USING btree (comet_address);
+
+
+--
+-- Name: etl_validator_deregistrations_cursor_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX etl_validator_deregistrations_cursor_idx ON public.etl_validator_deregistrations USING btree (block_height, id);
+
+
+--
+-- Name: etl_validator_deregistrations_tx_hash_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX etl_validator_deregistrations_tx_hash_idx ON public.etl_validator_deregistrations USING btree (tx_hash);
+
+
+--
+-- Name: etl_validator_misbehavior_deregistrations_cursor_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX etl_validator_misbehavior_deregistrations_cursor_idx ON public.etl_validator_misbehavior_deregistrations USING btree (block_height, id);
+
+
+--
+-- Name: etl_validator_registrations_comet_address_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX etl_validator_registrations_comet_address_idx ON public.etl_validator_registrations USING btree (comet_address);
+
+
+--
+-- Name: etl_validator_registrations_cursor_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX etl_validator_registrations_cursor_idx ON public.etl_validator_registrations USING btree (block_height, id);
+
+
+--
+-- Name: etl_validator_registrations_tx_hash_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX etl_validator_registrations_tx_hash_idx ON public.etl_validator_registrations USING btree (tx_hash);
+
+
+--
+-- Name: etl_validators_active_reports_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX etl_validators_active_reports_idx ON public.etl_validators USING btree (status, comet_address) WHERE (status = 'active'::text);
+
+
+--
+-- Name: etl_validators_address_lower_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX etl_validators_address_lower_idx ON public.etl_validators USING btree (lower(address));
+
+
+--
+-- Name: etl_validators_comet_address_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX etl_validators_comet_address_idx ON public.etl_validators USING btree (comet_address);
+
+
+--
+-- Name: etl_validators_comet_address_lower_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX etl_validators_comet_address_lower_idx ON public.etl_validators USING btree (lower(comet_address));
+
+
+--
+-- Name: etl_validators_status_covering_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX etl_validators_status_covering_idx ON public.etl_validators USING btree (status, comet_address, endpoint, node_type, spid, voting_power) WHERE (status = 'active'::text);
+
+
+--
+-- Name: etl_validators_status_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX etl_validators_status_idx ON public.etl_validators USING btree (status);
+
+
+--
 -- Name: event_routes_event_id_idx; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -12619,6 +13834,13 @@ CREATE INDEX fix_tracks_top_genre_users_idx ON public.tracks USING btree (track_
 --
 
 CREATE INDEX follows_blocknumber_idx ON public.follows USING btree (blocknumber);
+
+
+--
+-- Name: follows_current_uniq_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX follows_current_uniq_idx ON public.follows USING btree (follower_user_id, followee_user_id) WHERE (is_current = true);
 
 
 --
@@ -12720,6 +13942,13 @@ CREATE INDEX idx_chain_blockhash ON public.core_indexed_blocks USING btree (bloc
 
 
 --
+-- Name: idx_chain_id_height; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_chain_id_height ON public.core_indexed_blocks USING btree (chain_id, height);
+
+
+--
 -- Name: idx_challenge_disbursements_created_at; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -12752,6 +13981,13 @@ CREATE INDEX idx_chat_message_reactions_message_id ON public.chat_message_reacti
 --
 
 CREATE INDEX idx_chat_message_user_id ON public.chat_message USING btree (user_id, created_at);
+
+
+--
+-- Name: idx_dashboard_wallet_users_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_dashboard_wallet_users_user_id ON public.dashboard_wallet_users USING btree (user_id);
 
 
 --
@@ -12843,6 +14079,13 @@ CREATE INDEX idx_genre_related_artists ON public.aggregate_user USING btree (dom
 --
 
 CREATE INDEX idx_grants_grantee_address ON public.grants USING btree (grantee_address, is_revoked, created_at DESC) WHERE (is_current = true);
+
+
+--
+-- Name: idx_grants_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_grants_user_id ON public.grants USING btree (user_id);
 
 
 --
@@ -12990,6 +14233,20 @@ COMMENT ON INDEX public.idx_sol_reward_manager_inits_mint IS 'Index to quickly f
 --
 
 CREATE INDEX idx_track_collaborators_collaborator ON public.track_collaborators USING btree (collaborator_user_id, status, track_id);
+
+
+--
+-- Name: idx_track_downloads_track_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_track_downloads_track_id ON public.track_downloads USING btree (track_id);
+
+
+--
+-- Name: idx_track_downloads_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_track_downloads_user_id ON public.track_downloads USING btree (user_id);
 
 
 --
@@ -13189,6 +14446,13 @@ COMMENT ON INDEX public.ix_notification_cooldown_user_ids IS 'Partial GIN for th
 
 
 --
+-- Name: ix_oauth_redirect_uris_client_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_oauth_redirect_uris_client_id ON public.oauth_redirect_uris USING btree (client_id);
+
+
+--
 -- Name: ix_playlist_trending_scores_playlist_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -13336,6 +14600,27 @@ CREATE INDEX milestones_name_idx ON public.milestones USING btree (name, id);
 
 
 --
+-- Name: mv_dashboard_transaction_stats_24h_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX mv_dashboard_transaction_stats_24h_idx ON public.mv_dashboard_transaction_stats USING btree (transactions_24h);
+
+
+--
+-- Name: mv_dashboard_transaction_types_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX mv_dashboard_transaction_types_idx ON public.mv_dashboard_transaction_types USING btree (tx_type, transaction_count);
+
+
+--
+-- Name: new_chain_queue_confirmed_block_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX new_chain_queue_confirmed_block_idx ON public.new_chain_queue USING btree (confirmed_block);
+
+
+--
 -- Name: notification_multi_recipient_user_ids_idx; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -13382,6 +14667,13 @@ CREATE INDEX playlist_created_at_idx ON public.playlists USING btree (created_at
 --
 
 CREATE INDEX playlist_owner_idx ON public.playlists USING btree (playlist_owner_id, created_at);
+
+
+--
+-- Name: playlist_routes_owner_title_slug_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX playlist_routes_owner_title_slug_idx ON public.playlist_routes USING btree (owner_id, title_slug, collision_id);
 
 
 --
@@ -13438,6 +14730,13 @@ CREATE INDEX related_artists_related_artist_id_idx ON public.related_artists USI
 --
 
 CREATE INDEX remixes_child_idx ON public.remixes USING btree (child_track_id, parent_track_id);
+
+
+--
+-- Name: reposts_current_uniq_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX reposts_current_uniq_idx ON public.reposts USING btree (user_id, repost_item_id, repost_type) WHERE (is_current = true);
 
 
 --
@@ -13508,6 +14807,13 @@ CREATE INDEX rpclog_method_idx ON public.rpclog USING btree (method);
 --
 
 CREATE INDEX rpclog_wallet_idx ON public.rpclog USING btree (wallet);
+
+
+--
+-- Name: saves_current_uniq_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX saves_current_uniq_idx ON public.saves USING btree (user_id, save_item_id, save_type) WHERE (is_current = true);
 
 
 --
@@ -13917,6 +15223,13 @@ COMMENT ON INDEX public.sol_user_balances_mint_user_id_idx IS 'Index for quick a
 
 
 --
+-- Name: subscriptions_current_uniq_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX subscriptions_current_uniq_idx ON public.subscriptions USING btree (subscriber_id, user_id) WHERE (is_current = true);
+
+
+--
 -- Name: subscriptions_entity_type_entity_id_idx; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -13984,6 +15297,13 @@ CREATE INDEX track_owner_idx ON public.tracks USING btree (owner_id, created_at)
 --
 
 CREATE INDEX track_routes_owner_title_slug_collision_idx ON public.track_routes USING btree (owner_id, title_slug, collision_id DESC);
+
+
+--
+-- Name: track_routes_owner_title_slug_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX track_routes_owner_title_slug_idx ON public.track_routes USING btree (owner_id, title_slug, collision_id);
 
 
 --
@@ -14103,6 +15423,13 @@ CREATE INDEX user_events_user_id_idx ON public.user_events USING btree (user_id)
 --
 
 CREATE INDEX user_payout_wallet_history_wallet_idx ON public.user_payout_wallet_history USING btree (spl_usdc_payout_wallet, block_timestamp);
+
+
+--
+-- Name: users_current_uniq_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX users_current_uniq_idx ON public.users USING btree (user_id) WHERE (is_current = true);
 
 
 --
@@ -14561,6 +15888,20 @@ CREATE TRIGGER trigger_grant_change AFTER INSERT OR UPDATE ON public.grants FOR 
 
 
 --
+-- Name: etl_blocks trigger_notify_new_block; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER trigger_notify_new_block AFTER INSERT ON public.etl_blocks FOR EACH ROW EXECUTE FUNCTION public.notify_new_block();
+
+
+--
+-- Name: etl_plays trigger_notify_new_plays; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER trigger_notify_new_plays AFTER INSERT ON public.etl_plays FOR EACH ROW EXECUTE FUNCTION public.notify_new_plays();
+
+
+--
 -- Name: track_collaborators trigger_track_collaborator_change; Type: TRIGGER; Schema: public; Owner: -
 --
 
@@ -14669,6 +16010,14 @@ ALTER TABLE ONLY public.dashboard_wallet_users
 
 ALTER TABLE ONLY public.developer_apps
     ADD CONSTRAINT developer_apps_blocknumber_fkey FOREIGN KEY (blocknumber) REFERENCES public.blocks(number) ON DELETE CASCADE;
+
+
+--
+-- Name: etl_sla_node_reports etl_sla_node_reports_sla_rollup_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.etl_sla_node_reports
+    ADD CONSTRAINT etl_sla_node_reports_sla_rollup_id_fkey FOREIGN KEY (sla_rollup_id) REFERENCES public.etl_sla_rollups(id);
 
 
 --
@@ -14852,31 +16201,3 @@ ALTER TABLE ONLY public.users
 --
 
 
---
--- Partial unique indexes created by pkg/etl migration 0030, not by ddl/.
---
--- The ETL module's migrations run at indexer start, so these exist in every
--- deployed database — but `make test-schema` seeds from this dump and then
--- applies only ddl/ migrations, so nothing in that loop can ever introduce
--- them. They were therefore absent from CI while present in production, which
--- is how ddl 0236 came to be written against saves_pkey instead of the
--- constraint that actually binds it.
---
--- Added here so the seeded schema matches a deployed one. Because regeneration
--- starts from this file, they persist through future `make test-schema` runs.
---
--- users_current_uniq_idx is deliberately NOT included: pkg/etl 0035 has not run
--- in production yet, and ddl 0237 is specified to run before it does.
---
-
-CREATE UNIQUE INDEX IF NOT EXISTS saves_current_uniq_idx
-  ON public.saves (user_id, save_item_id, save_type) WHERE (is_current = true);
-
-CREATE UNIQUE INDEX IF NOT EXISTS reposts_current_uniq_idx
-  ON public.reposts (user_id, repost_item_id, repost_type) WHERE (is_current = true);
-
-CREATE UNIQUE INDEX IF NOT EXISTS follows_current_uniq_idx
-  ON public.follows (follower_user_id, followee_user_id) WHERE (is_current = true);
-
-CREATE UNIQUE INDEX IF NOT EXISTS subscriptions_current_uniq_idx
-  ON public.subscriptions (subscriber_id, user_id) WHERE (is_current = true);

--- a/sql/01_schema.sql
+++ b/sql/01_schema.sql
@@ -14851,3 +14851,32 @@ ALTER TABLE ONLY public.users
 -- PostgreSQL database dump complete
 --
 
+
+--
+-- Partial unique indexes created by pkg/etl migration 0030, not by ddl/.
+--
+-- The ETL module's migrations run at indexer start, so these exist in every
+-- deployed database — but `make test-schema` seeds from this dump and then
+-- applies only ddl/ migrations, so nothing in that loop can ever introduce
+-- them. They were therefore absent from CI while present in production, which
+-- is how ddl 0236 came to be written against saves_pkey instead of the
+-- constraint that actually binds it.
+--
+-- Added here so the seeded schema matches a deployed one. Because regeneration
+-- starts from this file, they persist through future `make test-schema` runs.
+--
+-- users_current_uniq_idx is deliberately NOT included: pkg/etl 0035 has not run
+-- in production yet, and ddl 0237 is specified to run before it does.
+--
+
+CREATE UNIQUE INDEX IF NOT EXISTS saves_current_uniq_idx
+  ON public.saves (user_id, save_item_id, save_type) WHERE (is_current = true);
+
+CREATE UNIQUE INDEX IF NOT EXISTS reposts_current_uniq_idx
+  ON public.reposts (user_id, repost_item_id, repost_type) WHERE (is_current = true);
+
+CREATE UNIQUE INDEX IF NOT EXISTS follows_current_uniq_idx
+  ON public.follows (follower_user_id, followee_user_id) WHERE (is_current = true);
+
+CREATE UNIQUE INDEX IF NOT EXISTS subscriptions_current_uniq_idx
+  ON public.subscriptions (subscriber_id, user_id) WHERE (is_current = true);

--- a/sql/03_migration_tracker.sql
+++ b/sql/03_migration_tracker.sql
@@ -106,7 +106,6 @@ functions/compute_user_score.sql	814b5fa3d1383d3e216943b4ff8c4877	2026-05-27 00:
 functions/country_to_iso_alpha2.sql	218832f0607aeca4fce99815a07f7a85	2026-05-27 00:22:35.592939+00
 functions/find_track.sql	f09431015118f31aa7b4ac49d14e7639	2026-05-27 00:22:35.667572+00
 functions/handle_artist_coins.sql	21ed1610d80cceca2262efb1338060ed	2026-05-27 00:22:35.905536+00
-functions/handle_challenge_disbursements.sql	1bbf82cc035971d828ed96f3ea1a23d6	2026-05-29 22:00:00+00
 functions/handle_chat_blast.sql	ccd276957c1b68bfc82fb5a11bac09ee	2026-05-27 00:22:36.155215+00
 functions/handle_chat_message.sql	31bebee3d0437133f1f53c2eadb7b391	2026-05-27 00:22:36.229275+00
 functions/handle_chat_message_reaction.sql	b898313aa8f31c61df7f1e6dd791ef31	2026-05-27 00:22:36.304728+00
@@ -125,7 +124,6 @@ functions/handle_supporter_rank_ups.sql	dea497f1859ade282b4f7d33687e6fe7	2026-05
 functions/handle_usdc_purchase.sql	c35bccc2789ae0641d413d28a131ef8d	2026-05-27 00:22:37.800109+00
 functions/handle_user.sql	169778112e5362ee20af56d9b8f274c5	2026-05-27 00:22:37.955619+00
 functions/handle_user_balance_changes.sql	1ae7f99f4f37194cdf27dc3189ebc858	2026-05-27 00:22:38.02983+00
-functions/handle_user_challenges.sql	8a1287bc971c83e7440b88da7c86e93d	2026-05-29 22:00:00.1+00
 functions/handle_user_tip.sql	e4bde4e7e04b0ed8254690959513bd69	2026-05-27 00:22:38.167097+00
 functions/is_country_eur.sql	c5641d570edb9cd47cd4e38d883e941a	2026-05-27 00:22:38.234372+00
 functions/notify_pending_purchase_revalidation.sql	beb9eebc6bd34ab069c7b90a51bb8bb3	2026-05-27 00:22:38.378429+00
@@ -133,7 +131,6 @@ functions/price_from_sqrt_price.sql	1b217f211adba88e3f12d1d6c81fc97d	2026-05-27 
 functions/refresh_all_user_scores.sql	04935173f102e5e28b5c384e312102c1	2026-05-27 00:22:38.539364+00
 functions/update_sol_user_balance.sql	4a297a671c74a683814ff217bd097589	2026-05-27 00:22:38.619283+00
 functions/user_mint_balance_at.sql	6d227781d4d97500e0ec2bb76e8fa295	2026-05-27 00:22:38.701765+00
-views/artist_coin_prices.sql	10a65b64b7d13aaabe18ad1055e9fd7b	2026-05-27 00:22:38.820919+00
 views/v_challenge_disbursements.sql	74a0a05af6a02f82af3695d5c3ade45c	2026-05-27 00:22:38.899214+00
 views/v_usdc_purchases.sql	322a527e132aed647c39b70d63aa6b51	2026-05-27 00:22:39.061667+00
 migrations/0204_backfill_eth_wallet_balances_tracked.sql	d8b752794c42edb94f0d43633e14208c	2026-05-28 00:56:10.178339+00
@@ -166,6 +163,8 @@ functions/handle_track.sql	c2d4c5674b0cb1db907ad625fd957c91	2026-07-28 05:42:29.
 functions/notify_on_row.sql	a326d476636de01dd939047526b0cb92	2026-07-28 05:42:29.345724+00
 preflight/0001_initial_block.sql	6cc3c0833c195a1104bed5bf849c0266	2026-07-28 05:42:29.588508+00
 functions/handle_comment_reaction.sql	8153e3cdb922265857b6beaf20d29733	2026-05-30 01:37:22.856663+00
+functions/handle_user_challenges.sql	202037a6ec14955885a479648e2cc57a	2026-08-05 00:50:26.86158+00
+views/artist_coin_prices.sql	fbfb4b530235c4b95f851bf5be2a063d	2026-08-05 00:50:27.089199+00
 functions/handle_comment_thread.sql	6eb74eb92cf3a01421498df96c6832f3	2026-05-30 01:37:22.955997+00
 functions/handle_eth_wallet_balance_change.sql	3e31160b4bc55e951d9dfa4d994c180b	2026-05-30 01:37:23.054573+00
 functions/handle_fan_club_text_post.sql	531bf682bcfd67c6866faf8ccdf7603b	2026-05-30 01:37:23.160142+00
@@ -208,6 +207,14 @@ migrations/0229_artist_coin_stats_onchain.sql	3e469a25759d4598603e4dc230466be3	2
 migrations/0230_artist_coin_price_history.sql	3f8e262d95c76c2b58d4eea8f2135840	2026-07-28 05:45:38.06593+00
 migrations/0231_artist_coin_volume_accumulator.sql	08ad700f8e10b84ee2c1b1e3eecbe033	2026-07-28 05:45:38.134036+00
 views/artist_coin_stats_comparison.sql	e323f13c890cf86ce06d164523c1ec5b	2026-07-28 05:45:38.857194+00
+migrations/0232_new_chain_queue.sql	50ba5b4bee289fddc17316c505dab465	2026-08-05 00:50:25.543262+00
+migrations/0233_comments_track_entity_created_at_idx.sql	a35b92644e65c68f924c0ed638c3ea90	2026-08-05 00:50:25.665626+00
+migrations/0233_notification_id_bigint.sql	5ae9ed5cae27021c6865b3508aa62a7d	2026-08-05 00:50:25.786408+00
+migrations/0234_drop_artist_coin_volume_accumulator.sql	e161882135bb98d95349fc01b5dd08d8	2026-08-05 00:50:25.877491+00
+migrations/0235_drop_coin_stats_shadow.sql	ecbd5cd4d2edd02bbb86d760c9768388	2026-08-05 00:50:25.971214+00
+migrations/0236_saves_reposts_album_to_playlist.sql	5bd5036831dbfa656352dfd937c3fe5c	2026-08-05 00:50:26.077564+00
+migrations/0237_users_one_current_row_backfill.sql	b48ab562bc1ab92d12a17795a59cdf84	2026-08-05 00:50:26.167093+00
+functions/handle_challenge_disbursements.sql	32db00f1ecfcfbda0094c0a5e1e6e300	2026-08-05 00:50:26.417396+00
 \.
 
 


### PR DESCRIPTION
Supersedes #1008, #1009 and #1010, which were the same work split three ways.

## Why one PR

These three changes are only correct **together, in one deploy**. Split, each one alone breaks something:

| merged alone | result |
|---|---|
| the bump | ETL `0035` creates `users_current_uniq_idx`, **fails on the existing duplicates**, `RunMigrations` errors and the indexer won't start |
| `0236` (album) | the old indexer keeps deriving `album` from `is_album` and undoes the backfill |
| `0237` (users) | harmless, but pointless without the index that stops it recurring |

As one PR the deploy is atomic, and the ordering inside it is guaranteed by existing machinery: `bridge migrate` runs as a pre-roll Job that every serving Deployment `DependsOn` (serving pods get `runMigrations=false`), so both ddl migrations complete before the indexer starts and runs the ETL's.

## Contents

**`0237_users_one_current_row_backfill`** — deletes 5 duplicate `is_current` rows from `users`. Small count, large blast radius: joins from an entity to its owner's wallet fan out, measured at **+18 tracks and +787 follows** on a production clone. Must precede the ETL index.

**`0236_saves_reposts_album_to_playlist`** — 670 saves and 528 reposts written as `album` collapse to `playlist`. `on_save`/`on_repost` are disabled for the update (their notification `group_id` embeds the type, so a plain UPDATE would mint duplicate favourite notifications); `trg_saves`/`trg_reposts` stay enabled so the search indexer sees the change.

**`deps: pin pkg/etl v1.6.4`** — brings OpenAudio/go-openaudio#428 (album type), #425 (the `users` invariant + genesis-writer join simplification) and #433 (`0035` no longer deletes anything).

## The delete moved out of the ETL migration

`v1.6.3`'s `0035` deleted the duplicates itself. Since ETL migrations run automatically at indexer start, that made a `go get` able to remove rows from this database. #433 split it: the index stays in the ETL migration, the repair moved to `0237` here. **`v1.6.4` ships zero `DELETE` statements** — verified against the resolved module, not just the tag.

The comment above the ETL config now records that line, and its corollary: an ETL migration can depend on a ddl one having run, and `0035` fails loudly if `0237` hasn't.

## Verified

- Resolved module `pkg/etl@v1.6.4` contains `0035` with `CREATE UNIQUE INDEX` and **0** `DELETE` statements.
- Both migration orders against fixtures: backfill→index applies cleanly (`violations 0`, `indisvalid = t`); index→backfill fails with `could not create unique index … Key (user_id)=(98311147) is duplicated`, which is the intended signal that `0237` hasn't run.
- Both migrations idempotent; re-running is a no-op.
- `0236` fires **zero** `on_save`/`on_repost` triggers against a fixture with the real wiring, and exactly one `pg_notify` per updated row.
- `go build ./...` and `go vet ./indexer/` clean.
- No FK references `users`; its triggers are INSERT / INSERT OR UPDATE, so the delete fires neither.
- Cutting `pkg/etl/v1.6.4` did not move `openaudio/go-openaudio:stable` — still the 2026-07-30 `v1.8.2` digest, so no node-operator rollout.

## Not established

The cause of the duplicate `users` rows. Both indexer create paths reject an existing user, so a single writer can't produce them; a second writer can, since check-then-act isn't atomic across transactions. Three of five pairs put a bare-hex `txhash` next to a `0x`-prefixed one, which fits but doesn't prove it. The index will surface it if it recurs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)