### PR TITLE
fix(api): keep unreachable content hosts out of the rendezvous rotation

### DIFF
--- a/api/content_host_health.go
+++ b/api/content_host_health.go
@@ -1,0 +1,159 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"sync"
+	"time"
+
+	"api.audius.co/config"
+	"go.uber.org/zap"
+)
+
+// Registration on chain says a node is *entitled* to serve content; it does
+// not say the box is up. Until this existed the rendezvous rotation was built
+// straight from the registry, so a node that had gone away kept being handed
+// out as the primary host for whatever CIDs hashed to it, and the only remedy
+// was a human noticing and shipping a new config.DeadNodes entry.
+//
+// That gap was live on 2026-08-11: audius.zeogrid.com was refusing
+// connections but still registered, and it came back as the primary host on
+// roughly a third of requests for the CIDs it owned. The blobs were fine and
+// replicated — the URL just pointed at a dead box, so the browser fell back
+// to whatever it had cached and users reported their new profile picture or
+// album art "reverting" on refresh. ~8% of sampled artists had it in their
+// host set.
+const (
+	// How long a single node's health probe may take.
+	hostProbeTimeout = 5 * time.Second
+
+	// How many probes run at once.
+	hostProbeConcurrency = 16
+
+	// Consecutive failures before a node leaves the rotation. Paired with the
+	// 1-minute nodesPoller this is a ~3 minute ejection, slow enough to ride
+	// out a restart or a blip and fast enough to matter. A single success
+	// resets the count and re-admits the node.
+	hostEjectAfterFailures = 3
+
+	// Never eject more than this share of the registry. If most probes fail
+	// the likely cause is this API's own network, not the whole network going
+	// down at once, and emptying the rotation would break every asset URL we
+	// serve. Fail open and keep the registry as-is.
+	hostMaxEjectedFraction = 0.5
+)
+
+// contentHostHealth tracks consecutive health-probe failures per endpoint so
+// unreachable nodes can be kept out of the rendezvous rotation.
+type contentHostHealth struct {
+	lock     sync.Mutex
+	failures map[string]int
+	client   *http.Client
+}
+
+func newContentHostHealth() *contentHostHealth {
+	return &contentHostHealth{
+		failures: map[string]int{},
+		client:   &http.Client{Timeout: hostProbeTimeout},
+	}
+}
+
+// filterLive probes every node and returns those fit to serve content.
+//
+// Nodes are only dropped once they've failed hostEjectAfterFailures probes in
+// a row, and the whole filter fails open if that would remove more than
+// hostMaxEjectedFraction of the registry.
+func (h *contentHostHealth) filterLive(ctx context.Context, nodes []config.Node, logger *zap.Logger) []config.Node {
+	if len(nodes) == 0 {
+		return nodes
+	}
+
+	results := h.probeAll(ctx, nodes)
+
+	h.lock.Lock()
+	live := make([]config.Node, 0, len(nodes))
+	ejected := make([]string, 0)
+	registered := make(map[string]bool, len(nodes))
+	for _, node := range nodes {
+		registered[node.Endpoint] = true
+		if results[node.Endpoint] {
+			delete(h.failures, node.Endpoint)
+			live = append(live, node)
+			continue
+		}
+		h.failures[node.Endpoint]++
+		if h.failures[node.Endpoint] >= hostEjectAfterFailures {
+			ejected = append(ejected, node.Endpoint)
+			continue
+		}
+		// Failing but not yet past the threshold — keep serving it.
+		live = append(live, node)
+	}
+	// Forget endpoints that have left the registry entirely.
+	for endpoint := range h.failures {
+		if !registered[endpoint] {
+			delete(h.failures, endpoint)
+		}
+	}
+	h.lock.Unlock()
+
+	if float64(len(ejected)) > hostMaxEjectedFraction*float64(len(nodes)) {
+		logger.Warn("content host health check failing too broadly to trust; keeping all registered nodes",
+			zap.Int("would_eject", len(ejected)),
+			zap.Int("registered", len(nodes)),
+		)
+		return nodes
+	}
+
+	if len(ejected) > 0 {
+		logger.Warn("excluding unreachable content hosts from rendezvous",
+			zap.Strings("endpoints", ejected),
+			zap.Int("registered", len(nodes)),
+		)
+	}
+	return live
+}
+
+// probeAll returns endpoint -> reachable.
+func (h *contentHostHealth) probeAll(ctx context.Context, nodes []config.Node) map[string]bool {
+	results := make(map[string]bool, len(nodes))
+	var (
+		mu sync.Mutex
+		wg sync.WaitGroup
+	)
+	sem := make(chan struct{}, hostProbeConcurrency)
+
+	for _, node := range nodes {
+		wg.Add(1)
+		go func(endpoint string) {
+			defer wg.Done()
+			sem <- struct{}{}
+			defer func() { <-sem }()
+
+			ok := h.probe(ctx, endpoint)
+			mu.Lock()
+			results[endpoint] = ok
+			mu.Unlock()
+		}(node.Endpoint)
+	}
+	wg.Wait()
+	return results
+}
+
+// probe reports whether the node answers its health check. Any non-2xx or
+// transport error counts as a failure.
+func (h *contentHostHealth) probe(ctx context.Context, endpoint string) bool {
+	ctx, cancel := context.WithTimeout(ctx, hostProbeTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint+"/health_check", nil)
+	if err != nil {
+		return false
+	}
+	resp, err := h.client.Do(req)
+	if err != nil {
+		return false
+	}
+	defer resp.Body.Close()
+	return resp.StatusCode >= 200 && resp.StatusCode < 300
+}

