### PR TITLE
chore(deps): bump pkg/etl to pick up the artist-pick profile-edit fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/AlecAivazis/survey/v2 v2.3.7
 	github.com/Doist/unfurlist v0.0.0-20250409100812-515f2735f8e5
 	github.com/OpenAudio/go-openaudio v1.8.2-0.20260727214803-1d9f69772e87
-	github.com/OpenAudio/go-openaudio/pkg/etl v1.6.5-0.20260810163330-95f8e2ff0c66
+	github.com/OpenAudio/go-openaudio/pkg/etl v1.7.1-0.20260818221412-81f4af523801
 	github.com/aquasecurity/esquery v0.2.0
 	github.com/axiomhq/axiom-go v0.23.0
 	github.com/axiomhq/hyperloglog v0.2.5

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5 h1:TngWCqHvy9oXAN6lEV
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5/go.mod h1:lmUJ/7eu/Q8D7ML55dXQrVaamCz2vxCfdQBasLZfHKk=
 github.com/OpenAudio/go-openaudio v1.8.2-0.20260727214803-1d9f69772e87 h1:HiLw4qrUkVWRADJjGsdHLlFMdJjhU5WCVNAfeKfww4s=
 github.com/OpenAudio/go-openaudio v1.8.2-0.20260727214803-1d9f69772e87/go.mod h1:lLRvUF5oWkxOyZx8rp/ecqxuMo3yzPvuvJbLSfvxguQ=
-github.com/OpenAudio/go-openaudio/pkg/etl v1.6.5-0.20260810163330-95f8e2ff0c66 h1:L5Db2Ht2XpUOBrU9RJZRxh3COkqJpPv9PVkRbJfND/o=
-github.com/OpenAudio/go-openaudio/pkg/etl v1.6.5-0.20260810163330-95f8e2ff0c66/go.mod h1:z7X/5RziXEpASGTz7tD+P3pg4W5iCA1cKW7ogw8GShY=
+github.com/OpenAudio/go-openaudio/pkg/etl v1.7.1-0.20260818221412-81f4af523801 h1:lYrbDv3cte0cW5AaT5oZ+u5cLPvy9pO7S05v5uwKVHQ=
+github.com/OpenAudio/go-openaudio/pkg/etl v1.7.1-0.20260818221412-81f4af523801/go.mod h1:z7X/5RziXEpASGTz7tD+P3pg4W5iCA1cKW7ogw8GShY=
 github.com/StackExchange/wmi v1.2.1 h1:VIkavFPXSjcnS+O8yTq7NI32k0R5Aj+v39y29VYDOSA=
 github.com/StackExchange/wmi v1.2.1/go.mod h1:rcmrprowKIVzvc+NUiLncP2uuArMWLCbu9SBzvHz7e8=
 github.com/VictoriaMetrics/fastcache v1.12.2 h1:N0y9ASrJ0F6h0QaC3o6uJb3NIZ9VKLjCM7NQbSmF7WI=


### PR DESCRIPTION
Picks up OpenAudio/go-openaudio#510 (merged as \`81f4af5\`), which unblocks profile editing for accounts whose artist pick points at a deleted track.

## Why this bump is the step that actually reaches users

The fix lives in \`pkg/etl\`, a separate Go module. This repo's \`indexer\` package wraps it and \`main.go\` runs it as \`core_indexer\` — that is the process serving production. Merging the go-openaudio PR alone changes nothing here until this pin moves.

## What was broken

A User Update whose \`artist_pick_track_id\` pointed at a deleted or no-longer-owned track was rejected outright. Clients resend the full user object on every profile edit, so that stale id rode along with unrelated changes and blocked them — profile picture, cover photo, bio, name.

The failure was invisible from both ends: the tx landed on chain, the indexer swallowed the \`ValidationError\` and continued, and the client had already applied the change optimistically. The user just saw their edit revert on refresh, with no error anywhere. Support reports of "my profile photo keeps reverting" are this.

**1,241 accounts were stuck on 2026-08-11** — 427 with 100+ followers, 89 with 1000+ — every one from a deleted pick.

## Migration delta is exactly one

\`0035\`–\`0038\` were already in the previous pin, so **\`0039\` (the backfill) is the only new migration this bump applies**. Notably \`0035_users_one_current_row\` — which fails loudly unless api's ddl \`0237\` backfill ran first — is already satisfied at the current pin, so it is not newly applied here.

\`0039\` clears only dangling references; a pick that still resolves is left alone.

## Risk review of the nine pkg/etl commits riding along

- \`#483\` removes tip reactions from the writer and indexer — this repo has **zero** references to \`TipReaction\`/\`tip_reaction\`.
- \`#508\` regenerates sqlc models; \`#494\`/\`#485\`/\`#482\` are genesis-migration-path fixes, not steady-state indexing.
- The main \`go-openaudio\` module pin is unchanged; only \`pkg/etl\` moves.

\`go build ./...\` and \`go vet ./...\` both clean. Diff is 3 lines (go.mod + go.sum).

## After deploy

- \`entity manager validation rejected\` warns with the artist-pick reason should drop to zero in the \`core-indexer\` pod.
- Re-run the count before/after — the 1,241 figure is from 2026-08-11 and the real number today may differ:

\`\`\`sql
SELECT count(*) FROM users u
WHERE u.is_current AND u.artist_pick_track_id IS NOT NULL
  AND NOT EXISTS (SELECT 1 FROM tracks t
    WHERE t.track_id = u.artist_pick_track_id AND t.owner_id = u.user_id
      AND t.is_current AND t.is_delete = false);
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)