### PR TITLE
Extend trending decay to 10 days

### DIFF
--- a/jobs/index_trending.go
+++ b/jobs/index_trending.go
@@ -155,7 +155,7 @@ const (
 	trendingI  = 0.01
 	trendingQ  = 100000.0
 	trendingY  = 3
-	trendingWk = 7
+	trendingWk = 10
 	trendingMo = 30
 
 	trendingAllTimeCheckpoint = "track_trending_scores_all_time"


### PR DESCRIPTION
Changes trendingWk from 7 to 10 days for the weekly trending algorithm. Test: go test ./jobs -run '^$' -count=1