### PR TITLE
fix(api): scope user-subscriber reads to entity_type 'User'; unbreak main CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,9 +44,6 @@ jobs:
           done
 
       - name: Run tests
-        # -count=1 defeats Go's test-result cache. The test schema lives in a
-        # dockerized Postgres the cache can't see, so a sql/-only change can
-        # otherwise ride a stale green (how #1011 merged with a failing test).
         run: go test -count=1 -cover ./...
 
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,7 +44,10 @@ jobs:
           done
 
       - name: Run tests
-        run: go test -cover ./...
+        # -count=1 defeats Go's test-result cache. The test schema lives in a
+        # dockerized Postgres the cache can't see, so a sql/-only change can
+        # otherwise ride a stale green (how #1011 merged with a failing test).
+        run: go test -count=1 -cover ./...
 
 
       - name: Shutdown

--- a/api/dbv1/get_users.sql.go
+++ b/api/dbv1/get_users.sql.go
@@ -39,6 +39,7 @@ current_user_subscribed_targets AS (
   FROM subscriptions s
   JOIN input_users i ON i.user_id = s.user_id
   WHERE $1 > 0
+    AND s.entity_type = 'User'
     AND s.subscriber_id = $1
     AND s.is_delete = false
   GROUP BY s.user_id

--- a/api/dbv1/queries/get_users.sql
+++ b/api/dbv1/queries/get_users.sql
@@ -23,6 +23,7 @@ current_user_subscribed_targets AS (
   FROM subscriptions s
   JOIN input_users i ON i.user_id = s.user_id
   WHERE @my_id > 0
+    AND s.entity_type = 'User'
     AND s.subscriber_id = @my_id
     AND s.is_delete = false
   GROUP BY s.user_id

--- a/api/v1_events_followers_test.go
+++ b/api/v1_events_followers_test.go
@@ -172,8 +172,15 @@ func TestEventFollowState_CountsOnlyLiveEventSubscriptions(t *testing.T) {
 			},
 			// A legacy user-type subscription with matching numeric id —
 			// must NOT be counted.
+			//
+			// Seeded from subscriber 5 so it doesn't share
+			// (subscriber_id, user_id) with subscriber 2's Event row above:
+			// production's subscriptions_current_uniq_idx currently keys
+			// current rows on that pair alone. Once go-openaudio#469 widens
+			// the index to include entity_type, same-subscriber coexistence
+			// becomes legal and is worth covering here again.
 			{
-				"subscriber_id": 2,
+				"subscriber_id": 5,
 				"user_id":       200,
 				"entity_type":   "User",
 				"entity_id":     nil,

--- a/api/v1_events_followers_test.go
+++ b/api/v1_events_followers_test.go
@@ -172,13 +172,6 @@ func TestEventFollowState_CountsOnlyLiveEventSubscriptions(t *testing.T) {
 			},
 			// A legacy user-type subscription with matching numeric id —
 			// must NOT be counted.
-			//
-			// Seeded from subscriber 5 so it doesn't share
-			// (subscriber_id, user_id) with subscriber 2's Event row above:
-			// production's subscriptions_current_uniq_idx currently keys
-			// current rows on that pair alone. Once go-openaudio#469 widens
-			// the index to include entity_type, same-subscriber coexistence
-			// becomes legal and is worth covering here again.
 			{
 				"subscriber_id": 5,
 				"user_id":       200,
@@ -572,13 +565,6 @@ func TestEventsFollowers_ReturnsOnlyLiveEventSubscribers(t *testing.T) {
 			},
 			// Legacy user-type subscription with a colliding numeric id —
 			// must NOT show up.
-			//
-			// Seeded from subscriber 4 (not 1) so it doesn't share
-			// (subscriber_id, user_id) with the deleted-event row below:
-			// production's subscriptions_current_uniq_idx currently keys
-			// current rows on that pair alone. Once go-openaudio#469 widens
-			// the index to include entity_type, same-subscriber coexistence
-			// becomes legal and is worth covering here again.
 			{
 				"subscriber_id": 4,
 				"user_id":       200,

--- a/api/v1_events_followers_test.go
+++ b/api/v1_events_followers_test.go
@@ -514,7 +514,12 @@ func TestEventsFollowers_ReturnsOnlyLiveEventSubscribers(t *testing.T) {
 	app := emptyTestApp(t)
 
 	database.Seed(app.pool.Replicas[0], database.FixtureMap{
-		"users": testEventFollowersBaseUsers(),
+		"users": append(testEventFollowersBaseUsers(), map[string]any{
+			"user_id":   4,
+			"handle":    "legacyfan",
+			"handle_lc": "legacyfan",
+			"name":      "Legacy Fan",
+		}),
 		"tracks": {
 			{
 				"track_id":   1,
@@ -560,8 +565,15 @@ func TestEventsFollowers_ReturnsOnlyLiveEventSubscribers(t *testing.T) {
 			},
 			// Legacy user-type subscription with a colliding numeric id —
 			// must NOT show up.
+			//
+			// Seeded from subscriber 4 (not 1) so it doesn't share
+			// (subscriber_id, user_id) with the deleted-event row below:
+			// production's subscriptions_current_uniq_idx currently keys
+			// current rows on that pair alone. Once go-openaudio#469 widens
+			// the index to include entity_type, same-subscriber coexistence
+			// becomes legal and is worth covering here again.
 			{
-				"subscriber_id": 1,
+				"subscriber_id": 4,
 				"user_id":       200,
 				"entity_type":   "User",
 				"entity_id":     nil,

--- a/api/v1_users_subscribers.go
+++ b/api/v1_users_subscribers.go
@@ -20,9 +20,6 @@ func (app *ApiServer) v1UsersSubscribers(c *fiber.Ctx) error {
 		FROM
 			subscriptions
 		WHERE
-			-- user_id is overloaded: it mirrors the event id for Event
-			-- subscriptions, so an unqualified match would count followers of
-			-- an event whose id collides with this user's id.
 			entity_type = 'User'
 			AND user_id = @userId
 			AND is_current = true

--- a/api/v1_users_subscribers.go
+++ b/api/v1_users_subscribers.go
@@ -20,7 +20,11 @@ func (app *ApiServer) v1UsersSubscribers(c *fiber.Ctx) error {
 		FROM
 			subscriptions
 		WHERE
-			user_id = @userId
+			-- user_id is overloaded: it mirrors the event id for Event
+			-- subscriptions, so an unqualified match would count followers of
+			-- an event whose id collides with this user's id.
+			entity_type = 'User'
+			AND user_id = @userId
 			AND is_current = true
 			AND is_delete = false
 		ORDER BY

--- a/api/v1_users_subscribers_test.go
+++ b/api/v1_users_subscribers_test.go
@@ -31,9 +31,6 @@ func TestUsersSubscribers(t *testing.T) {
 	}
 
 	database.Seed(app.pool.Replicas[0], fixtures)
-	// The last row is an Event subscription whose event id collides with the
-	// artist's user id (user_id mirrors the event id for Event rows). Its
-	// subscriber follows event 1, not user 1, and must NOT be listed.
 	_, err := app.pool.Exec(t.Context(), `
 		INSERT INTO subscriptions (user_id, subscriber_id, is_current, is_delete, txhash, entity_type, entity_id)
 		VALUES

--- a/api/v1_users_subscribers_test.go
+++ b/api/v1_users_subscribers_test.go
@@ -18,6 +18,7 @@ func TestUsersSubscribers(t *testing.T) {
 			{"user_id": 3, "handle": "subscriber3", "name": "Subscriber 3"},
 			{"user_id": 4, "handle": "deletedsub", "name": "Deleted Sub"},
 			{"user_id": 5, "handle": "oldsub", "name": "Old Sub"},
+			{"user_id": 6, "handle": "eventonlyfan", "name": "Event Only Fan"},
 		},
 		"aggregate_user": []map[string]any{
 			{"user_id": 1, "track_count": 1},
@@ -25,17 +26,22 @@ func TestUsersSubscribers(t *testing.T) {
 			{"user_id": 3, "track_count": 1},
 			{"user_id": 4, "track_count": 1},
 			{"user_id": 5, "track_count": 1},
+			{"user_id": 6, "track_count": 1},
 		},
 	}
 
 	database.Seed(app.pool.Replicas[0], fixtures)
+	// The last row is an Event subscription whose event id collides with the
+	// artist's user id (user_id mirrors the event id for Event rows). Its
+	// subscriber follows event 1, not user 1, and must NOT be listed.
 	_, err := app.pool.Exec(t.Context(), `
-		INSERT INTO subscriptions (user_id, subscriber_id, is_current, is_delete, txhash)
+		INSERT INTO subscriptions (user_id, subscriber_id, is_current, is_delete, txhash, entity_type, entity_id)
 		VALUES
-			(1, 3, TRUE, FALSE, 'tx-sub-3'),
-			(1, 2, TRUE, FALSE, 'tx-sub-2'),
-			(1, 4, TRUE, TRUE, 'tx-sub-deleted'),
-			(1, 5, FALSE, FALSE, 'tx-sub-not-current')
+			(1, 3, TRUE, FALSE, 'tx-sub-3', 'User', NULL),
+			(1, 2, TRUE, FALSE, 'tx-sub-2', 'User', NULL),
+			(1, 4, TRUE, TRUE, 'tx-sub-deleted', 'User', NULL),
+			(1, 5, FALSE, FALSE, 'tx-sub-not-current', 'User', NULL),
+			(1, 6, TRUE, FALSE, 'tx-sub-event-collision', 'Event', 1)
 	`)
 	assert.NoError(t, err)
 

--- a/api/v1_users_test.go
+++ b/api/v1_users_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"api.audius.co/api/dbv1"
+	"api.audius.co/database"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -85,6 +86,51 @@ func TestUserQuery(t *testing.T) {
 		user := users[0]
 		assert.Equal(t, int64(1), user.CurrentUserFolloweeFollowCount)
 	}
+}
+
+func TestUserQuery_DoesCurrentUserSubscribeIgnoresEventSubscriptions(t *testing.T) {
+	app := emptyTestApp(t)
+
+	database.Seed(app.pool.Replicas[0], database.FixtureMap{
+		"users": []map[string]any{
+			{"user_id": 1, "handle": "artist", "name": "Artist"},
+			{"user_id": 2, "handle": "eventhost", "name": "Event Host"},
+			{"user_id": 3, "handle": "viewer", "name": "Viewer"},
+		},
+		"subscriptions": []map[string]any{
+			{
+				"subscriber_id": 3,
+				"user_id":       1,
+				"entity_type":   "User",
+				"entity_id":     nil,
+				"is_current":    true,
+				"is_delete":     false,
+				"txhash":        "tx-user-sub",
+			},
+			{
+				"subscriber_id": 3,
+				"user_id":       2,
+				"entity_type":   "Event",
+				"entity_id":     2,
+				"is_current":    true,
+				"is_delete":     false,
+				"txhash":        "tx-event-collision",
+			},
+		},
+	})
+
+	users, err := app.queries.Users(t.Context(), dbv1.GetUsersParams{
+		MyID: 3,
+		Ids:  []int32{1, 2},
+	})
+	assert.NoError(t, err)
+	require.Len(t, users, 2)
+	byID := map[int32]dbv1.User{}
+	for _, user := range users {
+		byID[user.UserID] = user
+	}
+	assert.True(t, byID[1].DoesCurrentUserSubscribe)
+	assert.False(t, byID[2].DoesCurrentUserSubscribe)
 }
 
 func TestGetUsers(t *testing.T) {

--- a/ddl/functions/handle_playlist.sql
+++ b/ddl/functions/handle_playlist.sql
@@ -60,9 +60,6 @@ begin
           from subscriptions
           where is_current and
           not is_delete and
-          -- user_id is overloaded: it mirrors the event id for Event
-          -- subscriptions, so an unqualified match can pick up followers of an
-          -- event whose id collides with this artist's user id.
           entity_type = 'User' and
           user_id=new.playlist_owner_id
       ) into subscriber_user_ids;

--- a/ddl/functions/handle_playlist.sql
+++ b/ddl/functions/handle_playlist.sql
@@ -60,6 +60,10 @@ begin
           from subscriptions
           where is_current and
           not is_delete and
+          -- user_id is overloaded: it mirrors the event id for Event
+          -- subscriptions, so an unqualified match can pick up followers of an
+          -- event whose id collides with this artist's user id.
+          entity_type = 'User' and
           user_id=new.playlist_owner_id
       ) into subscriber_user_ids;
       if array_length(subscriber_user_ids, 1)	> 0 then

--- a/ddl/functions/handle_track.sql
+++ b/ddl/functions/handle_track.sql
@@ -52,9 +52,6 @@ begin
           from subscriptions
           where is_current and
           not is_delete and
-          -- user_id is overloaded: it mirrors the event id for Event
-          -- subscriptions, so an unqualified match can pick up followers of an
-          -- event whose id collides with this artist's user id.
           entity_type = 'User' and
           user_id=new.owner_id
       ) into subscriber_user_ids;

--- a/ddl/functions/handle_track.sql
+++ b/ddl/functions/handle_track.sql
@@ -52,6 +52,10 @@ begin
           from subscriptions
           where is_current and
           not is_delete and
+          -- user_id is overloaded: it mirrors the event id for Event
+          -- subscriptions, so an unqualified match can pick up followers of an
+          -- event whose id collides with this artist's user id.
+          entity_type = 'User' and
           user_id=new.owner_id
       ) into subscriber_user_ids;
 

--- a/sql/01_schema.sql
+++ b/sql/01_schema.sql
@@ -3537,6 +3537,10 @@ begin
           from subscriptions
           where is_current and
           not is_delete and
+          -- user_id is overloaded: it mirrors the event id for Event
+          -- subscriptions, so an unqualified match can pick up followers of an
+          -- event whose id collides with this artist's user id.
+          entity_type = 'User' and
           user_id=new.playlist_owner_id
       ) into subscriber_user_ids;
       if array_length(subscriber_user_ids, 1)	> 0 then
@@ -4784,6 +4788,10 @@ begin
           from subscriptions
           where is_current and
           not is_delete and
+          -- user_id is overloaded: it mirrors the event id for Event
+          -- subscriptions, so an unqualified match can pick up followers of an
+          -- event whose id collides with this artist's user id.
+          entity_type = 'User' and
           user_id=new.owner_id
       ) into subscriber_user_ids;
 

--- a/sql/01_schema.sql
+++ b/sql/01_schema.sql
@@ -3537,9 +3537,6 @@ begin
           from subscriptions
           where is_current and
           not is_delete and
-          -- user_id is overloaded: it mirrors the event id for Event
-          -- subscriptions, so an unqualified match can pick up followers of an
-          -- event whose id collides with this artist's user id.
           entity_type = 'User' and
           user_id=new.playlist_owner_id
       ) into subscriber_user_ids;
@@ -4788,9 +4785,6 @@ begin
           from subscriptions
           where is_current and
           not is_delete and
-          -- user_id is overloaded: it mirrors the event id for Event
-          -- subscriptions, so an unqualified match can pick up followers of an
-          -- event whose id collides with this artist's user id.
           entity_type = 'User' and
           user_id=new.owner_id
       ) into subscriber_user_ids;


### PR DESCRIPTION
## What

Four related fixes around the overloaded `subscriptions.user_id` column (it mirrors the event id for Event rows, and event ids are allocated independently of user ids). Background: #1011 seeded production's `subscriptions_current_uniq_idx` into the test schema, which both broke main's CI and led to the discovery of the bugs below (see OpenAudio/go-openaudio#469 for the upstream identity fix).

**1. Live bug: event followers counted as user subscribers.** `/v1/users/{id}/subscribers` and the upload-notification fan-outs in `handle_track` / `handle_playlist` match on `user_id` alone. A follower of event N therefore counts as a subscriber of user N whenever the ids collide — they appear in the subscriber list and get "new upload" notifications for an artist they never subscribed to. Reachable today with a single Event row; go-openaudio#469 (which legalizes cross-type coexistence) widens the exposure. Fixed by adding `entity_type = 'User'` to all three readers (trigger functions updated in `ddl/functions/`, which `pg_migrate.sh` re-applies on md5 change, with the schema dump edited to match). The Event-side readers were already correctly scoped since #977; this is the mirror image nobody did.

**2. Unbreak main CI.** The events-followers fixture seeds a legacy User-type row sharing `(subscriber_id, user_id)` with a deleted-event row — illegal under the index #1011 seeded, so `database.Seed` panics. The legacy row moves to its own subscriber; both exclusion behaviors stay covered. Once go-openaudio#469 widens the index to include `entity_type`, the same-subscriber collision becomes legal again and is worth re-adding (noted in a comment).

**2b. Same bug in `does_current_user_subscribe`.** The `current_user_subscribed_targets` CTE in `get_users.sql` also matched on `user_id` alone, so a viewer following event N showed as subscribed to user N on every user-list surface. Same `entity_type = 'User'` fix (sqlc regenerated). Note: this CTE filters only `is_delete` and not `is_current`, unlike the other readers — that predates the #892 refactor and is left as-is here.

**3. Close the cache hole that let this merge green.** `setup-go` restores the go-build cache (including test results) keyed on `go.sum`, but the test schema lives in dockerized Postgres, invisible to Go's cache invalidation — so #1011's sql/-only commits rode a stale green while its own schema change broke a test. `-count=1` forces tests to actually run.

## Tests

- `TestUsersSubscribers` now seeds an Event subscription whose event id collides with the artist's user id and asserts the follower is not listed (fails without the filter).
- `TestUserQuery_DoesCurrentUserSubscribeIgnoresEventSubscriptions` seeds a colliding Event subscription and asserts the flag stays false (fails without the filter).
- `TestEventsFollowers_ReturnsOnlyLiveEventSubscribers` passes again (was panicking on main).
- Full suite green locally with `-count=1` against a freshly initialized schema volume.

## Not in this PR

The `pkg/etl` pin bump + seeded-index update land separately once go-openaudio#469/#470 cut a release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