--- a/api/content_host_health_test.go
+++ b/api/content_host_health_test.go
@@ -1,0 +1,185 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"api.audius.co/config"
+	"go.uber.org/zap"
+)
+
+func healthyServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/health_check" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(s.Close)
+	return s
+}
+
+// deadEndpoint returns a URL nothing is listening on.
+func deadEndpoint(t *testing.T) string {
+	t.Helper()
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	url := s.URL
+	s.Close()
+	return url
+}
+
+func nodesFor(endpoints ...string) []config.Node {
+	nodes := make([]config.Node, 0, len(endpoints))
+	for _, e := range endpoints {
+		nodes = append(nodes, config.Node{Endpoint: e, ServiceType: "content-node"})
+	}
+	return nodes
+}
+
+func endpointsOf(nodes []config.Node) []string {
+	out := make([]string, 0, len(nodes))
+	for _, n := range nodes {
+		out = append(out, n.Endpoint)
+	}
+	return out
+}
+
+func contains(haystack []string, needle string) bool {
+	for _, h := range haystack {
+		if h == needle {
+			return true
+		}
+	}
+	return false
+}
+
+// A node that answers its health check is never dropped.
+func TestContentHostHealth_KeepsHealthyNodes(t *testing.T) {
+	h := newContentHostHealth()
+	a, b := healthyServer(t), healthyServer(t)
+	nodes := nodesFor(a.URL, b.URL)
+
+	for i := 0; i < hostEjectAfterFailures+2; i++ {
+		live := h.filterLive(context.Background(), nodes, zap.NewNop())
+		if len(live) != 2 {
+			t.Fatalf("round %d: live = %v, want both nodes", i, endpointsOf(live))
+		}
+	}
+}
+
+// Regression (prod, 2026-08-11): audius.zeogrid.com was registered on chain
+// but refusing connections, and kept being handed out as the primary host for
+// the CIDs that hashed to it — so users saw their new profile picture or album
+// art "revert" while the browser fell back to a cached copy. An unreachable
+// node must leave the rotation, but only after it has failed consistently.
+func TestContentHostHealth_EjectsUnreachableNodeAfterThreshold(t *testing.T) {
+	h := newContentHostHealth()
+	good1, good2, good3 := healthyServer(t), healthyServer(t), healthyServer(t)
+	dead := deadEndpoint(t)
+	nodes := nodesFor(good1.URL, good2.URL, good3.URL, dead)
+
+	// Below the threshold the node is still served: one blip shouldn't pull a
+	// node out from under live traffic.
+	for i := 1; i < hostEjectAfterFailures; i++ {
+		live := endpointsOf(h.filterLive(context.Background(), nodes, zap.NewNop()))
+		if !contains(live, dead) {
+			t.Fatalf("probe %d: dead node ejected too early, live = %v", i, live)
+		}
+	}
+
+	live := endpointsOf(h.filterLive(context.Background(), nodes, zap.NewNop()))
+	if contains(live, dead) {
+		t.Errorf("dead node still in rotation after %d failures: %v", hostEjectAfterFailures, live)
+	}
+	if len(live) != 3 {
+		t.Errorf("live = %v, want the three healthy nodes", live)
+	}
+}
+
+// A node that comes back is re-admitted, and its failure count resets so the
+// next outage gets a full threshold again.
+func TestContentHostHealth_ReadmitsRecoveredNode(t *testing.T) {
+	h := newContentHostHealth()
+	good1, good2, good3 := healthyServer(t), healthyServer(t), healthyServer(t)
+
+	flaky := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer flaky.Close()
+	nodes := nodesFor(good1.URL, good2.URL, good3.URL, flaky.URL)
+
+	for i := 0; i < hostEjectAfterFailures; i++ {
+		h.filterLive(context.Background(), nodes, zap.NewNop())
+	}
+	if live := endpointsOf(h.filterLive(context.Background(), nodes, zap.NewNop())); contains(live, flaky.URL) {
+		t.Fatalf("setup: expected flaky node ejected, live = %v", live)
+	}
+
+	flaky.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	live := endpointsOf(h.filterLive(context.Background(), nodes, zap.NewNop()))
+	if !contains(live, flaky.URL) {
+		t.Errorf("recovered node not re-admitted: %v", live)
+	}
+
+	h.lock.Lock()
+	failures := h.failures[flaky.URL]
+	h.lock.Unlock()
+	if failures != 0 {
+		t.Errorf("failure count = %d after recovery, want 0", failures)
+	}
+}
+
+// If most probes fail the likely cause is this API's own network, not the
+// whole network. Emptying the rotation would break every asset URL, so the
+// filter fails open.
+func TestContentHostHealth_FailsOpenWhenMostNodesUnreachable(t *testing.T) {
+	h := newContentHostHealth()
+	good := healthyServer(t)
+	nodes := nodesFor(good.URL, deadEndpoint(t), deadEndpoint(t), deadEndpoint(t))
+
+	var live []config.Node
+	for i := 0; i < hostEjectAfterFailures; i++ {
+		live = h.filterLive(context.Background(), nodes, zap.NewNop())
+	}
+	if len(live) != len(nodes) {
+		t.Errorf("live = %v, want all %d nodes kept (fail open)", endpointsOf(live), len(nodes))
+	}
+}
+
+// An empty registry passes through untouched rather than being probed.
+func TestContentHostHealth_EmptyRegistry(t *testing.T) {
+	h := newContentHostHealth()
+	if live := h.filterLive(context.Background(), nil, zap.NewNop()); len(live) != 0 {
+		t.Errorf("live = %v, want empty", endpointsOf(live))
+	}
+}
+
+// Endpoints that leave the registry stop being tracked.
+func TestContentHostHealth_ForgetsDeregisteredEndpoints(t *testing.T) {
+	h := newContentHostHealth()
+	good1, good2, good3 := healthyServer(t), healthyServer(t), healthyServer(t)
+	dead := deadEndpoint(t)
+
+	h.filterLive(context.Background(), nodesFor(good1.URL, good2.URL, good3.URL, dead), zap.NewNop())
+	h.lock.Lock()
+	tracked := h.failures[dead]
+	h.lock.Unlock()
+	if tracked == 0 {
+		t.Fatalf("setup: expected a recorded failure for %s", dead)
+	}
+
+	h.filterLive(context.Background(), nodesFor(good1.URL, good2.URL, good3.URL), zap.NewNop())
+	h.lock.Lock()
+	_, stillTracked := h.failures[dead]
+	h.lock.Unlock()
+	if stillTracked {
+		t.Errorf("failure count for deregistered %s should have been dropped", dead)
+	}
+}

--- a/api/server.go
+++ b/api/server.go
@@ -304,6 +304,7 @@ func NewApiServer(config config.Config) *ApiServer {
 		solanaConfig:            &config.SolanaConfig,
 		antiAbuseOracles:        config.AntiAbuseOracles,
 		validators:              NewNodes(),
+		contentHosts:            newContentHostHealth(),
 		openAudioSDK:            openAudioSDK,
 		openAudioPool:           openAudioPool,
 		metricsCollector:        metricsCollector,
@@ -870,6 +871,7 @@ type ApiServer struct {
 	solanaRpcClient         *rpc.Client
 	meteoraDbcClient        *meteora_dbc.Client
 	validators              *Nodes
+	contentHosts            *contentHostHealth
 	openAudioPool           *OpenAudioPool
 	newChainFlusher         *NewChainFlusher
 }

--- a/api/v1_validators.go
+++ b/api/v1_validators.go
@@ -88,7 +88,9 @@ func (app *ApiServer) updateNodes(ctx context.Context) {
 			rendezvousNodes = append(rendezvousNodes, n)
 		}
 	}
-	rendezvous.Refresh(rendezvousNodes)
+	// Registration doesn't mean the node is actually up — drop the ones that
+	// aren't, so we stop handing out asset URLs that can't be fetched.
+	rendezvous.Refresh(app.contentHosts.filterLive(ctx, rendezvousNodes, app.logger))
 }
 
 func (app *ApiServer) v1Validators(c *fiber.Ctx) error {


### PR DESCRIPTION
## What's broken

`updateNodes` builds the rendezvous rotation straight from the on-chain registry. Registration says a node is *entitled* to serve content — it doesn't say the box is up. The only way to exclude a dead node today is for a human to notice and ship a `config.DeadNodes` entry.

`audius.zeogrid.com` has been sitting in that gap: refusing connections, still registered as validator Id 99, still in the rotation.

```
$ curl https://audius.zeogrid.com/health_check
curl: (7) Failed to connect to audius.zeogrid.com port 443 after 35 ms
```

Measured against prod on 2026-08-11:

- returned as the **primary** host on **9 of 25** sampled requests (36%) for gotamaX's cover photo
- **~8%** of sampled trending artists have it in their image host set

## Why this looked like a data bug

The blobs are fine. Every affected image serves `200` from its mirrors — gotamaX changed their cover photo three times and all three writes landed correctly with distinct CIDs. Only the *URL* was bad, so the browser fell back to its cached copy and the user reported their new profile picture or album art "reverting" on refresh.

This is one of two causes behind the current batch of "my profile photo keeps reverting" support reports. The other is a genuine write-path bug, fixed separately in OpenAudio/go-openaudio#510.

## The fix

The existing 1-minute `nodesPoller` now probes each registered node's `/health_check` and drops the ones that don't answer.

Guards against the obvious ways active health checking could make things worse:

| Guard | Why |
|---|---|
| 3 consecutive failures before ejection (~3 min) | A restart or blip shouldn't pull a node out from under live traffic |
| One success re-admits and resets the count | Recovery shouldn't need a deploy |
| Fail open if >50% would be ejected | Most probes failing at once means *our* network is the problem; emptying the rotation would break every asset URL we serve |

This also removes the need to hand-maintain `config.DeadNodes`.

## Tests

Six cases in `content_host_health_test.go` covering each guard: healthy nodes retained, ejection only after the threshold, re-admission on recovery with the counter reset, fail-open, empty registry, and deregistered endpoints being forgotten.

Full `./api/` suite passes (0 failures). `TestSearch` fails in my sandbox for want of Elasticsearch — verified identical on clean `main`, so unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)